### PR TITLE
Use get_url for logo path

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
     <header class="container">
         <div class="site-logo">
             <a href="/" style="text-decoration: none; color: inherit;">
-                <img src="/logo.svg" alt="{{ config.title }} Logo" style="vertical-align: middle; max-width: 100%; height: auto;">
+                <img src="{{ get_url(path="logo.svg") }}" alt="{{ config.title }} Logo" style="vertical-align: middle; max-width: 100%; height: auto;">
             </a>
         </div>
         <input type="checkbox" id="nav-toggle" class="nav-toggle">


### PR DESCRIPTION
## Summary
- use Zola's `get_url` helper for the site logo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a9ceac9148329abd9acd2907d6f3b