### PR TITLE
Switch site to system fonts

### DIFF
--- a/sass/critical-inline.scss
+++ b/sass/critical-inline.scss
@@ -1,5 +1,5 @@
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji" !important;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif !important;
   }
 
   /* Home hero headline */

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -148,8 +148,8 @@
 
   /// If prepending/appending fonts above, then no need to change them with the 2 below lines.
   /// The following 2 below lines give a way to hard code a font list if you prefer.
-  //$font: Roboto system-ui -apple-system BlinkMacSystemFont "Segoe UI" Oxygen Ubuntu Cantarell "Fira Sans" "Droid Sans" "Helvetica Neue" "Noto Sans" Helvetica Arial sans-serif,
-  //$font-mono: ui-monospace Menlo Monaco Consolas "SF Mono" "Cascadia Mono" "Segoe UI Mono" "DejaVu Sans Mono" "Liberation Mono" "Roboto Mono" "Oxygen Mono" "Ubuntu Monospace" "Ubuntu Mono" "Source Code Pro" "Fira Mono" "Droid Sans Mono" "Courier New" Courier monospace,
+  //$font: system-ui -apple-system BlinkMacSystemFont "Segoe UI" "Roboto" "Helvetica Neue" Arial sans-serif,
+  //$font-mono: ui-monospace SFMono-Regular Menlo Monaco Consolas "Liberation Mono" "Roboto Mono" "Courier New" monospace,
 
   /// Enable <header>, <main>, <footer> inside <body> as a container
   //$enable-semantic-container: true,

--- a/themes/abridge/COPY-TO-ROOT-SASS/abridge.scss
+++ b/themes/abridge/COPY-TO-ROOT-SASS/abridge.scss
@@ -147,8 +147,8 @@
 
   /// If prepending/appending fonts above, then no need to change them with the 2 below lines.
   /// The following 2 below lines give a way to hard code a font list if you prefer.
-  //$font: Roboto system-ui -apple-system BlinkMacSystemFont "Segoe UI" Oxygen Ubuntu Cantarell "Fira Sans" "Droid Sans" "Helvetica Neue" "Noto Sans" Helvetica Arial sans-serif,
-  //$font-mono: ui-monospace Menlo Monaco Consolas "SF Mono" "Cascadia Mono" "Segoe UI Mono" "DejaVu Sans Mono" "Liberation Mono" "Roboto Mono" "Oxygen Mono" "Ubuntu Monospace" "Ubuntu Mono" "Source Code Pro" "Fira Mono" "Droid Sans Mono" "Courier New" Courier monospace,
+  //$font: system-ui -apple-system BlinkMacSystemFont "Segoe UI" "Roboto" "Helvetica Neue" Arial sans-serif,
+  //$font-mono: ui-monospace SFMono-Regular Menlo Monaco Consolas "Liberation Mono" "Roboto Mono" "Courier New" monospace,
 
   /// Enable <header>, <main>, <footer> inside <body> as a container
   //$enable-semantic-container: true,

--- a/themes/abridge/sass/abridge.scss
+++ b/themes/abridge/sass/abridge.scss
@@ -162,8 +162,8 @@ $findFont-Code : null !default;
 $fontExt-Main  : null !default;
 $fontExt-Code  : null !default;
 
-$font: Roboto system-ui -apple-system BlinkMacSystemFont "Segoe UI" Oxygen Ubuntu Cantarell "Fira Sans" "Droid Sans" "Helvetica Neue" "Noto Sans" Helvetica Arial sans-serif !default;
-$font-mono: ui-monospace Menlo Monaco Consolas "SF Mono" "Cascadia Mono" "Segoe UI Mono" "DejaVu Sans Mono" "Liberation Mono" "Roboto Mono" "Oxygen Mono" "Ubuntu Monospace" "Ubuntu Mono" "Source Code Pro" "Fira Mono" "Droid Sans Mono" "Courier New" Courier monospace !default;
+$font: system-ui -apple-system BlinkMacSystemFont "Segoe UI" "Roboto" "Helvetica Neue" Arial sans-serif !default;
+$font-mono: ui-monospace SFMono-Regular Menlo Monaco Consolas "Liberation Mono" "Roboto Mono" "Courier New" monospace !default;
 
 /// Enable <header>, <main>, <footer> inside <body> as a container
 $enable-semantic-container: true !default;


### PR DESCRIPTION
## Summary
- update the inline critical CSS to use system fonts
- change the theme defaults to system font stacks
- update sample configuration comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c032657e0832982525888a7a5a2ab