### PR TITLE
Fix code block border artifact

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -55,13 +55,15 @@ code {
 // --- Styles for Highlighted Code Blocks (Terminal Look) ---
 // From Turn 104 - to remove lines around the block
 div.highlight {
-  background: $code-block-bg !important; 
-  border: none !important;               
-  outline: none !important;             
-  box-shadow: none !important;          
-  padding: 0 !important;                
-  margin-bottom: 1.6em;                  
-  overflow: hidden;                     
+  background: $code-block-bg !important;
+  // Add a border matching the background color to help avoid rendering artifacts
+  border: 1px solid $code-block-bg;
+  outline: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin-bottom: 1.6em;
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 div.highlight pre.highlight, 


### PR DESCRIPTION
## Summary
- add a 1px border to `.highlight` to hide tiny blue edge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b45085bb4832987153e59f81fbac0