### PR TITLE
Fix CSP nonce and clean CSS

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -99,11 +99,6 @@ body { overflow-x: hidden; }
     margin-left: 0 !important;
     margin-right: 4px !important;
   }
-  .mode-btn{
-    position: relative;
-    top: 1px;
-    margin-right: -6px;
-  }
   .nav-wrapper ul{
     gap: 0.75rem !important;
     font-size: 1.15rem !important;
@@ -123,7 +118,6 @@ body { overflow-x: hidden; }
       transform: none !important;
       position: absolute !important;
       column-count: 1 !important;
-      columns: 1 auto !important;
       column-width: auto !important;
       column-gap: 0 !important;
       display: flex !important;
@@ -139,7 +133,6 @@ body { overflow-x: hidden; }
   }
   .dropdown-content ul{
     column-count: 1 !important;
-    columns: 1 auto !important;
     column-width: auto !important;
     column-gap: 0 !important;
     display: flex !important;
@@ -162,6 +155,9 @@ body { overflow-x: hidden; }
     margin-top: 0px !important;
   }
   .mode-btn{
+    position: relative;
+    top: 1px;
+    margin-right: -6px;
     font-size: 1.9rem !important;
   }
 }

--- a/templates/macros/csp.html
+++ b/templates/macros/csp.html
@@ -1,3 +1,3 @@
 {% macro generate_csp_nonce() %}
-    {{ get_random(start=100000000000, end=999999999999) }}
+    {{ get_random(length=16, kind="alphanumeric") }}
 {% endmacro %}

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -119,7 +119,7 @@
 <meta http-equiv="Content-Security-Policy"
       content="default-src 'self';
                img-src     'self' data:;
-               style-src   'self' 'nonce-{{ csp_nonce }}' talk.hyvor.com cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;
+               style-src   'self' 'nonce-{{ csp_nonce | safe }}' talk.hyvor.com cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;
                script-src  'self';">
 
 {# --- Favicons etc. --- #}

--- a/themes/abridge/COPY-TO-ROOT-SASS/abridge.scss
+++ b/themes/abridge/COPY-TO-ROOT-SASS/abridge.scss
@@ -204,5 +204,3 @@
  *     make sure to have the relevant woff2 fonts in your static/fonts folder
  *   I measured the least Cumulative Layout Shift with: Roboto, Lato, Arimo
  *****************************************************************************/
-//@use "fonts/Roboto";
-//@use "fonts/Arimo";

--- a/themes/abridge/sass/_functions.scss
+++ b/themes/abridge/sass/_functions.scss
@@ -35,7 +35,6 @@
 @function font-prepend($base, $ext) {
   $ext-type: meta.type-of($ext);
   @if not ($ext-type == 'string') and not ($ext-type == 'list') {
-    //@debug "⚠ Expected a string or a list, but got '#{$ext-type}' in '#{$ext}'";
     @return $base;
   } @else {
     @return list.join($ext, $base);
@@ -77,7 +76,7 @@
       @return '%23888';//default color
     }
     @return nth($list, $index);
-  };
+  }
   @return '%23888';//default color
 }
 


### PR DESCRIPTION
## Summary
- ensure CSP nonce is safely rendered
- drop deprecated Sass comments
- remove duplicate/invalid CSS
- use alphanumeric nonce generator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685636ec3ff883299e0d3169ec044ef3