### PR TITLE
Fix header alignment on expertise page

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -95,6 +95,8 @@ pre {
 .page-title,
 .post-title {
   text-align: center;
+  margin: 0 auto;
+  width: max-content;
 }
 
 
@@ -113,7 +115,9 @@ header {
   margin: 0 0 0.25rem 0 !important;
   width: 100% !important;
   position: relative !important;
-  display: block !important;
+  display: flex !important;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
 }
 
@@ -130,7 +134,7 @@ header {
 /* Center logo above navigation */
 .site-logo {
   text-align: center;
-  margin: 0.25rem 0;
+  margin: 0.25rem auto;
 }
 .site-logo img {
   display: block;


### PR DESCRIPTION
## Summary
- use flexbox for header element and center align items
- center logo container
- center titles with margin auto

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e3d1182a083299a4f9f86858cdd8f