### PR TITLE
Add fallback blog image

### DIFF
--- a/content/blog/featured-images-in-zola-best-practices.md
+++ b/content/blog/featured-images-in-zola-best-practices.md
@@ -5,7 +5,7 @@ author: Carey Balboa
 categories: [Zola, Web Development]
 tags: [featured image, front matter, zola]
 extra:
-  image: images/logo-blue.png
+  image: images/logo-blue-square.svg
   image_alt: "Example featured graphic for Zola posts"
 description: "How to use extra.image in front matter and templates for clean featured images in Zola."
 ---

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -18,14 +18,14 @@
         </p>
       {%- endif %}
 
-      {# thumbnail: prefer extra.image but fall back to top-level image #}
-      {% set thumb = page.extra.image | default(value=page.image) %}
-      {% if thumb %}
-        <img src="{{ get_url(path=thumb) }}"
-             alt="{{ page.title }} thumbnail"
-             width="200"
-             class="post-thumb">
-      {% endif %}
+      {# thumbnail: prefer extra.image then page.image, fallback to logo #}
+      {% set thumb = page.extra.image
+                      | default(value=page.image)
+                      | default(value='images/logo-blue-square.svg') %}
+      <img src="{{ get_url(path=thumb) }}"
+           alt="{{ page.title }} thumbnail"
+           width="200"
+           class="post-thumb">
 
       <div class="post-excerpt">
         {{ page.summary | default(value=page.content | striptags | truncate(length=160)) }}

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,11 +2,10 @@
 {% block content %}
     <article class="post">
         <h1>{{ page.title }}</h1>
-        {% if page.extra.image %}
+        {% set hero = page.extra.image | default(value='images/logo-blue-square.svg') %}
         <figure class="featured-image">
-            <img src="{{ get_url(path=page.extra.image) }}" alt="{{ page.extra.image_alt | default(value="Featured") }}">
+            <img src="{{ get_url(path=hero) }}" alt="{{ page.extra.image_alt | default(value="Featured") }}">
         </figure>
-        {% endif %}
         {{ page.content | safe }}
     </article>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- update blog template to default to `images/logo-blue-square.svg`
- show fallback logo on individual posts when no featured image
- update example blog post to use new `logo-blue-square.svg`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683bc2040ea88329885ae714a923b17e