### PR TITLE
Optimize CSS load timing

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -93,9 +93,7 @@
 <link rel="preload"
       href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}"
       as="style"
-      class="preStyle">
-<link rel="stylesheet" href="/css/override.min.css">
-
+      onload="this.onload=null;this.rel='stylesheet'">
 <noscript>
   {%- for i in stylesheets %}
     <link rel="stylesheet" href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">


### PR DESCRIPTION
## Summary
- prevent `override.min.css` from blocking initial render by using preload+onload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68570a2b1a6083298c87134f56e55479