### PR TITLE
Add SEO metadata tags

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,41 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+
+    {# Determine whether we're rendering a page or a section #}
+    {% if page is defined %}
+        {% set entity = page %}
+    {% else %}
+        {% set entity = section %}
+    {% endif %}
+
+    {# Compute common meta values #}
+    {% set meta_title = entity.title | default(value=config.title) %}
+    {% set meta_desc = entity.description
+                        | default(value=entity.content | striptags | truncate(length=160))
+                        | default(value=config.description) %}
+    {% set meta_image = entity.extra.image | default(value='logo.svg') %}
+    {% set canonical = entity.permalink | default(value=config.base_url) %}
+    {% set og_type = entity.date | default(value=false) | ternary(value='article',
+                                                                     alt='website') %}
+
+    <title>{{ meta_title }}{% if meta_title != config.title %} | {{ config.title }}{% endif %}</title>
+    <meta name="description" content="{{ meta_desc }}">
+    <link rel="canonical" href="{{ canonical }}">
+
+    {# Open Graph tags #}
+    <meta property="og:title" content="{{ meta_title }}">
+    <meta property="og:description" content="{{ meta_desc }}">
+    <meta property="og:image" content="{{ get_url(path=meta_image) }}">
+    <meta property="og:url" content="{{ canonical }}">
+    <meta property="og:type" content="{{ og_type }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ meta_title }}">
+    <meta name="twitter:description" content="{{ meta_desc }}">
+    <meta name="twitter:image" content="{{ get_url(path=meta_image) }}">
+
     <link rel="stylesheet" href="/global.css">
     <link rel="icon" href="/red-plus.ico" type="image/x-icon">
     <link rel="stylesheet" href="{{ get_url(path='css/fix-logo.css') }}">


### PR DESCRIPTION
## Summary
- use front-matter values for SEO metadata
- inject canonical, Open Graph and Twitter tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683be9259a1c8329ac617359851f5787