### PR TITLE
Fix theme toggle and title width

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -36,9 +36,9 @@ h2, h3, h4, h5, h6      { text-align: left; }
 /* Page / post titles left-aligned by default */
 .page-title,
 .post-title {
-  text-align: left;
+  text-align: center;
   margin: 0 auto;
-  width: 100%;
+  width: max-content;
   max-width: 100%;
   overflow-wrap: break-word;
   word-break: break-word;

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -75,11 +75,10 @@ body { overflow-x: hidden; }
   .page-title,
   .post-title,
   h1.page-title,
-  h1.post-title{
-    text-align:left !important;
-    margin-left:0 !important;
-    margin-right:auto !important;
-    width:100% !important;
+  h1.post-title {
+    text-align:center !important;
+    margin:0 auto !important;
+    width:max-content !important;
     max-width:100% !important;
     overflow-wrap:break-word !important;
     word-break:break-word !important;
@@ -217,10 +216,12 @@ main {
   }
 }
 .page-title, .post-title {
+    text-align: center;
+    margin: 0 auto;
+    width: max-content;
     max-width: 100%;
     overflow-wrap: break-word;
     white-space: normal;
-    text-align: center;
 }
 @media (max-width: 699px) {
   h1.page-title:has(+ .post-image) {

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -153,8 +153,8 @@
 
   /* Makes the theme switcher work instantly */
   .mode-btn { background:none; border:0; padding:0; cursor:pointer; font-size:1.5rem; line-height:1; }
-  .mode-btn::before{ content: "\2600\fe0f"; }
-  html.switch .mode-btn::before{ content: "\1F319"; }
+  .mode-btn::before { content: "☀️"; }
+  html.switch .mode-btn::before { content: "🌙"; }
 
   /* Defines the light theme palette to prevent flicker */
   html.switch .dropdown-content {


### PR DESCRIPTION
## Summary
- use emoji in inline CSS for immediate icon rendering
- center titles and limit width to avoid overflow

## Testing
- `npm test`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504b4330488329a24a5872cc3de984