### PR TITLE
Remove obsolete light theme test styles

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -396,7 +396,4 @@ a.read-more {
   /* color will be inherited from general h2,h3,h4 styles (light mode) or _darkmode.scss */
 }
 
-html body.force-light-theme-test {
-    background-color: #FF0000 !important; /* Bright red for testing */
-}
 /* Your Existing Custom Styles - END */


### PR DESCRIPTION
## Summary
- remove `html body.force-light-theme-test` block from custom styles

No pages referenced this class after removal.

## Testing
- `grep -R "force-light-theme-test" -n`