### PR TITLE
Set site background color to #2A4055

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,7 +1,7 @@
 /* _custom.scss - Light Theme Defaults & Custom Site Styles */
 
 // Color variables
-$primary-bg: #dbe7f7;
+$primary-bg: #2A4055;
 $primary-text: #212529;
 $primary-link: #59aaff;
 


### PR DESCRIPTION
## Summary
- revert light theme background color variable

## Testing
- `bundle exec jekyll build` *(fails: bundler can't find jekyll)*
- `bundle install` *(fails: could not fetch gems)*