### PR TITLE
Fix strong text color in light mode

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -111,3 +111,9 @@ html.switch .mode-btn::before{
   background:none;border:0;padding:0;
   cursor:pointer;font-size:1.5rem;line-height:1;
 }
+
+/* ─────────── 5.  STRONG TEXT COLOR FIX ───────────── */
+strong,
+li strong{
+  color: var(--f2) !important;
+}


### PR DESCRIPTION
## Summary
- update CSS override to ensure strong text shows correctly in light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f635872c0832994e70aab0fa389f3