### PR TITLE
Fix layout shift and inline theme logic

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,7 @@ external_links_no_referrer  = true      # strip Referer header
 
 [extra]
 #abridgeMode = "switcher"
-js_switcher = true
+js_switcher = false
 js_switcher_default = "dark"
 # enable non-blocking stylesheet loading
 js_prestyle = true

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,7 @@
   <div class="site-logo">
     {%- if config.extra.logo.file %}
       <a href="{{ get_url(path='/') }}">
-        <img src="{{ get_url(path=config.extra.logo.file) }}" alt="{{ config.extra.logo.alt | safe }}">
+        <img src="{{ get_url(path=config.extra.logo.file) }}" alt="{{ config.extra.logo.alt | safe }}" width="{{ config.extra.logo.width }}" height="{{ config.extra.logo.height }}">
       </a>
     {%- endif %}
   </div>
@@ -97,13 +97,6 @@
 </footer>
 {%- endblock footer %}
 
-{% if config.extra.js_switcher %}
-  <script defer src="{{ get_url(path='js/theme-toggle.min.js',                       trailing_slash=false) | safe }}"
-          {% if integrity %} integrity="sha384-{{ get_hash(path='js/theme-toggle.min.js',    sha_type=384, base64=true) | safe }}"{% endif %}></script>
-  <!-- CSP-compliant fallback for dark-mode toggle -->
-  <script defer src="{{ get_url(path='js/theme_button.js',                           trailing_slash=false) | safe }}"
-          {% if integrity %} integrity="sha384-{{ get_hash(path='js/theme_button.js',       sha_type=384, base64=true) | safe }}"{% endif %}></script>
-{% endif %}
 
 </body>
 </html>

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -28,22 +28,6 @@
   {%- set integrity = config.extra.integrity | default(value=true) -%}
   {%- if config.extra.search_library %}{%- if config.extra.search_library == "offline" %}{% set integrity = false %}{% endif %}{% endif %}
 
-  {%- if config.extra.js_switcher | default(value=true) %}
-  {%- set js_theme="js/theme.min.js" %}
-  {%- if config.extra.js_switcher_default %}
-    {%- if config.extra.js_switcher_default == "light" %}{% set js_theme="js/theme_light.min.js" %}{% endif %}
-  {%- endif %}
-  <script src="{{                     get_url(path=js_theme                        , trailing_slash=false) | safe }}"{%- if integrity %} integrity="sha384-{{ get_hash(path=js_theme, sha_type=384, base64=true) | safe }}"{%- endif %}></script>
-{%- if config.extra.js_switcher | default(value=true) %}
-  <script defer
-          src="{{ get_url(path='js/theme-toggle.min.js', trailing_slash=false) | safe }}"
-          {% if integrity %} integrity="sha384-{{ get_hash(path='js/theme-toggle.min.js', sha_type=384, base64=true) | safe }}"{% endif %}></script>
-  <!-- CSP-compliant fallback for dark-mode toggle -->
-  <script defer
-          src="{{ get_url(path='js/theme_button.js', trailing_slash=false) | safe }}"
-          {% if integrity %} integrity="sha384-{{ get_hash(path='js/theme_button.js', sha_type=384, base64=true) | safe }}"{% endif %}></script>
-{%- endif %}
-{%- endif %}
 {%- if config.extra.js_prestyle | default(value=false) %}
 <script defer src="{{ get_url(path='js/prestyle.js', trailing_slash=false) | safe }}"{% if integrity %} integrity="sha384-{{ get_hash(path='js/prestyle.js', sha_type=384, base64=true) | safe }}"{% endif %}></script>
 {%- endif %}
@@ -206,8 +190,43 @@
   <link rel="alternate" type="application/rss+xml" title="{{ config.title }} RSS Feed" href="{{ get_url(path=feed, trailing_slash=false, lang=lang) | safe }}" />
   {%- endif %}
 
-  {%- endfor %}
-  {%- endif %}
+
+{%- endfor %}
+{%- endif %}
+
+<script>
+  (function() {
+    const html = document.documentElement;
+    const key = 'theme';
+    const pref = localStorage.getItem(key);
+    const defaultTheme = "{{ config.extra.js_switcher_default | default(value='dark') }}";
+
+    let theme;
+    if (pref) {
+      theme = pref;
+    } else {
+      theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    }
+
+    if (theme === 'light') {
+      html.classList.add('switch');
+    } else {
+      html.classList.remove('switch');
+    }
+  })();
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('mode');
+    if (!toggle) return;
+
+    toggle.addEventListener('click', () => {
+      const html = document.documentElement;
+      const key = 'theme';
+      const isLight = html.classList.toggle('switch');
+      localStorage.setItem(key, isLight ? 'light' : 'dark');
+    });
+  });
+</script>
 
 
 


### PR DESCRIPTION
## Summary
- avoid dark-mode JS from theme and inline own logic
- fix logo layout shift

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549c79878883299a92658908ab37de