### PR TITLE
Ignore generated site for SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.sources=.
+sonar.exclusions=public/**


### PR DESCRIPTION
## Summary
- add `sonar-project.properties` to exclude `public/` from analysis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b6982cf608329b7d27346f2de9179