### PR TITLE
Fix GitHub comment link to include page slug

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -13,7 +13,7 @@
     <section class="comment-form">
         <h2>Leave a Comment</h2>
         <p>
-            <a href="https://github.com/careyjames/it-help-tech-site/issues/new?template=comment.yml&amp;labels=comment&amp;title=Comment%20on%20{{ page.slug | urlencode }}" target="_blank" rel="noopener">
+            <a href="https://github.com/careyjames/it-help-tech-site/issues/new?template=comment.yml&amp;labels=comment&amp;title=Comment%20on%20{{ page.slug | urlencode }}&amp;page={{ page.slug | urlencode }}" target="_blank" rel="noopener">
                 Submit your comment via GitHub
             </a>
         </p>


### PR DESCRIPTION
## Summary
- update the comment link in `templates/page.html` to include the page slug parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b935620c883299a562305f286db02