### PR TITLE
Fix phone number link and restore theme styles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ generate_sitemap = true
 abridgeMode = "dark"
 switcher    = true
 logo = { file = "logo.svg", height = "48", alt = "IT Help San Diego" }
-stylesheets = ["abridge.css", "global.css", "css/fix-logo.css"]
+stylesheets = ["global.css", "css/fix-logo.css"]
 copyright = false
 footer_credit = false
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -46,7 +46,7 @@ image = "images/logo-slogan.jpeg"
 San Diego’s Apple-centric IT support for homes & SMBs. 25+ years fixing Mac, WiFi, DNS & Email issues. We fix macOS/iOS glitches, eliminate WiFi dead zones, boost security, and ensure Email delivery (SPF/DKIM/DMARC)— on-site, in-home or meet at our office (by appointment) in La Jolla. Clear answers & discreet service. **We solve tech problems—no monthly retainers.**
 
 
-<p class="phone-line">(619) 853-5008</p>  
+<p class="phone-line"><a href="tel:16198535008">(619) 853-5008</a></p>
 
 <a href="https://8750b1ff89054a2b8a27550322e2ed7c.elf.site" target="_blank" class="cta-button">Read Verified Reviews</a>   
 

--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -9,5 +9,5 @@
 
 /* ensure phone number line has breathing room */
 .phone-line {
-  margin-bottom: 1rem;
+  margin: 0.5rem 0 1.5rem;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -137,7 +137,7 @@
       <p>&copy; {{ now() | date(format="%Y") }} IT Help San Diego Inc.<br />
       888 Prospect Street Suite 200<br />
       La Jolla, CA 92037<br />
-      (619) 853-5008<br />
+      <a href="tel:16198535008">(619) 853-5008</a><br />
       SIC: 73790200<br />
       NAICS: 541519</p>
       <p class="footer-brag">✨ Built with Rust (Zola) &amp; Sass, deployed via GitHub Actions, hosted on AWS S3/CloudFront/Route 53 (&lt;$10/mo). Zero JS, trackers, or cookies. Just lean, fast, cost-efficient tech. ✨</p>


### PR DESCRIPTION
## Summary
- make phone number clickable on homepage and footer
- give phone line some spacing
- revert to theme-provided styles so abridge colors work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b2acd1f908329ba863883cb8a8a89