### PR TITLE
Fix HTML entity issue in blog excerpts

### DIFF
--- a/templates/blog.html
+++ b/templates/blog.html
@@ -32,7 +32,7 @@
            class="post-thumb">
 
       <div class="post-excerpt">
-        {{ page.summary | default(value=page.content | striptags | truncate(length=160)) }}
+        {{ page.summary | default(value=page.content | striptags | truncate(length=160)) | safe }}
       </div>
 
       <a href="{{ page.permalink }}" class="read-more">Read more &rarr;</a>


### PR DESCRIPTION
## Summary
- render blog post excerpts as safe text so quotes aren't escaped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b19d1d508329bb6997229eab7e0f