### PR TITLE
Display blog post author name

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,5 @@
 base_url = "https://d316lglduxncrn.cloudfront.net/"
 title = "IT Help San Diego Inc."
 description = "Remote IT Help - Mac, DNS, Email & Cybersecurity expertise."
+[extra]
+author_name = "Carey Balboa"

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -10,15 +10,15 @@
 
       <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
 
-      {% if page.date or page.author -%}
+      {% if page.date or page.author or page.extra.author or config.extra.author_name -%}
         <p class="post-meta">
           {% if page.date -%}
             <time datetime="{{ page.date | date(format="%Y-%m-%d") }}">
               {{ page.date | date(format="%B %d, %Y") }}
             </time>
           {%- endif %}
-          {% if page.author -%}
-            &nbsp;&mdash; {{ page.author }}
+          {% if page.author or page.extra.author or config.extra.author_name -%}
+            &nbsp;&mdash; {{ page.author | default(value=page.extra.author | default(value=config.extra.author_name)) }}
           {%- endif %}
         </p>
       {%- endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,15 +2,15 @@
 {% block content %}
     <article class="post">
         <h1>{{ page.title }}</h1>
-        {% if page.date or page.author -%}
+        {% if page.date or page.author or page.extra.author or config.extra.author_name -%}
             <p class="post-meta">
                 {% if page.date -%}
                     <time datetime="{{ page.date | date(format="%Y-%m-%d") }}">
                         {{ page.date | date(format="%B %d, %Y") }}
                     </time>
                 {%- endif %}
-                {% if page.author -%}
-                    &nbsp;&mdash; {{ page.author }}
+                {% if page.author or page.extra.author or config.extra.author_name -%}
+                    &nbsp;&mdash; {{ page.author | default(value=page.extra.author | default(value=config.extra.author_name)) }}
                 {%- endif %}
             </p>
         {%- endif %}


### PR DESCRIPTION
## Summary
- set default author in `config.toml`
- show the author name for blog posts using the default if none is provided

## Testing
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_683bc7429dd883299689cd108a367366