### PR TITLE
Improve code block readability

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -46,12 +46,14 @@ code { /* Inline code */
 }
 
 pre, pre code { /* Code blocks */
-    background-color: #e9ecef !important; 
-    color: #212529 !important; /* Dark grey text */
+    background-color: #333 !important; /* Darker background for better contrast */
+    color: #f8f9fa !important; /* Light text for readability */
     border: 1px solid #dee2e6; /* Optional: subtle border for code blocks */
     border-radius: 6px;
     padding: 1em;
     overflow: auto;
+    white-space: pre-wrap; /* Prevent overlapping long lines */
+    word-wrap: break-word;
 }
 
 header,

--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -58,11 +58,13 @@
 
   /* Style for code blocks */
   pre, pre code {
-      background-color: #282c34 !important; /* Ensure override */
+      background-color: #1e1e1e !important; /* Darker background */
       color: #abb2bf !important;
       border-radius: 6px;
       padding: 1em;
       overflow: auto;
+      white-space: pre-wrap; /* Prevent overlapping long lines */
+      word-wrap: break-word;
   }
 
 


### PR DESCRIPTION
## Summary
- tweak code block background to be darker
- ensure long lines wrap to prevent overlapping text

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*