### PR TITLE
Fix stylesheet loading and dark mode

### DIFF
--- a/static/js/theme-toggle.min.js
+++ b/static/js/theme-toggle.min.js
@@ -1,21 +1,20 @@
 /* tiny, plain-JS dark-mode helper  –  530 bytes un-minified               */
 /* ---------------------------------------------------------------------- */
-document.addEventListener('DOMContentLoaded', () => {
+(function() {
   const html   = document.documentElement;   // <html>
   const key    = 'theme';                    // localStorage key
-  const toggle = document.getElementById('mode');
+  const pref   = localStorage.getItem(key);
 
-  /* 1.  apply stored choice  (or fall back to DARK) ------------------- */
-  const pref  = localStorage.getItem(key);
-  if (pref === 'light') {
-    html.classList.add('switch');            // light mode
-  } else {
-    html.classList.remove('switch');         // dark mode by default
-  }
+  // apply stored choice (default: dark)
+  if (pref === 'light') html.classList.add('switch');
+  else html.classList.remove('switch');
 
-  /* 2.  click  →  switch class  +  remember -------------------------- */
-  toggle.addEventListener('click', () => {
-    const light = html.classList.toggle('switch');
-    localStorage.setItem(key, light ? 'light' : 'dark');
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('mode');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      const light = html.classList.toggle('switch');
+      localStorage.setItem(key, light ? 'light' : 'dark');
+    });
   });
-});
+})();

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -35,17 +35,14 @@
 {#- Style Sheets #}
   {%- set stylesheets=config.extra.stylesheets | default(value=[ "css/abridge.css" ]) -%}
   {%- if stylesheets %}{%- for i in stylesheets %}
-  <link rel="preload" as="style" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}"></noscript>
+  <link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">
   {%- endfor %}{%- endif %}
 
   {%- if ctx.extra.stylesheets %}{%- set pagestylesheets=ctx.extra.stylesheets -%}{%- endif %}
   {%- if pagestylesheets %}{%- for i in pagestylesheets %}
-  <link rel="preload" as="style" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}"></noscript>
+  <link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">
   {%- endfor %}{%- endif %}
-  <link rel="preload" as="style" href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}"></noscript>
+  <link rel="stylesheet" href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}">
 
 
 


### PR DESCRIPTION
## Summary
- ensure CSS loads synchronously so styles always apply
- set dark mode at page load for less flicker

## Testing
- `npm test`
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_6853291a15808329b5ab721621f1a8e0