### PR TITLE
Set site background color to #2A4055

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,7 +1,7 @@
 /* _custom.scss - Light Theme Defaults & Custom Site Styles */
 
 // Color variables
-$primary-bg: #dbe7f7;
+$primary-bg: #2A4055;
 $primary-text: #212529;
 $primary-link: #59aaff;
 


### PR DESCRIPTION
## Summary
- change the light theme primary background color to #2A4055

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `bundle install` *(fails to fetch gems from rubygems.org)*