### PR TITLE
Inline critical CSS with CSP hash

### DIFF
--- a/headers.json
+++ b/headers.json
@@ -25,7 +25,7 @@
       "Override": true
     },
     "ContentSecurityPolicy": {
-      "ContentSecurityPolicy": "default-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; manifest-src 'self'; worker-src 'self'; form-action 'self'; connect-src 'self' *.hyvor.com ws://*.hyvor.com; script-src 'self'; img-src 'self' data: talk.hyvor.com cdn.cloudflare.com; frame-src 'self' www.youtube-nocookie.com player.vimeo.com streamable.com www.streamable.com; media-src 'self' data: cdn.cloudflare.com www.youtube-nocookie.com player.vimeo.com; font-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.gstatic.com; style-src 'self' 'sha256-DSxqvtjlBf6//1Lv9kJ9fUVHmNdMAZy2trzcwRVhElw=' talk.hyvor.com cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;",
+      "ContentSecurityPolicy": "default-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; manifest-src 'self'; worker-src 'self'; form-action 'self'; connect-src 'self' *.hyvor.com ws://*.hyvor.com; script-src 'self' 'sha256-9nVCkkTFORKiqpR0FuxxoyKXrSbNXeyP6hvPTluz+Z4='; img-src 'self' data: talk.hyvor.com cdn.cloudflare.com; frame-src 'self' www.youtube-nocookie.com player.vimeo.com streamable.com www.streamable.com; media-src 'self' data: cdn.cloudflare.com www.youtube-nocookie.com player.vimeo.com; font-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.gstatic.com; style-src 'self' 'sha256-GE1VJuE/duBNxOi4DDKe59GLkGOhtPg7O8ljLw2CnaY=' talk.hyvor.com cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;",
       "Override": true
     }
   },

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -1,3 +1,17 @@
+{% set critical_css = load_data(path="static/css/critical.min.css") %}
+<script>
+  // Prevent a flash of the wrong theme before CSS loads.
+  (function () {
+    try {
+      if (localStorage.getItem('theme') === 'light') {
+        document.documentElement.classList.add('switch');
+      }
+    } catch (e) {
+      console.warn('Could not read theme preference from localStorage.', e);
+    }
+  })();
+</script>
+<style>{{- critical_css | safe -}}</style>
 <meta charset="utf-8" />
 <meta http-equiv="x-ua-compatible" content="ie=edge" />
 
@@ -55,7 +69,6 @@
 {%- endif %}
 
 <!-- critical CSS -->
-<link rel="preload" href="/css/critical.min.css" as="style" class="preStyle">
 <link rel="preload"
       href="{{ get_url(path='css/cls-fixes.css', trailing_slash=false, cachebust=true) | safe }}"
       as="style"
@@ -65,7 +78,6 @@
   <link rel="stylesheet" href="{{ get_url(path='css/critical-inline.css') | safe }}">
   <link rel="stylesheet"
         href="{{ get_url(path='css/cls-fixes.css', trailing_slash=false, cachebust=true) | safe }}">
-  <link rel="stylesheet" href="/css/critical.min.css">
 </noscript>
 
 {# --- Critical hero styling uses CSP nonce --- #}
@@ -94,7 +106,6 @@
       href="{{ get_url(path='css/override.min.css', trailing_slash=false, cachebust=true) | safe }}"
       as="style"
       class="preStyle">
-<link rel="stylesheet" href="/css/override.min.css">
 
 <noscript>
   {%- for i in stylesheets %}


### PR DESCRIPTION
## Summary
- inline theme script and critical CSS before other head tags
- remove external critical stylesheet link
- hash new inline resources in Content-Security-Policy
- handle possible localStorage errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685840c064248329bdaeee1fd605ca1d