### PR TITLE
Fix CSP nonce and heading CSS

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -12,6 +12,14 @@ h1 {
   font-size: 2rem;
 }
 
+/* Ensure headings inside structural elements have a defined size */
+article h1,
+section h1,
+nav h1,
+aside h1 {
+  font-size: 2rem;
+}
+
 a          { color: var(--a1); }
 a:hover    { text-decoration: underline; color: var(--a2); }
 

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -183,22 +183,7 @@
   //$embedded: true,//Embedded content, iframe, video, images, etc.
   //$table: true,//table specific elements
   //$code: true,//codeblocks, code, pre, kbd
-  //$hr: true,//Horizontal Rule
-  //$scroller: true,//Horizontal scroller (<figure>)
-  //$button: true,//Form elements (button)
-  //$form: true,//Form elements (non-button)
-  //$top: true,//back to top button using CSS
-  //$search: true,//search feature
-  //$blocks: true,//css classes for block formatting, eg: recent posts, table of contents, series navigation
-  //$series: true,//series navigation list
-  //$modifiers: true,//tiny modifier classes for sizing, spacing, etc.
-  //$misc: false,
-  //$grid: true,//Infinity Grid, column based layouts.
-  //$syntax: true,//syntax highlighting for code blocks
-  //$coderoundhighlight: false,//round corners on highlighted code blocks
 );
-//@use "fonts/Roboto";
-//@use "fonts/Arimo";
 @use "../_custom" as *;
 @use "../_extra"  as *;
 

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -119,7 +119,7 @@
 <meta http-equiv="Content-Security-Policy"
       content="default-src 'self';
                img-src     'self' data:;
-               style-src   'self' talk.hyvor.com cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;
+               style-src   'self' 'nonce-{{ macros::csp_nonce() }}' talk.hyvor.com cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;
                script-src  'self';">
 
 {# --- Favicons etc. --- #}


### PR DESCRIPTION
## Summary
- add nonce to CSP meta tag
- ensure headings inside sections have a font size
- clean out commented Sass code
- remove unused empty CSS file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685631253ab883298f72ad28ac4b6b11