### PR TITLE
Fix responsive image fallback source

### DIFF
--- a/templates/macros/images.html
+++ b/templates/macros/images.html
@@ -17,7 +17,7 @@
   <img {%- if lcp -%} loading="eager" {%- else -%} loading="lazy" {%- endif -%}
        decoding="async"
        width="1920" height="1080"
-       src="{{ base }}-640.jpg"
+       src="{{ base }}-640.webp"
        alt="{{ alt | escape }}">
 </picture>
 {%- endmacro -%}


### PR DESCRIPTION
## Summary
- tweak responsive macro to use existing 640.webp fallback

## Testing
- `zola build` *(fails: `zola` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525fb1c96c83299e8f677c353ecd13