### PR TITLE
Remove inline styles in base template

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -274,4 +274,8 @@ body > a.anchor {
 
 /******************************************************************************
  *   Extra - Put your extra SASS/CSS here, it will get bundled with abridge.css
- *****************************************************************************/
+*****************************************************************************/
+/* CSP-safe helpers */
+.align-super { vertical-align: super; }
+.text-center { text-align: center; }
+.mb-1rem     { margin-bottom: 1rem; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,7 +59,7 @@
                 </details>
             </li>
             <li>
-                <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener">Schedule<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" style="vertical-align: super;"><path fill="currentColor" d="M14 4h6v6h-2V7.41L9.41 16 8 14.59 16.59 6H14V4Z"/><path fill="currentColor" d="M18 13v6H6V6h6V4H6a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h13a2 2 0 0 0 2-2v-7h-2Z"/></svg></a>
+                <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener">Schedule<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" class="align-super"><path fill="currentColor" d="M14 4h6v6h-2V7.41L9.41 16 8 14.59 16.59 6H14V4Z"/><path fill="currentColor" d="M18 13v6H6V6h6V4H6a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h13a2 2 0 0 0 2-2v-7h-2Z"/></svg></a>
             </li>
             {%- if config.extra.js_switcher | default(value=true) -%}
               {%- set icon_adjust = config.extra.icon_adjust | default(value='svgs adjust') -%}
@@ -81,7 +81,7 @@
     <div class="c">
       {%- include "partials/social.html" %}
 
-      <div style="text-align: center; margin-bottom: 1rem;">
+      <div class="text-center mb-1rem">
         <img src="/images/owl-of-athena.svg" width="100" height="100" alt="Owl of Athena" />
       </div>
       <p>&copy; {{ now() | date(format="%Y") }} IT Help San Diego Inc.<br />


### PR DESCRIPTION
## Summary
- add CSP-safe helper classes
- replace inline styles with helper classes

## Testing
- `zola build`
- `grep -R 'style="' public | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684e11a602388329a7fbd6bd1a66826c