### PR TITLE
Fix overflowing blog titles

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -38,7 +38,10 @@ h2, h3, h4, h5, h6      { text-align: left; }
 .post-title {
   text-align: left;
   margin: 0 auto;
-  width: max-content;
+  width: 100%;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 /* Hero headline on home page stays centred */


### PR DESCRIPTION
## Summary
- ensure blog titles can wrap by removing max-content width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f7aac29208329b756d9cc0c6b64b4