### PR TITLE
Fix missing background color variable

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,7 +1,8 @@
 /* _custom.scss - Light Theme Defaults & Custom Site Styles */
 
 // Color variables
-$primary-bg: #dbe7f7;
+// Primary background color for the light theme
+$primary-bg: #2E455B;
 $primary-text: #212529;
 $primary-link: #59aaff;
 


### PR DESCRIPTION
## Summary
- define `$primary-bg` for the light theme so the color is set correctly

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `bundle install` *(fails to fetch gems)*