### PR TITLE
Fix blog post title alignment

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -25,7 +25,7 @@
 {%- macro title_post(page, config) %}
 {%- set uglyurls = config.extra.uglyurls | default(value=false) -%}
 {%- if config.extra.search_library %}{%- if config.extra.search_library == "offline" %}{% set uglyurls = true %}{% endif %}{% endif %}
-      <h1>{{ page.title | markdown(inline=true) | safe }}</h1>
+      <h1 class="page-title">{{ page.title | markdown(inline=true) | safe }}</h1>
 {%- endmacro title_post %}
 
 


### PR DESCRIPTION
## Summary
- align blog post titles using `page-title` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df39c152883298733ad6a453ced8c