### PR TITLE
Center page titles and fix header layout

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -90,11 +90,11 @@ pre {
   padding-inline: 1rem;
 }
 
-/* Left‑align page/article titles, but keep the landing hero centred */
-main header:not(.homepage-hero),
+
+/* Center page and article titles */
 .page-title,
 .post-title {
-  text-align: left !important;
+  text-align: center;
 }
 
 
@@ -113,9 +113,7 @@ header {
   margin: 0 0 0.25rem 0 !important;
   width: 100% !important;
   position: relative !important;
-  display: flex !important;
-  flex-direction: column;
-  align-items: center;
+  display: block !important;
   text-align: center;
 }
 

--- a/static/abridge.css
+++ b/static/abridge.css
@@ -1335,11 +1335,10 @@ pre {
   padding-inline: 1rem;
 }
 
-/* Left‑align page/article titles, but keep the landing hero centred */
-main header:not(.homepage-hero),
+/* Center page and article titles */
 .page-title,
 .post-title {
-  text-align: left !important;
+  text-align: center;
 }
 
 /* Footer brag text */
@@ -1356,9 +1355,7 @@ header {
   margin: 0 0 0.25rem 0 !important;
   width: 100% !important;
   position: relative !important;
-  display: flex !important;
-  flex-direction: column;
-  align-items: center;
+  display: block !important;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- center titles on all non-home pages again
- restore header layout to block for consistent logo/nav alignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e35968c5c83298205a5bd40c81939