### PR TITLE
Fix code block border

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -82,17 +82,18 @@ pre {
 }
 
 div.highlight pre.highlight code,
-pre code { 
-  background: none !important; 
-  color: inherit !important; 
+pre code {
+  background: none !important;
+  color: inherit !important;
   padding: 0 !important;
   margin: 0 !important;
-  font-size: inherit !important; 
-  line-height: inherit !important; 
+  font-size: inherit !important;
+  line-height: inherit !important;
+  border: none !important;
   border-radius: 0 !important;
-  white-space: inherit; 
-  word-wrap: inherit; 
-  display: block; 
+  white-space: inherit;
+  word-wrap: inherit;
+  display: block;
 }
 
 div.highlight table,

--- a/_sass/_darkmode.scss
+++ b/_sass/_darkmode.scss
@@ -60,6 +60,7 @@
   pre, pre code {
       background-color: #1e1e1e !important; /* Darker background */
       color: #abb2bf !important;
+      border: none !important;
       border-radius: 6px;
       padding: 1em;
       overflow: auto;


### PR DESCRIPTION
## Summary
- remove border from `pre code` rules in light and dark themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b48e478908329affff94337ad64a0