### PR TITLE
Enable Zola sitemap

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 base_url = "https://d316lglduxncrn.cloudfront.net/"
 title = "IT Help San Diego Inc."
 description = "Remote IT Help - Mac, DNS, Email & Cybersecurity expertise."
+generate_sitemap = true
 [extra]
 author_name = "Carey Balboa"


### PR DESCRIPTION
## Summary
- enable sitemap generation in Zola config

## Testing
- `zola build`


------
https://chatgpt.com/codex/tasks/task_e_683bece117148329838f8bfeb4cd16e4