### PR TITLE
Fix Safari preload warning for abridge.css

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -83,7 +83,7 @@
 
 {# --- Style Sheets --- #}
 {%- set stylesheets = config.extra.stylesheets | default(value=[ "css/abridge.css" ]) -%}
-  <link rel="preload" as="style" href="/css/abridge.css" />
+  <link rel="preload" as="style" href="{{ get_url(path='css/abridge.css', trailing_slash=false, cachebust=true) | safe }}" />
 {%- for i in stylesheets %}
   <link rel="stylesheet"
         href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">


### PR DESCRIPTION
## Summary
- ensure `abridge.css` preload uses same hashed URL as stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c29382354832994ee6da5372ab490