### PR TITLE
Hard enforce header logo height

### DIFF
--- a/static/css/fix-logo.css
+++ b/static/css/fix-logo.css
@@ -1,0 +1,6 @@
+/* header logo must always have size */
+.site-logo img{
+  height:48px !important;
+  width:auto  !important;
+  display:block !important;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
     <link rel="stylesheet" href="/global.css">
     <link rel="icon" href="/red-plus.ico" type="image/x-icon">
+    <link rel="stylesheet" href="{{ get_url(path='css/fix-logo.css') }}">
 </head>
 <body>
     <header class="container">


### PR DESCRIPTION
## Summary
- add static stylesheet for header logo sizing
- link new stylesheet in the base template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aad63687c832998d58149c8af787c