### PR TITLE
Fix mobile header overflow

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -161,14 +161,19 @@ div.highlight td.code {
 header {
   position: relative;
   display: flex;
-  flex-direction: column; 
-  align-items: center;   
-  text-align: center;    
-  gap: 1rem;             
-  padding: 1rem;         
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 1rem;
   width: 100%;
   float: none;
   margin-bottom: 0;
+}
+
+.site-logo img {
+  max-width: 100%;
+  height: auto;
 }
 
 header h1 {

--- a/build.py
+++ b/build.py
@@ -156,7 +156,7 @@ current_year = '2025'
 HEADER = f"""
     <header class="container">
       <div class="site-logo"> <a href="/" style="text-decoration: none; color: inherit;">
-        <img src="/images/logo.svg" alt="{site_title} Logo" width="400" height="50" style="vertical-align: middle;">
+        <img src="/images/logo.svg" alt="{site_title} Logo" style="vertical-align: middle; max-width: 100%; height: auto;">
         </a>
       </div>
 


### PR DESCRIPTION
## Summary
- make the header logo responsive
- size the logo with CSS so the hamburger icon stays onscreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a1ffeff04832998ef37aa8427924e