### PR TITLE
Remove default logo from about page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -2,6 +2,8 @@
 title: About Carey Balboa & Remote IT Help
 description: "Learn about Carey Balboa, the founder of Remote IT Help (IT Help San Diego Inc.), with 25 years of experience providing expert, ethical remote IT support."
 path: about
+extra:
+  skip_image: true
 ---
 
 <script type="application/ld+json">

--- a/templates/page.html
+++ b/templates/page.html
@@ -15,9 +15,11 @@
             </p>
         {%- endif %}
         {% set hero = page.extra.image | default(value='images/logo-blue-square.svg') %}
+        {% if not page.extra.skip_image %}
         <figure class="featured-image">
             <img src="{{ get_url(path=hero) }}" alt="{{ page.extra.image_alt | default(value="Featured") }}">
         </figure>
+        {% endif %}
         {{ page.content | safe }}
     </article>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- stop rendering the hero image when `skip_image` is set
- disable the hero image on the about page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683bd3bbb65c8329897e5e4ad907e9de