### PR TITLE
Enable abridge theme styling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,10 +6,11 @@ description = "Apple-centric IT support across San Diego."
 generate_sitemap = true
 
 [extra]
-abridgeMode = "dark"
-switcher    = true
+abridgeMode = "switcher"
+js_switcher = true
+js_switcher_default = "dark"
 logo = { file = "logo.svg", height = "48", alt = "IT Help San Diego" }
-stylesheets = ["global.css", "css/fix-logo.css"]
+stylesheets = ["abridge.css", "css/fix-logo.css"]
 copyright = false
 footer_credit = false
 


### PR DESCRIPTION
## Summary
- enable dark/light switcher support
- load theme's abridge.css stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b2fe7d94083299c4d8f17b23cf6c7