### PR TITLE
Fix rounded corners on blog images

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -450,6 +450,7 @@ footer p {
   width: 200px;
   height: auto;
   border-radius: 15px;
+  overflow: hidden;
 }
 
 a.read-more {
@@ -474,6 +475,7 @@ a.read-more {
   width: 200px;
   height: auto;
   border-radius: 15px;
+  overflow: hidden;
 }
 
 .post-content h2, .post-content h3, .post-content h4 {


### PR DESCRIPTION
## Summary
- keep blog image corners rounded by adding overflow hidden to `.post-thumb` and `.featured-image img`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e20d3967c832996cc87559f343614