### PR TITLE
Fix homepage and about page alignment

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -41,10 +41,8 @@ image = "images/logo-slogan.jpeg"
 </script>
 
 
-<header class="homepage-hero">
-  <h1>Expert Mac&nbsp;IT Support—Complex Tech Challenges</h1>
-  <!-- Optional subtitle or CTA buttons can stay inside this header -->
-</header>
+<!-- Homepage hero heading -->
+# Expert Mac&nbsp;IT Support—Complex Tech Challenges
 
 San Diego’s Apple-centric IT support for homes & SMBs. 25+ years fixing Mac, WiFi, DNS & Email issues. We fix macOS/iOS glitches, eliminate WiFi dead zones, boost security, and ensure Email delivery (SPF/DKIM/DMARC)— on-site, in-home or meet at our office (by appointment) in La Jolla. Clear answers & discreet service. **We solve tech problems—no monthly retainers.**
 

--- a/content/about.md
+++ b/content/about.md
@@ -6,6 +6,7 @@ extra:
   image: images/carey-balboa.png
   image_alt: "Carey Balboa with service animal Tango"
   skip_author: true
+  toc: false
 ---
 
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- drop extra header wrapper on the homepage
- disable the table-of-contents sidebar on the About page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e489f12948329908e79e297cf4b2d