### PR TITLE
Fix CLS from override preload timing

### DIFF
--- a/static/js/preload-promote.min.js
+++ b/static/js/preload-promote.min.js
@@ -1,0 +1,1 @@
+document.addEventListener("DOMContentLoaded",()=>{const l=document.getElementById("ovr");l&&l.rel!=="stylesheet"&&(l.rel="stylesheet")});

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -90,11 +90,11 @@
   {%- endfor %}
 {%- endif %}
 
-<link rel="preload"
+<link id="ovr"
+      rel="preload"
       href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}"
       as="style"
-      class="preStyle">
-<link rel="stylesheet" href="/css/override.min.css">
+      fetchpriority="high">
 
 <noscript>
   {%- for i in stylesheets %}
@@ -233,5 +233,7 @@
 {%- if config.extra.head_extra %}
   {{ config.extra.head_extra | safe }}
 {%- endif %}
+
+<script defer src="{{ get_url(path='js/preload-promote.min.js', trailing_slash=false, cachebust=true) | safe }}"></script>
 
 {# --- End of head partial --- #}


### PR DESCRIPTION
## Summary
- preload override.min.css with `fetchpriority="high"`
- auto-promote override preload to stylesheet
- remove blocking stylesheet tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857347817948329b27f906b0217580e