### PR TITLE
Display hero images & adjust header

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -319,6 +319,7 @@ header {
   text-align: center;
   gap: 1rem;
   padding: 1rem;
+  padding-top: 0;
   width: 100%;
   float: none;
   margin-bottom: 0;
@@ -426,6 +427,7 @@ footer p {
     justify-content: space-between;
     align-items: center;
     padding: 1rem;
+    padding-top: 0;
     gap: 1rem;
     position: relative;
     text-align: left;

--- a/templates/page.html
+++ b/templates/page.html
@@ -48,6 +48,12 @@
     {%- endif %}{%- endif %}
     {%- endblock page_header %}
 
+    {%- if page.extra.image %}
+    <p class="post-image">
+      <img src="{{ get_url(path=page.extra.image) }}" width="200"{%- if page.extra.image_alt %} alt="{{ page.extra.image_alt }}"{%- endif %}>
+    </p>
+    {%- endif %}
+
     {# In Page Series Navigation #}
     {%- if config.extra.series | default(value=true) %}
     {%- if page.extra.series %}


### PR DESCRIPTION
## Summary
- add blog/about hero image support
- tweak header padding so logo appears flush at page top

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1dc41d9c8329b2948375b719ff04