### PR TITLE
Fix blog fallback image

### DIFF
--- a/content/blog/apple-sends-you-to-ijail.md
+++ b/content/blog/apple-sends-you-to-ijail.md
@@ -4,8 +4,6 @@ date: 2025-06-05
 author: Carey Balboa
 categories: [Apple, Security, Passwords]
 tags: [Apple Account, password reset, account recovery, security keys, passkeys]
-extra:
-  image: images/apple-account-locked.png
 description: "Learn how to unlock your Apple Account after too many failed sign-ins and avoid 'iJail'. Updated for 2025 with passkeys and security key tips."
 ---
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,7 @@
     {% set meta_desc = entity.description
                         | default(value=entity.content | striptags | truncate(length=160))
                         | default(value=config.description) %}
-    {% set meta_image = entity.extra.image | default(value='logo.svg') %}
+    {% set meta_image = entity.extra.image | default(value='images/logo-blue-square.svg') %}
     {% set canonical = entity.permalink | default(value=config.base_url) %}
     {% if entity.date %}
         {% set og_type = "article" %}

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -23,9 +23,8 @@
         </p>
       {%- endif %}
 
-      {# thumbnail: prefer extra.image then page.image, fallback to logo #}
+      {# thumbnail: prefer extra.image, fallback to logo #}
       {% set thumb = page.extra.image
-                      | default(value=page.image)
                       | default(value='images/logo-blue-square.svg') %}
       <img src="{{ get_url(path=thumb) }}"
            alt="{{ page.title }} thumbnail"


### PR DESCRIPTION
## Summary
- use `images/logo-blue-square.svg` as the fallback OpenGraph image
- remove nonexistent image reference from the "Apple Sends You To iJail" post so the default shows
- avoid undefined `page.image` in blog template to fix site build

## Testing
- `zola build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683de7d1503c8329913c2af6b034f00a