### PR TITLE
Fix render-blocking CSS

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -94,7 +94,6 @@
       href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}"
       as="style"
       class="preStyle">
-<link rel="stylesheet" href="/css/override.min.css">
 
 <noscript>
   {%- for i in stylesheets %}


### PR DESCRIPTION
## Summary
- remove the synchronous `override.min.css` link so it loads after `prestyle.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579227b9f88329a5bbbf59f6ef88ff