### PR TITLE
Fix dropdown spacing

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -156,7 +156,7 @@ header nav ul li a {
     border: 1px solid rgb(58, 89, 119);
     border-radius: 8px;
     list-style: none;
-    padding: 0.5rem 0;
+    padding: 0.25rem 0;
     margin: 0;
     min-width: 10rem;
     z-index: 1000;
@@ -193,7 +193,7 @@ header nav ul li a {
 
 .dropdown-content li a {
     display: block;
-    padding: 0.5rem 0;
+    padding: 0.25rem 0;
 }
 
 


### PR DESCRIPTION
## Summary
- reduce padding inside dropdown menu links so links sit closer together

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8be5d4688329b694689ec62d44c4