### PR TITLE
Add dropdown navigation

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -78,57 +78,58 @@ header {
 .nav-wrapper {
     max-width: 900px;
     margin: 0 auto;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     padding: 0 1rem;
-    height: 70px;
 }
 
-/* Hide the mobile toggle on desktop */
-.nav-toggle, .nav-toggle-label {
-    display: none;
+/* Always show the navigation */
+header nav {
+    display: block !important;
 }
 
-header nav, header nav ul {
-    display: flex;
-    align-items: center;
+header nav ul {
+    display: flex !important;
+    flex-wrap: wrap;
+    justify-content: center;
     list-style: none;
     margin: 0;
     padding: 0;
     gap: 1.5rem;
 }
 
-/* --- REVISED MOBILE STYLES (for screens 768px or less) --- */
-@media (max-width: 768px) {
-    .nav-wrapper { position: relative; }
-    .nav-toggle-label { display: block; cursor: pointer; z-index: 1001; }
-    .nav-toggle-label span, .nav-toggle-label span::before, .nav-toggle-label span::after {
-        display: block; background-color: #f8f9fa; height: 3px;
-        width: 25px; border-radius: 2px; position: relative;
-        transition: transform 0.3s ease, background-color 0.3s ease;
-    }
-    .nav-toggle-label span::before, .nav-toggle-label span::after { content: ''; position: absolute; }
-    .nav-toggle-label span::before { top: -8px; }
-    .nav-toggle-label span::after { top: 8px; }
+header nav ul li {
+    position: relative;
+}
 
-    header nav {
-        display: none; position: absolute; top: 60px; right: 0;
-        width: 220px; background-color: var(--c2);
-        border: 1px solid rgb(58, 89, 119); border-radius: 8px;
-        box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2); z-index: 1000;
-    }
-    .nav-toggle:checked ~ nav { display: block; }
-    header nav ul {
-        flex-direction: column; align-items: flex-start;
-        width: 100%; padding: 0.5rem 0; gap: 0;
-    }
-    header nav ul li { width: 100%; text-align: left; }
-    header nav ul li a { display: block; padding: 0.75rem 1.25rem; width: 100%; box-sizing: border-box; }
-    header nav ul li a:hover { background-color: rgb(50, 77, 102); }
-    #nav-toggle:checked ~ .nav-toggle-label span { background-color: transparent; }
-    #nav-toggle:checked ~ .nav-toggle-label span::before { transform: rotate(45deg); top: 0; }
-    #nav-toggle:checked ~ .nav-toggle-label span::after { transform: rotate(-45deg); top: 0; }
-}/******************************************************************************
+/* Dropdown styles */
+.dropdown-content {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background-color: var(--c2);
+    border: 1px solid rgb(58, 89, 119);
+    border-radius: 8px;
+    list-style: none;
+    padding: 0.5rem 0;
+    margin: 0;
+    min-width: 10rem;
+    z-index: 1000;
+}
+
+.dropdown-content li {
+    white-space: nowrap;
+    padding: 0 1rem;
+}
+
+.dropdown-content li a {
+    display: block;
+    padding: 0.5rem 0;
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+/******************************************************************************
  *   Extra - Put your extra SASS/CSS here, it will get bundled with abridge.css
  *****************************************************************************/

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,16 +37,28 @@
             {%- endif %}
         </div>
 
-        <input type="checkbox" id="nav-toggle" class="nav-toggle">
-        <label for="nav-toggle" class="nav-toggle-label"><span></span></label>
-
         <nav>
             <ul>
-                {%- if config.extra.menu %}
-                  {%- for i in config.extra.menu -%}
-                    <li><a href="{%- if i.url is matching('^http[s]?://') %}{{ i.url }}{%- else -%}{{ get_url(path=i.url, trailing_slash=i.slash) }}{%- endif %}"{% if i.blank %} target="_blank"{% endif %}>{{ i.name | safe }}</a></li>
-                  {%- endfor -%}
-                {%- endif -%}
+                <li><a href="{{ get_url(path='/') }}">Home</a></li>
+                <li><a href="{{ get_url(path='/billing/') }}">Pricing</a></li>
+                <li class="dropdown">
+                    <a href="#">More</a>
+                    <ul class="dropdown-content">
+                        <li><a href="{{ get_url(path='/services/') }}">Services</a></li>
+                        <li><a href="{{ get_url(path='/dns-tool/') }}">DNS Tool</a></li>
+                        <li><a href="{{ get_url(path='/blog/') }}">Blog</a></li>
+                        <li><a href="{{ get_url(path='/about/') }}">About</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener">
+                        Schedule
+                        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" style="vertical-align: text-top;">
+                            <path fill="currentColor" d="M14 4h6v6h-2V7.41L9.41 16 8 14.59 16.59 6H14V4Z"/>
+                            <path fill="currentColor" d="M18 13v6H6V6h6V4H6a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h13a2 2 0 0 0 2-2v-7h-2Z"/>
+                        </svg>
+                    </a>
+                </li>
                 {%- if config.extra.js_switcher | default(value=true) -%}
                   {%- set icon_adjust = config.extra.icon_adjust | default(value='svgs adjust') -%}
                   <li><i type="reset" id="mode" class="js {{ icon_adjust }}"></i></li>


### PR DESCRIPTION
## Summary
- keep navigation visible at all screen sizes
- add dropdown with Services, DNS Tool, Blog, About
- display an external-link icon next to Schedule link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b59f0ad948329ace35247b2428a96