### PR TITLE
Fix nav toggle and remove old blue

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -2,8 +2,8 @@
 
 /* Main theme dark mode colors */
 body {
-  background-color: #2A4055;
-  color: #f8f9fa;
+  background-color: var(--c1);
+  color: var(--f1);
   font-family: "JetBrains Mono", "Courier New", monospace;
   font-size: 1.125rem;
   line-height: 1.6;
@@ -114,7 +114,7 @@ header nav, header nav ul {
 
     header nav {
         display: none; position: absolute; top: 60px; right: 0;
-        width: 220px; background-color: #2A4055;
+        width: 220px; background-color: var(--c2);
         border: 1px solid rgb(58, 89, 119); border-radius: 8px;
         box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2); z-index: 1000;
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,6 +47,10 @@
                     <li><a href="{%- if i.url is matching('^http[s]?://') %}{{ i.url }}{%- else -%}{{ get_url(path=i.url, trailing_slash=i.slash) }}{%- endif %}"{% if i.blank %} target="_blank"{% endif %}>{{ i.name | safe }}</a></li>
                   {%- endfor -%}
                 {%- endif -%}
+                {%- if config.extra.js_switcher | default(value=true) -%}
+                  {%- set icon_adjust = config.extra.icon_adjust | default(value='svgs adjust') -%}
+                  <li><i type="reset" id="mode" class="js {{ icon_adjust }}"></i></li>
+                {%- endif -%}
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
## Summary
- restore dark mode toggle in nav
- use theme color variables instead of hard-coded blue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b54cb6cd88329882ac0716060bfdb