### PR TITLE
Fix deprecated tags & header CSP

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -18,6 +18,7 @@ section h1,
 nav h1,
 aside h1 {
   font-size: 2rem;
+  line-height: 1.2;
 }
 
 a          { color: var(--a1); }

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -107,7 +107,13 @@
 {%- macro title_index(page, config) %}
 {%- set uglyurls = config.extra.uglyurls | default(value=false) -%}
 {%- if config.extra.search_library %}{%- if config.extra.search_library == "offline" %}{% set uglyurls = true %}{% endif %}{% endif %}
-        <big>{% if config.extra.title_size_index %}<span class="{{ config.extra.title_size_index }}">{% endif %}{{ page.title | markdown(inline=true) | safe }}{% if config.extra.title_size_index %}</span>{% endif %}</big>
+{%- if config.extra.title_size_index -%}
+  <span class="{{ config.extra.title_size_index }}">
+    {{ page.title | markdown(inline=true) | safe }}
+  </span>
+{%- else -%}
+  {{ page.title | markdown(inline=true) | safe }}
+{%- endif -%}
 {%- endmacro title_index %}
 
 

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -116,18 +116,6 @@
   <meta name="referrer" content="{{ config.extra.security_header_referrer | safe }}">
 {%- endif %}
 
-<meta http-equiv="Content-Security-Policy"
-      content="default-src 'none';
-               base-uri 'self';
-               script-src 'self';
-               style-src 'self' 'nonce-{{ csp_nonce | safe }}';
-               img-src 'self' data:;
-               font-src 'self';
-               connect-src 'self';
-               form-action 'self';
-               frame-ancestors 'none';
-               object-src 'none';
-               upgrade-insecure-requests">
 
 {# --- Favicons etc. --- #}
 {%- if config.extra.favicon_theme_color %}


### PR DESCRIPTION
## Summary
- fix deprecated HTML `<big>` tag in macros
- add explicit heading size rules
- remove meta-based CSP tag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856ec80a82c832981d0d0863b27c51d