### PR TITLE
Fix theme toggle icons

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -163,6 +163,10 @@ header > nav > div:nth-child(2) {
 /* Edit house icon on mobile nav here */
 .home-icon svg           { display: block; width: 28px; height: 28px; margin-top: 8px; }
 #mode                    { display: flex; align-items: center; margin-top: -0.25rem; }
+.mode-btn               { background: none; border: none; cursor: pointer; padding: 0; }
+.mode-btn svg           { width: 1.25rem; height: 1.25rem; }
+html.switch .moon-icon  { display: none; }
+html:not(.switch) .sun-icon { display: none; }
 .dropdown-content        { /* stays unchanged */ }
 
 /* Hide orphan anchors injected by the theme */

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -71,8 +71,8 @@
   //$icon-globe: false,
   //$icon-home: false,
   //$icon-minus: false,// minus symbol
-  //$icon-moon: false,// dark moon
-  //$icon-sun: false,// light sun
+  $icon-moon: true,// dark moon
+  $icon-sun: true,// light sun
 
   /// The colors below can be overrided individually as needed.
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,7 +74,16 @@
       </li>
 
       <!-- ALWAYS-ON sun / moon toggle -->
-      <li><button id="mode" class="mode-btn" type="button" aria-label="Toggle dark / light"></button></li>
+      <li>
+        <button id="mode" class="mode-btn" type="button" aria-label="Toggle dark / light">
+          <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.8 1.42-1.42Zm10.45 1.79 1.79-1.8-1.41-1.41-1.8 1.79 1.42 1.42ZM12 5a7 7 0 1 0 7 7 7 7 0 0 0-7-7Zm0 12a5 5 0 1 1 5-5 5 5 0 0 1-5 5Zm8-5h3v-2h-3v2Zm-19 0h3v-2H1v2Zm15.45 5.95 1.8 1.79 1.41-1.41-1.79-1.8-1.42 1.42ZM6.76 19.16l-1.42 1.42 1.8 1.79 1.41-1.41-1.79-1.8ZM13 21h-2v3h2v-3Z"/>
+          </svg>
+          <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2a9.93 9.93 0 0 0-7.06 2.94A10 10 0 1 0 21.06 9 8 8 0 0 1 12 2Z"/>
+          </svg>
+        </button>
+      </li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- enable icons for theme switcher in Sass configuration
- add toggle button SVGs in the base template
- style the mode button and hide the inactive icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec0bb500c8329bdd90ed0ebf5f88e