### PR TITLE
Optimize CSS loading

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,11 @@ insert_anchor_links = "none"   # disable auto “##” anchors globally
 js_switcher = false
 # enable non-blocking stylesheet loading
 js_prestyle = true
+# Preload JetBrains Mono fonts
+fonts = [
+    { url = "fonts/jetbrains/JetBrainsMono-Regular.woff2" },
+    { url = "fonts/jetbrains/JetBrainsMono-Bold.woff2" }
+]
 #js_switcher_default = "dark"
 logo = { file = "logo.svg", height = "48", width = "356", alt = "IT Help San Diego" }
 stylesheets = ["css/abridge.min.css"]

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -27,6 +27,156 @@
   {%- endif %}
   <script src="{{                     get_url(path=js_theme                        , trailing_slash=false) | safe }}"{%- if integrity %} integrity="sha384-{{ get_hash(path=js_theme, sha_type=384, base64=true) | safe }}"{%- endif %}></script>
   {%- endif %}
+<style>
+:root {
+  --ff: Roboto, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", "Noto Sans", Helvetica, Arial, sans-serif;
+  --fm: ui-monospace, Menlo, Monaco, Consolas, "SF Mono", "Cascadia Mono", "Segoe UI Mono", "DejaVu Sans Mono", "Liberation Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Ubuntu Mono", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", Courier, monospace;
+  color-scheme: var(--cs);
+  --s1: .5rem;
+  --s2: 1rem;
+  --rc: .5rem;
+  --br: 0.25rem;
+  --bw: 0.0625rem;
+  --ow: 0.1875rem;
+  --fs: 1rem;
+  --lh: 1.5;
+  --lhh: 1.2;
+  --fw: 400;
+  --fh: 700;
+}
+:root:not(.switch) {
+  --cs: dark;
+  --f1: #ccc;
+  --f2: #ddd;
+  --c1: #111;
+  --c2: #222;
+  --c3: #333;
+  --c4: #888;
+  --a1: #f90;
+  --a2: #fb0;
+  --a3: #f90;
+  --a4: #f90;
+  --cg: #593;
+  --cr: #e33;
+  --h0: #191919;
+  --h1: #ddd;
+  --h2: #888;
+  --h3: #e65;
+  --h4: #e83;
+  --h5: #eb6;
+  --h6: #ac3;
+  --h7: #8db;
+  --h8: #6ae;
+  --h9: #d6e;
+  --ha: 160%;
+}
+:root.switch {
+  --cs: light;
+  --f1: #333;
+  --f2: #222;
+  --c1: #fff;
+  --c2: #eee;
+  --c3: #ddd;
+  --c4: #555;
+  --a1: #c40;
+  --a2: #e60;
+  --a3: #f90;
+  --a4: #c40;
+  --cg: #373;
+  --cr: #d33;
+  --h0: #f7f7f7;
+  --h1: #222;
+  --h2: #666;
+  --h3: #a21;
+  --h4: #930;
+  --h5: #a50;
+  --h6: #350;
+  --h7: #286;
+  --h8: #059;
+  --h9: #a3c;
+  --ha: 92%;
+}
+html {
+  background-color: var(--c1);
+  color: var(--f1);
+  font-family: var(--ff);
+  font-weight: var(--fw);
+  font-size: var(--fs);
+  line-height: var(--lh);
+}
+body {
+  background-color: var(--c1);
+  color: var(--f1);
+  font-family: "JetBrains Mono", "Courier New", monospace;
+  margin: 0;
+}
+.nav-wrapper {
+  display: flex;
+  width: fit-content;
+  margin: 0 auto;
+  padding: 0.25rem 0.75rem;
+  background-color: var(--c2);
+  border-radius: 2rem;
+  box-shadow: 0 2px 5px rgba(0,0,0,.3);
+}
+.nav-wrapper ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0.5rem;
+}
+.nav-wrapper ul li {
+  display: flex;
+  align-items: center;
+}
+.nav-wrapper ul li a {
+  display: flex;
+  align-items: center;
+}
+.homepage-hero {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  max-width: 60rem;
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+.homepage-hero>h1,
+.homepage-hero>.phone-line,
+.homepage-hero>p:has(.cta-button) {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+.homepage-hero>h2,
+.homepage-hero>p:not(.phone-line):not(:has(.cta-button)) {
+  text-align: left;
+  width: 100%;
+}
+.homepage-hero h2,
+.homepage-hero h3,
+.homepage-hero h4,
+.homepage-hero h5,
+.homepage-hero h6 {
+  text-align: left !important;
+  margin-left: 0 !important;
+  margin-right: auto !important;
+}
+.mode-btn {
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+.mode-btn::before { content: "\2600\fe0f"; }
+html.switch .mode-btn::before { content: "\1f319"; }
+</style>
 
 
 
@@ -35,14 +185,23 @@
 {#- Style Sheets #}
   {%- set stylesheets=config.extra.stylesheets | default(value=[ "css/abridge.css" ]) -%}
   {%- if stylesheets %}{%- for i in stylesheets %}
-  <link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">
+  <link rel="preload" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
   {%- endfor %}{%- endif %}
 
   {%- if ctx.extra.stylesheets %}{%- set pagestylesheets=ctx.extra.stylesheets -%}{%- endif %}
   {%- if pagestylesheets %}{%- for i in pagestylesheets %}
+  <link rel="preload" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  {%- endfor %}{%- endif %}
+  <link rel="preload" href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+  {%- if stylesheets %}{%- for i in stylesheets %}
+  <link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">
+  {%- endfor %}{%- endif %}
+  {%- if pagestylesheets %}{%- for i in pagestylesheets %}
   <link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">
   {%- endfor %}{%- endif %}
   <link rel="stylesheet" href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}">
+  </noscript>
 
 
 
@@ -118,7 +277,7 @@
   {%- if i.url is matching("^http[s]?://") %}
   <link rel="preload" as="style" class="preStyle" href="{{ i.url | safe }}" crossorigin="anonymous" />
   {%- else %}
-  <link rel="preload" as="font" href="{{ get_url(path=i.url, trailing_slash=false) | safe }}" type="font/woff2" />
+  <link rel="preload" as="font" href="{{ get_url(path=i.url, trailing_slash=false) | safe }}" type="font/woff2" crossorigin />
   {%- endif %}
 {%- endfor %}{%- endif %}
 


### PR DESCRIPTION
## Summary
- preload JetBrains Mono fonts
- inline critical styles for dark theme and navigation
- load stylesheets asynchronously with a noscript fallback
- add `crossorigin` to font preload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685340b4337883299ca492febee219b8