### PR TITLE
Fix blog title layout and add author label

### DIFF
--- a/templates/blog.html
+++ b/templates/blog.html
@@ -16,7 +16,7 @@
 {% endblock seo %}
 
 {% block content %}
-<h1 class="page-title">Blog Posts</h1>
+<h1 class="page-title text-center">Blog Posts</h1>
 
 <ul class="post-list">
   {# section.pages is already sorted by date desc in Zola #}
@@ -33,7 +33,7 @@
             </time>
           {%- endif %}
           {% if page.author or page.extra.author or config.extra.author_name -%}
-            &nbsp;&mdash; {{ page.author | default(value=page.extra.author | default(value=config.extra.author_name)) }}
+            &nbsp;&mdash; Author: {{ page.author | default(value=page.extra.author | default(value=config.extra.author_name)) }}
           {%- endif %}
         </p>
       {%- endif %}

--- a/themes/abridge/templates/archive.html
+++ b/themes/abridge/templates/archive.html
@@ -53,10 +53,10 @@ This Template can also be used as the rendering template for Sections, eg: examp
         {%- set hide_section_dates = true -%}
       {%- endif -%}
     {%- endif %}
-    <div>
-      {%- if section_item.title %}
-      <h2>{{ section_item.title }}</h2>
-      {%- endif %}
+    {%- if section_item.title %}
+    <h1 class="page-title text-center">{{ section_item.title }}</h1>
+    {%- endif %}
+    <div class="post-list">
       {{- section_item.content | safe }}
       {%- if config.extra.archive_reverse %}
       {%- for year, posts in section_item.pages | sort(attribute="year") | reverse | group_by(attribute="year") %}
@@ -68,7 +68,7 @@ This Template can also be used as the rendering template for Sections, eg: examp
       {%- endif %}
       {%- endif %}
       {%- for post in posts %}
-      <p><a href="{{ post.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ post.title }}</a>{%- if not hide_section_dates %} - <time datetime="{{ post.date }}">{{ post.date | date(format="%F") }}</time>{%- endif %}</p>
+      <p><a href="{{ post.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ post.title }}</a>{%- if not hide_section_dates %} - <time datetime="{{ post.date }}">{{ post.date | date(format="%F") }}</time>{%- endif %}{% if post.author or post.extra.author or config.extra.author_name %} &mdash; Author: {{ post.author | default(value=post.extra.author | default(value=config.extra.author_name)) }}{% endif %}</p>
       {%- endfor %}
       {%- endfor %}
       {%- else %}
@@ -81,7 +81,7 @@ This Template can also be used as the rendering template for Sections, eg: examp
       {%- endif %}
       {%- endif %}
       {%- for post in posts %}
-      <p><a href="{{ post.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ post.title }}</a>{%- if not hide_section_dates %} - <time datetime="{{ post.date }}">{{ post.date | date(format="%F") }}</time>{%- endif %}</p>
+      <p><a href="{{ post.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ post.title }}</a>{%- if not hide_section_dates %} - <time datetime="{{ post.date }}">{{ post.date | date(format="%F") }}</time>{%- endif %}{% if post.author or post.extra.author or config.extra.author_name %} &mdash; Author: {{ post.author | default(value=post.extra.author | default(value=config.extra.author_name)) }}{% endif %}</p>
       {%- endfor %}
       {%- endfor %}
       {%- endif %}


### PR DESCRIPTION
## Summary
- center the blog index heading and add author labels in post meta
- adjust archive page template so section title is centered and author info is shown with dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f77e6b6e48329b0333f808798d872