### PR TITLE
Fix hero alignment and center header

### DIFF
--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -10,9 +10,8 @@
   padding-inline: 1rem;
 }
 
-/* Center hero headings */
-.homepage-hero > h1,
-.homepage-hero > h2 {
+/* Center only the main hero heading */
+.homepage-hero > h1 {
   text-align: center;
   margin-left: auto;
   margin-right: auto;

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -51,6 +51,15 @@ h2 a:hover {
 }
 
 /* Default left‑alignment for article/page headings */
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-align: left;
+}
+
+/* Ensure article or page h1s align left as well */
 .post-content h1 {
   text-align: left;
 }
@@ -90,9 +99,8 @@ pre {
   padding-inline: 1rem;
 }
 
-/* Keep hero headings centered */
-.homepage-hero > h1,
-.homepage-hero > h2 {
+/* Center only the main hero heading */
+.homepage-hero > h1 {
   text-align: center;
   margin-left: auto;
   margin-right: auto;

--- a/static/abridge.css
+++ b/static/abridge.css
@@ -1294,7 +1294,16 @@ h2 a:hover {
   color: var(--a3);
 }
 
-/* Default left‑alignment for article/page headings */
+/* Default left‑alignment for subheadings */
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-align: left;
+}
+
+/* Ensure article or page h1s align left as well */
 .post-content h1 {
   text-align: left;
 }
@@ -1335,9 +1344,8 @@ pre {
   padding-inline: 1rem;
 }
 
-/* Keep hero headings centered */
-.homepage-hero > h1,
-.homepage-hero > h2 {
+/* Center only the main hero heading */
+.homepage-hero > h1 {
   text-align: center;
   margin-left: auto;
   margin-right: auto;
@@ -1591,9 +1599,8 @@ body > a.anchor {
   padding-inline: 1rem;
 }
 
-/* Center hero headings */
-.homepage-hero > h1,
-.homepage-hero > h2 {
+/* Center only the main hero heading */
+.homepage-hero > h1 {
   text-align: center;
   margin-left: auto;
   margin-right: auto;

--- a/static/css/fix-logo.css
+++ b/static/css/fix-logo.css
@@ -6,6 +6,18 @@
   border-radius:0 !important;
 }
 
+/* Ensure header elements remain centered */
+.site-header {
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  text-align:center;
+}
+.nav-wrapper {
+  margin-left:auto;
+  margin-right:auto;
+}
+
 /* center the profile image on the about page */
 .post-image img {
   display: block;


### PR DESCRIPTION
## Summary
- keep only the main hero heading centered
- align all subheadings to the left
- force header and navigation to stay centered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e781516948329a32aaa63bf5674e8