### PR TITLE
Fix rounded corners on blog images

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -450,6 +450,8 @@ footer p {
   width: 200px;
   height: auto;
   border-radius: 15px;
+  overflow: hidden;
+  display: block;
 }
 
 a.read-more {
@@ -468,12 +470,15 @@ a.read-more {
 .featured-image {
   margin-bottom: 1rem;
   text-align: center;
+  overflow: hidden;
+  border-radius: 15px;
 }
 
 .featured-image img {
   width: 200px;
   height: auto;
   border-radius: 15px;
+  display: block;
 }
 
 .post-content h2, .post-content h3, .post-content h4 {


### PR DESCRIPTION
## Summary
- keep thumbnails clipped by ensuring `.featured-image img` has its own radius
- confirm `.post-thumb` properties

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683e20d3967c832996cc87559f343614