### PR TITLE
Add footer address and codes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -79,7 +79,12 @@
         <div style="text-align: center; margin-bottom: 1rem;">
             <img src="/images/owl-of-athena.svg" width="100" height="100" alt="Owl of Athena">
         </div>
-        <p>&copy; {{ now() | date(format="%Y") }} {{ config.title }}
+        <p>&copy; {{ now() | date(format="%Y") }} {{ config.title }}<br>
+        888 Prospect Street Suite 200<br>
+        La Jolla, CA 92037<br>
+        (619) 853-5008<br>
+        SIC: 73790200<br>
+        NAICS: 541519
         <p class="footer-brag">✨ Built with Rust (Zola) & Sass, deployed via GitHub Actions, hosted on AWS S3/CloudFront/Route 53 (&lt;$10/mo). Zero JS, trackers, or cookies. Just lean, fast, cost-efficient tech. ✨</p>
     </footer>
 </body>


### PR DESCRIPTION
## Summary
- include company address & classification codes in site footer

## Testing
- `npm test`
- `zola build`


------
https://chatgpt.com/codex/tasks/task_e_683d2ca335748329b0ff84d70d18031d