### PR TITLE
CLS & DOM-size final pass

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -279,3 +279,26 @@ img[alt="IT Help San Diego"] {
   src: url('/fonts/jetbrains/JetBrainsMono-Bold.woff2') format('woff2');
   font-display: swap;
 }
+
+/* --- CLS: reserve header space & swap fonts --- */
+header.site-header{height:calc(48px + 0.5rem);}        /* logo (48px) + vertical pad */
+header.site-header *{font-family:var(--ff)!important;} /* fall back until JB-Mono loads */
+
+/* Ensure both JetBrains Mono faces swap, not FOIT */
+@font-face{
+  font-family:'JetBrains Mono';
+  font-style:normal;
+  font-weight:400;
+  src:url('/fonts/jetbrains/JetBrainsMono-Regular.woff2') format('woff2');
+  font-display:swap;
+}
+@font-face{
+  font-family:'JetBrains Mono';
+  font-style:normal;
+  font-weight:700;
+  src:url('/fonts/jetbrains/JetBrainsMono-Bold.woff2')    format('woff2');
+  font-display:swap;
+}
+
+/* Dropdown toggle helper */
+.dropdown-content.hidden{display:none}

--- a/static/js/theme_button.js
+++ b/static/js/theme_button.js
@@ -1,5 +1,3 @@
-/* tiny, plain-JS dark-mode helper  –  530 bytes un-minified               */
-/* ---------------------------------------------------------------------- */
 (function() {
   const html   = document.documentElement;   // <html>
   const key    = 'theme';                    // localStorage key
@@ -18,3 +16,11 @@
     });
   });
 })();
+
+document.addEventListener('DOMContentLoaded',() => {
+  document.querySelector('.dropdown-toggle')?.addEventListener('click',e=>{
+    const btn=e.currentTarget;
+    const list=btn.nextElementSibling;
+    btn.setAttribute('aria-expanded',list.classList.toggle('hidden')?'false':'true');
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,16 +46,14 @@
 
       <!-- dropdown -->
       <li class="dropdown">
-        <details>
-          <summary class="dropdown-toggle">More</summary>
-          <ul class="dropdown-content">
-            <li><a href="{{ get_url(path='/billing/')  }}">Pricing</a></li>
-            <li><a href="{{ get_url(path='/services/') }}">Services</a></li>
-            <li><a href="{{ get_url(path='/dns-tool/') }}">DNS Tool</a></li>
-            <li><a href="{{ get_url(path='/blog/')     }}">Blog</a></li>
-            <li><a href="{{ get_url(path='/about/')    }}">Our Expertise</a></li>
-          </ul>
-        </details>
+        <button class="dropdown-toggle" aria-expanded="false">More</button>
+        <ul class="dropdown-content hidden">
+          <li><a href="{{ get_url(path='/billing/')  }}">Pricing</a></li>
+          <li><a href="{{ get_url(path='/services/') }}">Services</a></li>
+          <li><a href="{{ get_url(path='/dns-tool/') }}">DNS Tool</a></li>
+          <li><a href="{{ get_url(path='/blog/')     }}">Blog</a></li>
+          <li><a href="{{ get_url(path='/about/')    }}">Our Expertise</a></li>
+        </ul>
       </li>
 
       <!-- schedule -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
-  {{ section.content | regex_replace(pattern="\s+(\S+)$", rep="&nbsp;$1") | safe }}
+<main>
+  <section class="homepage-hero">
+    {{ section.content | regex_replace(pattern="\s+(\S+)$", rep="&nbsp;$1") | safe }}
+  </section>
+</main>
 {% endblock content %}

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -17,6 +17,12 @@
       fetchpriority="high"
       imagesrcset="/logo.svg 356w"
       imagesizes="356px">
+<link rel="preload" as="font"
+      href="/fonts/jetbrains/JetBrainsMono-Regular.woff2"
+      type="font/woff2" crossorigin>
+<link rel="preload" as="font"
+      href="/fonts/jetbrains/JetBrainsMono-Bold.woff2"
+      type="font/woff2" crossorigin>
 {% if page.title %}
   <title>{{ page.title }} – {{ config.title }}</title>
 {% else %}


### PR DESCRIPTION
## Summary
- reserve header height and ensure JetBrains Mono swaps
- preload JetBrains Mono fonts
- wrap home page content in `<section>`
- simplify dropdown markup and toggle logic
- tweak JS for dropdown

## Testing
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_68541cc0c3a4832983158b9b6866c53a