### PR TITLE
Fix CSP header and heading styles

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,6 @@ js_switcher_default = "dark"
 js_prestyle = true
 logo = { file = "logo.svg", height = "48", width = "356", alt = "IT Help San Diego" }
 stylesheets = ["css/cls-fixes.css", "css/abridge.css"]
-csp_nonce = "{% set _ = macros::generate_csp_nonce() %}{{ macros::csp_nonce }}"
 author_name = "Carey Balboa"
 copyright = false
 footer_credit = false

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -7,6 +7,11 @@ body {
   line-height: 1.6;
 }
 
+/* Explicit font size for headings to avoid Chrome deprecation warning */
+h1 {
+  font-size: 2rem;
+}
+
 a          { color: var(--a1); }
 a:hover    { text-decoration: underline; color: var(--a2); }
 


### PR DESCRIPTION
## Summary
- remove invalid `csp_nonce` entry from `config.toml`
- define a default font size for `<h1>` elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68562cf41c648329bb9466076a035c04