### PR TITLE
Fix Safari font stack

### DIFF
--- a/sass/critical-inline.scss
+++ b/sass/critical-inline.scss
@@ -1,6 +1,6 @@
 :root {
   color-scheme: light dark;
-  --ff: "SF Pro Text", "SF Pro Icons", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --ff: -apple-system, system-ui, BlinkMacSystemFont, "SF Pro Text", "SF Pro Icons", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --fm: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Roboto Mono", "Courier New", monospace;
 }
 body {

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -6,7 +6,7 @@
   /// Fluid layout until a defined size, then becomes centered viewport.
   //$enable-maxwidth: true,
   $mw: 70%,// max-width
-  $font: "SF Pro Text" "SF Pro Icons" "Helvetica Neue" Helvetica Arial sans-serif,
+  $font: -apple-system system-ui BlinkMacSystemFont "SF Pro Text" "SF Pro Icons" "Helvetica Neue" Helvetica Arial sans-serif,
   //$mb: 1200px,// value at which to switch from fluid layout to max-width
 
   $abridgeMode: "switcher",//valid values: switcher, auto, dark, light


### PR DESCRIPTION
## Summary
- align font stack with Safari's `-apple-system`

## Testing
- `zola build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c214105888329bd509b48c90d64ce