### PR TITLE
Remove CSS preload to silence Safari warning

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -83,7 +83,6 @@
 
 {# --- Style Sheets --- #}
 {%- set stylesheets = config.extra.stylesheets | default(value=[ "css/abridge.css" ]) -%}
-  <link rel="preload" as="style" href="{{ get_url(path='css/abridge.css', trailing_slash=false, cachebust=true) | safe }}" />
 {%- for i in stylesheets %}
   <link rel="stylesheet"
         href="{{ get_url(path=i, trailing_slash=false, cachebust=true) | safe }}">


### PR DESCRIPTION
## Summary
- stop preloading `abridge.css`

## Testing
- `npm test`
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_685c2b4946488329a6f48798da9b81d0