### PR TITLE
Restore dark palette and toggle

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,7 @@ external_links_no_referrer  = true      # strip Referer header
 
 [extra]
 #abridgeMode = "switcher"
-js_switcher = false
+js_switcher = true
 js_switcher_default = "dark"
 # enable non-blocking stylesheet loading
 js_prestyle = false

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -77,58 +77,58 @@
   /// The colors below can be overrided individually as needed.
 
   /// Dark Colors
-  //$f1d: #ccc,// Font Color Primary
-  //$f2d: #ddd,// Font Color Headers
-  //$c1d: #111,// Background Color Primary
-  //$c2d: #222,// Background Color Secondary
-  //$c3d: #333,// Table Rows, Block quote edge, Borders
-  //$c4d: #777,// Disabled Buttons, Borders, mark background
-  //$a1d: #f90,// link color
-  //$a2d: #fb0,// link hover/focus color
-  //$a3d: #f90,// link h1-h2 hover/focus color
-  //$a4d: #f90,// link visited color
-  //$cgd: #593,// ins green, success
-  //$crd: #e33,// del red, errors
+  $f1d: #E8E8E8,// Font Color Primary
+  $f2d: #E8E8E8,// Font Color Headers
+  $c1d: #0A0A0A,// Background Color Primary
+  $c2d: #1A1A1A,// Background Color Secondary
+  $c3d: #2A2A2A,// Table Rows, Block quote edge, Borders
+  $c4d: #2A2A2A,// Disabled Buttons, Borders, mark background
+  $a1d: #FFD700,// link color
+  $a2d: #D5AD36,// link hover/focus color
+  $a3d: #FFD700,// link h1-h2 hover/focus color
+  $a4d: #FFD700,// link visited color
+  $cgd: #5AFE73,// ins green, success
+  $crd: #FF5555,// del red, errors
 
   /// Light Colors
-  //$f1: #333,// Font Color Primary
-  //$f2: #222,// Font Color Headers
-  //$c1: #fff,// Background Color Primary
-  //$c2: #eee,// Background Color Secondary
-  //$c3: #ddd,// Table Rows, Block quote edge, Borders
-  //$c4: #555,// Disabled Buttons, Borders, mark background
-  //$a1: #c40,// link color
-  //$a2: #e60,// link hover/focus color
-  //$a3: #f90,// link h1-h2 hover/focus color
-  //$a4: #c40,// link visited color
-  //$cg: #373,// ins green, success
-  //$cr: #d33,// del red, errors
+  $f1: #0A0A0A,// Font Color Primary
+  $f2: #0A0A0A,// Font Color Headers
+  $c1: #FFFFFF,// Background Color Primary
+  $c2: #F8F9FA,// Background Color Secondary
+  $c3: #E1E4E8,// Table Rows, Block quote edge, Borders
+  $c4: #E1E4E8,// Disabled Buttons, Borders, mark background
+  $a1: #001F3F,// link color
+  $a2: #003366,// link hover/focus color
+  $a3: #003366,// link h1-h2 hover/focus color
+  $a4: #001F3F,// link visited color
+  $cg: #2E7D32,// ins green, success
+  $cr: #D32F2F,// del red, errors
 
   /// Dark Syntax Colors
-  //$h0d: #191919,// background color
-  //$h1d: #ddd,// unstyled text
-  //$h2d: #888,// comments
-  //$h3d: #e65,// red, support function
-  //$h4d: #e83,// orange, punctuation, constant, variable, json-key
-  //$h5d: #eb6,// tan, entity/function name
-  //$h6d: #ac3,// green, string
-  //$h7d: #8db,// teal, escape character
-  //$h8d: #6ae,// blue, declaration, tag, property
-  //$h9d: #d6e,// purple, operators
-  //$had: 160%,// mark/highlight line
+  $h0d: #1E1E1E,// background color
+  $h1d: #E8E8E8,// unstyled text
+  $h2d: #A0A0A0,// comments
+  $h3d: #FF5555,// red, support function
+  $h4d: #FFA500,// orange, punctuation, constant, variable, json-key
+  $h5d: #D5AD36,// tan, entity/function name
+  $h6d: #5AFE73,// green, string
+  $h7d: #4D9FFF,// teal, escape character
+  $h8d: #003366,// blue, declaration, tag, property
+  $h9d: #D5AD36,// purple, operators
+  $had: 160%,// mark/highlight line
 
   /// Light Syntax Colors
-  //$h0: #f7f7f7,// background color
-  //$h1: #222,// unstyled text
-  //$h2: #666,// comments
-  //$h3: #a21,// red, support function
-  //$h4: #930,// orange, punctuation, constant, variable, json-key
-  //$h5: #a50,// tan, entity/function name
-  //$h6: #350,// green, string
-  //$h7: #286,// teal, escape character
-  //$h8: #059,// blue, declaration, tag, property
-  //$h9: #a3c,// purple, operators
-  //$ha: 92%,// mark/highlight line
+  $h0: #F6F8FA,// background color
+  $h1: #0A0A0A,// unstyled text
+  $h2: #4A5568,// comments
+  $h3: #D32F2F,// red, support function
+  $h4: #F57C00,// orange, punctuation, constant, variable, json-key
+  $h5: #D5AD36,// tan, entity/function name
+  $h6: #2E7D32,// green, string
+  $h7: #1976D2,// teal, escape character
+  $h8: #003366,// blue, declaration, tag, property
+  $h9: #D5AD36,// purple, operators
+  $ha: 92%,// mark/highlight line
 
   /// These lines find the spot at which to insert your appended fonts.
   //$findFont-Main: "Segoe UI",     // ← APPEND custom MAIN font(s) AFTER this


### PR DESCRIPTION
## Summary
- bring back dark mode palette with new color sets for both modes
- enable JS theme switcher so users can choose light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e75fbaf488329b996fd88c6565795