### PR TITLE
Remove default hero from service pages

### DIFF
--- a/content/billing.md
+++ b/content/billing.md
@@ -2,6 +2,9 @@
 title: Rates & Billing Policies
 description: "View transparent remote IT support rates ($275/hour, 30-min minimum), billing policies, payment terms, and our commitment to ethical service."
 path: billing
+extra:
+  skip_image: true
+  skip_author: true
 ---
 
 # Remote Consulting Rates & Policies 💳

--- a/content/dns-tool.md
+++ b/content/dns-tool.md
@@ -2,6 +2,9 @@
 title: DNS Tool - My Go-To DNS & Email Security Auditor
 description: "Discover DNS Tool, a command-line DNS and Email security auditor for checking MX, SPF, DKIM, DMARC (p=reject), DNSSEC, and more. Open-source and available on GitHub."
 path: dns-tool
+extra:
+  skip_image: true
+  skip_author: true
 ---
 
 # DNS Tool 🛠️ - My Command-Line DNS Auditor

--- a/content/services.md
+++ b/content/services.md
@@ -1,6 +1,9 @@
 ---
 title: On-site, in-home IT Services & Expert Solutions
 path: services
+extra:
+  skip_image: true
+  skip_author: true
 ---
 
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- omit hero images and author line on service pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683bfd0331c88329b74d2ba83bbf034c