### PR TITLE
Fix home header markup

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -42,7 +42,9 @@ image = "images/logo-slogan.jpeg"
 
 # Expert Mac IT Support for Complex Tech Challenges&nbsp;🛡️
 
+
 San Diego’s Apple-centric IT support for homes & SMBs. 25+ years fixing Mac, WiFi, DNS & Email issues. We fix macOS/iOS glitches, eliminate WiFi dead zones, boost security, and ensure Email delivery (SPF/DKIM/DMARC)— on-site, in-home or meet at our office (by appointment) in La Jolla. Clear answers & discreet service. **We solve tech problems—no monthly retainers.**
+
 (619) 853-5008
 
 <a href="https://8750b1ff89054a2b8a27550322e2ed7c.elf.site" target="_blank" class="cta-button">Read Verified Reviews</a>  

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,12 +29,12 @@
 {%- block header %}
   <header>
     <nav>
-      <div>
+      <div class="site-logo">
         {%- if config.extra.logo -%}
 
         <big><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls %}/index.html{%- endif %}" title="{{config.title}}">
         {%- if config.extra.logo.file -%}
-        <img src="{{ config.base_url | safe }}/{{ config.extra.logo.file | safe }}"{%- if config.extra.logo.alt %} alt="{{ config.extra.logo.alt | safe }}"{%- endif %}{%- if config.extra.logo.width %} width="{{ config.extra.logo.width | safe }}"{%- endif %}{%- if config.extra.logo.height %} height="{{ config.extra.logo.height | safe }}"{%- endif %} />
+        <img src="{{ get_url(path=config.extra.logo.file) }}"{%- if config.extra.logo.alt %} alt="{{ config.extra.logo.alt | safe }}"{%- endif %}{%- if config.extra.logo.width %} width="{{ config.extra.logo.width | safe }}"{%- endif %}{%- if config.extra.logo.height %} height="{{ config.extra.logo.height | safe }}"{%- endif %} />
         {%- endif -%}
         {%- if config.extra.logo.text -%}{{ config.extra.logo.text | safe }}{%- endif -%}
         </a></big>


### PR DESCRIPTION
## Summary
- set `site-logo` class in `base.html` and use `get_url` for the logo path
- add spacing before phone number on home page

## Testing
- `./zola build`

------
https://chatgpt.com/codex/tasks/task_e_684b1b021f20832985554b98bc157757