### PR TITLE
Fix about page image formatting

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -37,7 +37,7 @@ path: about
 
 # About Carey Balboa 🧑‍🔬
 
-![Carey Balboa, Founder of Remote IT Help, with his service animal Tango.](/images/carey-balboa.jpeg){: width="200" loading="lazy" style="float: right; margin-left: 15px; margin-bottom: 15px;" }
+<img src="/images/carey-balboa.jpeg" alt="Carey Balboa, Founder of Remote IT Help, with his service animal Tango." width="200" loading="lazy" style="float: right; margin-left: 15px; margin-bottom: 15px;" />
 
 Hi, I’m Carey Balboa.
 *(Carey: Like the Hawksbill Sea Turtle (Eretmochelys imbricata) Common Name: Carey)*

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -66,7 +66,7 @@
 }
 </script>
 <h1 id="about-carey-balboa-adult-microscope">About Carey Balboa 🧑‍🔬</h1>
-<p><img src="/images/carey-balboa.jpeg" alt="Carey Balboa, Founder of Remote IT Help, with his service animal Tango." />{: width="200" loading="lazy" style="float: right; margin-left: 15px; margin-bottom: 15px;" }</p>
+<img src="/images/carey-balboa.jpeg" alt="Carey Balboa, Founder of Remote IT Help, with his service animal Tango." width="200" loading="lazy" style="float: right; margin-left: 15px; margin-bottom: 15px;" />
 <p>Hi, I’m Carey Balboa.
 <em>(Carey: Like the Hawksbill Sea Turtle (Eretmochelys imbricata) Common Name: Carey)</em>
 <em>(Balboa: Like Balboa Park in San Diego)</em></p>


### PR DESCRIPTION
## Summary
- render image on About page using HTML instead of kramdown attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683b4e36fedc8329a944fc8460646a93