### PR TITLE
Fix dropdown toggle

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -158,14 +158,20 @@ header nav ul li a {
     display: none;
 }
 
-.dropdown:hover > .dropdown-content,
 .dropdown-checkbox:checked ~ .dropdown-content {
     display: block;
 }
 
-.dropdown:hover > .dropdown-toggle .arrow,
 .dropdown-checkbox:checked + .dropdown-toggle .arrow {
     transform: rotate(180deg);
+}
+
+.dropdown:hover > .dropdown-content {
+    display: none;
+}
+
+.dropdown:hover > .dropdown-toggle .arrow {
+    transform: none;
 }
 
 .dropdown-content li {

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,7 +47,7 @@
             </li>
             <li class="dropdown">
                 <input type="checkbox" id="more-toggle" class="dropdown-checkbox">
-                <label for="more-toggle" class="dropdown-toggle">More <span class="arrow">▼</span></label>
+                <label for="more-toggle" class="dropdown-toggle"><span class="arrow">▼</span> More</label>
                 <ul class="dropdown-content">
                     <li><a href="{{ get_url(path='/billing/') }}">Pricing</a></li>
                     <li><a href="{{ get_url(path='/services/') }}">Services</a></li>


### PR DESCRIPTION
## Summary
- tweak navigation markup so the arrow icon is left of "More"
- make dropdown open only when checkbox is checked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b7bb223388329b588b946cafa0e7a