### PR TITLE
Remove inline event handler from template

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -110,7 +110,7 @@
                        trailing_slash=false,
                        cachebust=true) | safe }}"
       as="style"
-      onload="this.onload=null;this.rel='stylesheet'">
+      >
 <noscript>
   <link rel="stylesheet"
         href="{{ get_url(path='css/override.min.css',


### PR DESCRIPTION
## Summary
- remove the `onload` attribute from `head.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571588438c8329b797590479c1d86e