### PR TITLE
Fix Lighthouse SEO warnings

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ generate_sitemap = true
 abridgeMode = "switcher"
 js_switcher = true
 js_switcher_default = "dark"
-logo = { file = "logo.svg", height = "48", alt = "IT Help San Diego" }
+logo = { file = "logo.svg", height = "48", width = "356", alt = "IT Help San Diego" }
 stylesheets = ["abridge.css", "css/fix-logo.css"]
 copyright = false
 footer_credit = false

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -1,5 +1,20 @@
 {% extends "base.html" %}
 
+{% block seo %}
+  {{ super() }}
+  {%- set title = section.title | default(value=config.title) -%}
+  {%- if config.extra.title_addition and title %}
+    {%- set title_addition = title_separator ~ config.extra.title_addition -%}
+  {%- elif config.extra.title_addition %}
+    {%- set title_addition = config.extra.title_addition -%}
+  {%- else %}
+    {%- set title_addition = "" -%}
+  {%- endif %}
+  {%- set description = section.description | default(value=config.description) -%}
+  {%- set_global page = section -%}
+  {{- macros_seo::seo(config=config, title=title, title_addition=title_addition, description=description, is_home=true) }}
+{% endblock seo %}
+
 {% block content %}
 <h1>Blog Posts ✍️</h1>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,5 +1,20 @@
 {% extends "base.html" %}
 
+{% block seo %}
+  {{ super() }}
+  {%- set title = section.title | default(value=config.title) -%}
+  {%- if config.extra.title_addition and title %}
+    {%- set title_addition = title_separator ~ config.extra.title_addition -%}
+  {%- elif config.extra.title_addition %}
+    {%- set title_addition = config.extra.title_addition -%}
+  {%- else %}
+    {%- set title_addition = "" -%}
+  {%- endif %}
+  {%- set description = section.description | default(value=config.description) -%}
+  {%- set_global page = section -%}
+  {{- macros_seo::seo(config=config, title=title, title_addition=title_addition, description=description, is_home=true) }}
+{% endblock seo %}
+
 {% block content %}
 <section class="homepage-hero">
   {{ section.content | safe }}


### PR DESCRIPTION
## Summary
- add SEO blocks for home and blog templates
- define logo width in site config

## Testing
- `npm test`
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_684b44551d688329876fabb50111dd19