### PR TITLE
Fix orphan anchors, keep blog permalinks

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -4,6 +4,7 @@ description = "Explore the IT Help blog for expert insights, articles, and troub
 sort_by = "date"
 paginate_by = 5
 template = "blog.html"
+insert_anchor_links = "left"
 +++
 
 # Blog Posts ✍🏼

--- a/deploy_preview.sh
+++ b/deploy_preview.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+zola build
+aws s3 sync public s3://preview-archive.it-help.tech --delete

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -230,6 +230,11 @@ header nav ul li a svg {
 /* --- hide every orphan "##" anchor that sits directly under <body> --- */
 body > a.anchor {
   display: none !important;
+  visibility: hidden !important;
+  position: absolute !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
 }
 
 /* ─── Mobile dropdown tap-target fix ─────────────────────────── */

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 {% if section.path | starts_with(value="blog/") %}
-  {{ section.content | safe | markdown(heading_permalink=true) }}
+  {{ section.content | safe | markdown(insert_anchor_links="left") }}
 {% else %}
   {{ section.content | safe }}
 {% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -79,7 +79,7 @@
 
 
 {% if page.path | starts_with(value="blog/") %}
-  {{ page.content | safe | markdown(heading_permalink=true) }}
+  {{ page.content | safe | markdown(insert_anchor_links="left") }}
 {% else %}
   {{ page.content | safe }}
 {% endif %}


### PR DESCRIPTION
## Summary
- suppress orphan permalinks with strong CSS
- enable in-heading permalinks on blog posts only
- add section front matter for blog permalink insertion
- provide deploy script to sync preview

## Testing
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_684d0390b54083299ac51298c41ff8bf