### PR TITLE
Remove duplicate headings

### DIFF
--- a/content/billing.md
+++ b/content/billing.md
@@ -7,7 +7,6 @@ extra:
   skip_author: true
 ---
 
-# CONSULTING RATES & BOOKING POLICIES 💳
 
 We follow clear policies for our IT support services. No monthly retainers!
 

--- a/content/dns-tool.md
+++ b/content/dns-tool.md
@@ -7,7 +7,6 @@ extra:
   skip_author: true
 ---
 
-# DNS Tool 🛠️ - My Command-Line DNS Auditor
 
 Tired of juggling a dozen different web tools and `dig` commands just to check if a domain's DNS and email security records were *actually* set up right? **So was I.** That's why I built **DNS Tool**.
 

--- a/content/services.md
+++ b/content/services.md
@@ -146,7 +146,6 @@ extra:
 }
 </script>
 
-# IT Services 🛠️
 
 We offer specialized IT support solutions focused on robust infrastructure, advanced security, and deep-dive troubleshooting. Our expertise ensures your critical systems run smoothly, securely, and efficiently.
 


### PR DESCRIPTION
## Summary
- remove manual H1 heading from **billing**, **services**, and **dns-tool** pages
- rebuild the site with Zola so the template title is the only h1

## Testing
- `zola build`


------
https://chatgpt.com/codex/tasks/task_e_684dac5189c08329820e64050032e1f7