### PR TITLE
Move styles and update build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Compile styles
         run: |
           mkdir -p public
-          darksass assets/css/style.scss public/style.css
+          darksass src/styles/global.scss public/global.css
 
       # Sync the built site to S3
       - name: Sync to S3

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/global.css' | relative_url }}">
 
     <script type="application/ld+json">
     {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,6 +1,0 @@
----
----
-
-@use "jekyll-theme-minimal";
-@use "darkmode";
-@use "custom";

--- a/build.py
+++ b/build.py
@@ -196,7 +196,7 @@ HEAD_TEMPLATE = f"""<!DOCTYPE html>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {{{{jsonld}}}}
     </script>

--- a/public/about.html
+++ b/public/about.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/billing.html
+++ b/public/billing.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/blog.html
+++ b/public/blog.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/dns-security-best-practices.html
+++ b/public/dns-security-best-practices.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/dns-tool.html
+++ b/public/dns-tool.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/it-problem-solving-scientific-method.html
+++ b/public/it-problem-solving-scientific-method.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/mac-cybersecurity-threats.html
+++ b/public/mac-cybersecurity-threats.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/services.html
+++ b/public/services.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/public/why-your-wireless-network-sucks.html
+++ b/public/why-your-wireless-network-sucks.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/global.css">
     <script type="application/ld+json">
     {
   "@context": "https://schema.org",

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,0 +1,5 @@
+---
+---
+
+@use "../../_sass/darkmode";
+@use "../../_sass/custom";


### PR DESCRIPTION
## Summary
- move site stylesheet to `src/styles` and rename to `global.scss`
- drop `jekyll-theme-minimal` import and update references
- update workflow and layout to compile/use `global.css`
- point build script and HTML files to the new CSS file

## Testing
- `darksass src/styles/global.scss public/global.css` *(fails: command not found)*