### PR TITLE
Fix linter issues and improve accessibility

### DIFF
--- a/sass/critical-inline.scss
+++ b/sass/critical-inline.scss
@@ -22,7 +22,8 @@ html { background: var(--bg); color: var(--fg); transition: background .15s; }
 img.logo{
   width: 356px !important;   /* intrinsic header size */
   height: 48px !important;
-  max-width: none !important;/* defeat generic img{max-width:100%} */
+  /* defeat generic rule that sets img max-width to 100% */
+  max-width: none !important;
 }
 
 /* Generic max‑width utility for lists and paragraphs */

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -103,6 +103,7 @@ body { overflow-x: hidden; }
     position: relative;
     top: 1px;
     margin-right: -6px;
+    font-size: 1.9rem !important;
   }
   .nav-wrapper ul{
     gap: 0.75rem !important;
@@ -123,7 +124,6 @@ body { overflow-x: hidden; }
       transform: none !important;
       position: absolute !important;
       column-count: 1 !important;
-      columns: 1 auto !important;
       column-width: auto !important;
       column-gap: 0 !important;
       display: flex !important;
@@ -139,7 +139,6 @@ body { overflow-x: hidden; }
   }
   .dropdown-content ul{
     column-count: 1 !important;
-    columns: 1 auto !important;
     column-width: auto !important;
     column-gap: 0 !important;
     display: flex !important;
@@ -160,9 +159,6 @@ body { overflow-x: hidden; }
     width: 30px !important;
     height: 30px !important;
     margin-top: 0px !important;
-  }
-  .mode-btn{
-    font-size: 1.9rem !important;
   }
 }
 article ul, article ol{
@@ -258,5 +254,9 @@ header.site-header{
   width:100px;
   height:100px;
   max-width:none;
+}
+
+.big{
+  font-size: larger;
 }
 

--- a/themes/abridge/package_abridge.js
+++ b/themes/abridge/package_abridge.js
@@ -34,10 +34,10 @@ const pwa_IGNORE_FILES = data.extra.pwa_IGNORE_FILES;
 
 // This is used to pass arguments to zola via npm, for example:
 // npm run abridge -- "--base-url https://abridge.pages.dev"
-var args = process.argv[2] ? ' ' + process.argv[2] : '';
+let args = process.argv[2] ? ' ' + process.argv[2] : '';
 
 // check if abridge is used directly or as a theme.
-bpath = '';
+let bpath = '';
 if (fs.existsSync('./themes')) {
   bpath = 'themes/abridge/';
 }
@@ -64,7 +64,7 @@ async function abridge() {
   // set index_format for chosen search_library accordingly.
   if (search_library === 'offline') {
     replaceInFileSync({ files: 'config.toml', from: /index_format.*=.*/g, to: "index_format = \"elasticlunr_javascript\"" });
-    args = args + " -u \"" + __dirname + "\/public\""//set base_url to the path on disk for offline site.
+    args = args + " -u \"" + __dirname + '/public\"'//set base_url to the path on disk for offline site.
   } else if (search_library === 'elasticlunrjava') {
     replaceInFileSync({ files: 'config.toml', from: /index_format.*=.*/g, to: "index_format = \"elasticlunr_javascript\"" });
   } else if (search_library === 'elasticlunr') {
@@ -79,14 +79,14 @@ async function abridge() {
   await execWrapper('zola build' + args);
 
   //check that static/js exists, do this after zola build, it will handle creating static if missing.
-  var jsdir = 'static/js';
+  const jsdir = 'static/js';
   try {
     fs.mkdirSync(jsdir);
   } catch (e) {
     if (e.code != 'EEXIST') throw e;
   }
 
-  base_url = data.base_url;
+  let base_url = data.base_url;
   if (base_url.slice(-1) == "/") {
     base_url = base_url.slice(0, -1);
   }
@@ -126,7 +126,7 @@ async function abridge() {
       fs.copyFileSync(bpath + 'static/js/sw_load.js', 'static/js/sw_load.js');
       // Update settings in PWA javascript file, using options parsed from config.toml.  sw.min.js?v=3.10.0",  "++"
       if (fs.existsSync('static/js/sw_load.js')) {
-        sw_load_min = '.js?v=';
+        let sw_load_min = '.js?v=';
         if (js_bundle) {
           sw_load_min = '.min.js?v=';
         }
@@ -144,26 +144,26 @@ async function abridge() {
         console.log('info: pwa_cache_all = true in config.toml, so caching the entire site.\n');
         // Generate array from the list of files, for the entire site.
 
-        var dir = 'public';
+        const dir = 'public';
         try {
           fs.mkdirSync(dir);
         } catch (e) {
           if (e.code != 'EEXIST') throw e;
         }
         const path = './public/';
-        cache = '';
-        files = fs.readdirSync(path, { recursive: true, withFileTypes: false })
+        let cache = '';
+        const files = fs.readdirSync(path, { recursive: true, withFileTypes: false })
           .forEach(
             (file) => {
               // check if is directory, if not then add the path/file
               if (!fs.lstatSync(path + file).isDirectory()) {
                 // format output
-                item = "/" + file.replace(/index\.html$/i, '');// strip index.html from path
+                let item = "/" + file.replace(/index\.html$/i, '');// strip index.html from path
                 item = item.replace(/\\/g, '/');// replace backslash with forward slash for Windows
 
-                var arrayLength = pwa_IGNORE_FILES.length;
-                for (var i = 0; i < arrayLength; i++) {
-                    regex = new RegExp(`^\/${pwa_IGNORE_FILES[i]}`, `i`);
+                const arrayLength = pwa_IGNORE_FILES.length;
+                for (let i = 0; i < arrayLength; i++) {
+                    const regex = new RegExp(`^/${pwa_IGNORE_FILES[i]}`, `i`);
                     item = item.replace(regex, '');// dont cache files in the pwa_IGNORE_FILES array
                 }
 
@@ -182,7 +182,7 @@ async function abridge() {
       cache = cache.split(",").sort().join(",")//sort the cache list, this should help keep the commit history cleaner.
       cache = 'this.BASE_CACHE_FILES = [' + cache + '];';
       // update the BASE_CACHE_FILES variable in the sw.js service worker file
-      results = replaceInFileSync({
+      const results = replaceInFileSync({
         files: 'static/sw.js',
         from: /this\.BASE_CACHE_FILES =.*/g,
         to: cache,
@@ -222,7 +222,7 @@ async function abridge() {
     fs.writeFileSync('static/manifest.min.json', out);
   }
 
-  abridge_bundle = bundle(bpath, js_prestyle, js_switcher, js_email_encode, js_copycode, search_library, index_format, uglyurls, false);
+  let abridge_bundle = bundle(bpath, js_prestyle, js_switcher, js_email_encode, js_copycode, search_library, index_format, uglyurls, false);
   minify(abridge_bundle, 'static/js/abridge_nopwa.min.js');
 
   abridge_bundle = bundle(bpath, js_prestyle, js_switcher, js_email_encode, js_copycode, search_library, index_format, uglyurls, pwa);
@@ -286,7 +286,7 @@ function _cpRegex(source, dest, regex) {
 }
 
 function bundle(bpath, js_prestyle, js_switcher, js_email_encode, js_copycode, search_library, index_format, uglyurls, pwa) {
-  minify_files = [];
+  let minify_files = [];
 
   if (js_prestyle) {
     minify_files.push(path.join(bpath, 'static/js/prestyle.js'));
@@ -346,11 +346,11 @@ function minify(fileA, outfile) {
   if (!outfile) {// outfile parameter omitted, infer based on input
     outfile = fileA[0].slice(0, -2) + 'min.js';
   }
-  var filesContents = fileA.map(function (file) {// array input to support multiple files
+  const filesContents = fileA.map(function (file) {// array input to support multiple files
     return fs.readFileSync(file, 'utf8');
   });
 
-  result = UglifyJS.minify(filesContents, options);
+  const result = UglifyJS.minify(filesContents, options);
   fs.writeFileSync(outfile, result.code);
 
 }

--- a/themes/abridge/sass/_functions.scss
+++ b/themes/abridge/sass/_functions.scss
@@ -35,7 +35,6 @@
 @function font-prepend($base, $ext) {
   $ext-type: meta.type-of($ext);
   @if not ($ext-type == 'string') and not ($ext-type == 'list') {
-    //@debug "⚠ Expected a string or a list, but got '#{$ext-type}' in '#{$ext}'";
     @return $base;
   } @else {
     @return list.join($ext, $base);
@@ -77,7 +76,7 @@
       @return '%23888';//default color
     }
     @return nth($list, $index);
-  };
+  }
   @return '%23888';//default color
 }
 

--- a/themes/abridge/sass/abridge.scss
+++ b/themes/abridge/sass/abridge.scss
@@ -626,8 +626,6 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
         @if map-get($breakpoints, "sm") and $enable-viewport {
           @media (min-width: map-get($breakpoints, "sm")) {
             max-width: map-get($viewports, "sm");
-            //padding-right: 0;
-            //padding-left: 0;
             .toc {
               display: none;
             }
@@ -1043,11 +1041,9 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
   [type="button" i],
   [type="submit" i],
   [type="reset" i] {
-    //-webkit-appearance: button;
     display: inline-block;
     text-align: center;
     white-space: nowrap;
-    //background: var(--c2);
     color: var(--f1);
     border: 0;
     cursor: pointer;
@@ -1081,10 +1077,6 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
     margin-bottom: .25rem;
   }
   // flagged by yellow lab tools, and not entirely necessary, so disabled for now.
-  //select,
-  //input:not([size]) input:not([type="button" i]) input:not([type="submit" i]) input:not([type="reset" i]) input:not([type="checkbox" i]) input:not([type="radio" i]) {
-  //  width: 100%;
-  //}
   [type="color" i] {
     min-height: 2.125rem;
   }
@@ -1384,7 +1376,6 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
     width: 1.8rem;
     height: 1.8rem;
     display: inline-block;
-    //overflow: hidden;
     text-align: center;
     vertical-align: middle;
   }
@@ -1397,7 +1388,6 @@ $coderoundhighlight: false !default;//round corners on highlighted code blocks
     vertical-align: middle;
   }
   .svgm {
-    //set minimum width and height for items with insufficient spacings
     min-width: 24px;
     min-height: 24px;
   }

--- a/themes/abridge/templates/base.html
+++ b/themes/abridge/templates/base.html
@@ -10,6 +10,7 @@
 <html lang="{%- if lang != config.default_language %}{{ lang }}{% else %}{{ config.extra.language_code | default(value=lang) }}{% endif %}">
 <head>
   {%- include "partials/head.html" %}
+  <title>{{ config.title }}</title>
 
   {#- SEO: title, description, etc #}
   {%- block seo %}
@@ -28,23 +29,23 @@
 <body>
 {%- block header %}
   <header>
-    <nav>
+    <nav aria-label="Main navigation">
       <div>
         {%- if config.extra.logo -%}
 
-        <big><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls %}/index.html{%- endif %}" title="{{config.title}}">
+        <span class="big"><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls %}/index.html{%- endif %}" title="{{config.title}}">
         {%- if config.extra.logo.file -%}
         <img src="{{ config.base_url | safe }}/{{ config.extra.logo.file | safe }}"{%- if config.extra.logo.alt %} alt="{{ config.extra.logo.alt | safe }}"{%- endif %}{%- if config.extra.logo.width %} width="{{ config.extra.logo.width | safe }}"{%- endif %}{%- if config.extra.logo.height %} height="{{ config.extra.logo.height | safe }}"{%- endif %} />
         {%- endif -%}
         {%- if config.extra.logo.text -%}{{ config.extra.logo.text | safe }}{%- endif -%}
-        </a></big>
+        </a></span>
 
         {%- elif config.extra.textlogo -%}
-        <big><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls -%}
+        <span class="big"><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls -%}
         {%- if lang == config.default_language -%}/{%- endif -%}
-        index.html{%- endif -%}" title="{{config.title}}">{{ config.extra.textlogo | safe }}</a></big>
+        index.html{%- endif -%}" title="{{config.title}}">{{ config.extra.textlogo | safe }}</a></span>
         {%- elif config.title -%}
-        <big><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls %}/index.html{%- endif %}" title="{{config.title}}">{{ config.title | safe }}</a></big>
+        <span class="big"><a href="{{ get_url(path="/", lang=lang) }}{%- if uglyurls %}/index.html{%- endif %}" title="{{config.title}}">{{ config.title | safe }}</a></span>
         {%- endif -%}
       </div>
       <div>
@@ -134,7 +135,7 @@
 
 
       {%- if config.extra.menu_footer %}
-      <nav class="vpad">
+      <nav class="vpad" aria-label="Footer navigation">
         {%- for i in config.extra.menu_footer -%}
         {%- if i.url is matching("^http[s]?://") %}
         {%- set furl=i.url %}

--- a/themes/abridge/templates/macros/macros.html
+++ b/themes/abridge/templates/macros/macros.html
@@ -100,7 +100,7 @@
 {%- macro title_index(page, config) %}
 {%- set uglyurls = config.extra.uglyurls | default(value=false) -%}
 {%- if config.extra.search_library %}{%- if config.extra.search_library == "offline" %}{% set uglyurls = true %}{% endif %}{% endif %}
-        <big>{% if config.extra.title_size_index %}<span class="{{ config.extra.title_size_index }}">{% endif %}<a href="{{ page.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ page.title | markdown(inline=true) | safe }}</a>{% if config.extra.title_size_index %}</span>{% endif %}</big>
+        <span class="big">{% if config.extra.title_size_index %}<span class="{{ config.extra.title_size_index }}">{% endif %}<a href="{{ page.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ page.title | markdown(inline=true) | safe }}</a>{% if config.extra.title_size_index %}</span>{% endif %}</span>
 {%- endmacro title_index %}
 
 
@@ -177,7 +177,7 @@
       {#- prev/next content page nextprev title pagination #}
       {%- if not config.extra.hide_page_nextprev_titles | default(value=false) %}
       {%- if page.lower or page.higher %}
-      <nav>
+      <nav aria-label="Previous and next pages">
         <div>
           {%- if page.lower %}
           <a href="{{ page.lower.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">&#8249; {{ page.lower.title | truncate(length=100) | markdown(inline=true) | safe }}</a>
@@ -226,7 +226,7 @@
                     {%- set end = paginator.number_pagers %}
                 {%- endif %}
             {%- endif %}
-      <nav class="vpad">
+      <nav class="vpad" aria-label="Pagination">
         {%- set icon_first=config.extra.icon_first | default(value="svgs svgh angll") -%}
         {%- set icon_prev=config.extra.icon_prev | default(value="svgs svgh angl") -%}
         {%- set icon_next=config.extra.icon_next | default(value="svgs svgh angr") -%}
@@ -333,7 +333,7 @@
                     {%- set end = paginator.number_pagers %}
                 {%- endif %}
             {%- endif %}
-      <nav class="vpad">
+      <nav class="vpad" aria-label="Pagination">
         {%- if paginator.current_index > 6 and paginator.number_pagers > 7 %}
           <a class="inp on" href="{{ paginator.first | safe }}{%- if uglyurls %}index.html{%- endif %}" aria-label="First Page">1</a>
           <a class="inp on" href="{{ paginator.base_url | safe }}{{ 2 ~ '/' }}{%- if uglyurls %}index.html{%- endif %}" aria-label="Page 2">2</a>

--- a/themes/abridge/templates/shortcodes/gif.html
+++ b/themes/abridge/templates/shortcodes/gif.html
@@ -24,6 +24,12 @@
   {%- if type is matching("^mov$") %}{% set type = "quicktime" %}{% endif -%}
   <source src="{{ path | safe }}{{ video | safe }}" type="{{ 'video/' ~ type }}" />
   {% endfor -%}
+  {% if subtitles %}
+  <track kind="captions" src="{{ subtitles }}" srclang="{{ lang | default(value='en') }}" label="English" />
+  {% endif %}
+  {% if descriptions %}
+  <track kind="descriptions" src="{{ descriptions }}" srclang="{{ lang | default(value='en') }}" label="Description" />
+  {% endif %}
   Your browser doesn't support the video tag and/or the video formats in use here – sorry!
 </video>
 {%- if caption %}<figcaption>{{caption}}</figcaption></figure>{% endif -%}

--- a/themes/abridge/templates/shortcodes/video.html
+++ b/themes/abridge/templates/shortcodes/video.html
@@ -24,6 +24,12 @@
   {%- if type is matching("^mov$") %}{% set type = "quicktime" %}{% endif -%}
   <source src="{{ path | safe }}{{ video | safe }}" type="{{ 'video/' ~ type }}" />
   {% endfor -%}
+  {% if subtitles %}
+  <track kind="captions" src="{{ subtitles }}" srclang="{{ lang | default(value='en') }}" label="English" />
+  {% endif %}
+  {% if descriptions %}
+  <track kind="descriptions" src="{{ descriptions }}" srclang="{{ lang | default(value='en') }}" label="Description" />
+  {% endif %}
   Your browser doesn't support the video tag and/or the video formats in use here – sorry!
 </video>
 {%- if caption %}<figcaption>{{caption}}</figcaption></figure>{% endif -%}


### PR DESCRIPTION
## Summary
- remove leftover comments and fix lint complaints in Sass
- remove redundant CSS properties and merge duplicate selectors
- add helper CSS class for `<big>` replacements
- replace deprecated `<big>` tags and improve nav accessibility
- add optional subtitle tracks to video shortcodes
- clean up JavaScript variable declarations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856b90258248329a6d4bf0bc6971131