### PR TITLE
Fix navigation styles to use theme accent color

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -8,9 +8,22 @@ body {
   font-size: 1.125rem;
   line-height: 1.6;
 }
-a { color: #59aaff; }
-a:hover { text-decoration: underline; }
-h1, h2, h3, h4, h5, h6 { color: #59aaff; }
+/* Use theme accent colors so they follow config.toml */
+a {
+  color: var(--a1);
+}
+a:hover {
+  text-decoration: underline;
+  color: var(--a2);
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--a1);
+}
 strong, li strong { color: #ffffff; }
 
 img {


### PR DESCRIPTION
## Summary
- use theme CSS variables for links and headers so navigation color follows config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b5313511c8329a1c60e427b629c12