### PR TITLE
Fix blog header alignment and title color

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -38,6 +38,21 @@ h5,
 h6 {
   color: var(--a1);
 }
+
+h1 a,
+h2 a,
+h1 a:visited,
+h2 a:visited {
+  color: var(--a1);
+}
+h1 a:hover,
+h2 a:hover {
+  color: var(--a3);
+}
+
+.page-title {
+  text-align: center;
+}
 strong,
 li strong {
   color: #ffffff;

--- a/static/abridge.css
+++ b/static/abridge.css
@@ -1282,6 +1282,22 @@ h6 {
   color: var(--a1);
 }
 
+h1 a,
+h2 a,
+h1 a:visited,
+h2 a:visited {
+  color: var(--a1);
+}
+
+h1 a:hover,
+h2 a:hover {
+  color: var(--a3);
+}
+
+.page-title {
+  text-align: center;
+}
+
 strong,
 li strong {
   color: #ffffff;

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -16,7 +16,7 @@
 {% endblock seo %}
 
 {% block content %}
-<h1>Blog Posts ✍️</h1>
+<h1 class="page-title">Blog Posts ✍️</h1>
 
 <ul class="post-list">
   {# section.pages is already sorted by date desc in Zola #}


### PR DESCRIPTION
## Summary
- center the blog page header
- keep blog entry titles orange whether visited or not
- rebuild CSS after style changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684def8b7038832986fda48a54770eec