### PR TITLE
Fix schedule link and dark mode styles

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -203,4 +203,4 @@ We take a different approach focused on transparency and on-demand support. Unli
 Tired of paying for a month of IT service when nothing happened?
 Ready to make your tech problems disappear?  
 
-[Book an On-Site Visit Now](https://schedule.it-help.tech/)
+<p><a class="cta-button" href="https://schedule.it-help.tech/" target="_blank" rel="noopener noreferrer">Book an On-Site Visit Now</a></p>

--- a/content/services.md
+++ b/content/services.md
@@ -256,4 +256,4 @@ We believe in using best-in-class tools to achieve the best security and reliabi
 
 ---
 Need expert Mac IT help to solve your tech challenges?
-[Book an on-site Appointment Now](https://schedule.it-help.tech/)
+<p><a class="cta-button" href="https://schedule.it-help.tech/" target="_blank" rel="noopener noreferrer">Book an on-site Appointment Now</a></p>

--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -34,6 +34,14 @@
   color: #FFD700;
 }
 
+:root.switch .phone-line {
+  color: #001F3F;
+}
+
+:root.switch .homepage-hero > h1.hero {
+  color: #D5AD36;
+}
+
 /* Center the profile image on the About page */
 .post-image img {
   display: block;

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -256,9 +256,13 @@ details[open] summary::before {
 
 .schedule-link {
   background-color: #003366;
-  color: #FFD700;
+  color: #fff;
   padding: 0.25rem 0.75rem;
   border-radius: 0.25rem;
+}
+
+.schedule-link:hover {
+  color: var(--a2);
 }
 
 .nav-wrapper ul li a:hover {
@@ -269,4 +273,9 @@ details[open] summary::before {
 section h2 {
   border-left: 4px solid #003366;
   padding-left: 0.5rem;
+}
+
+/* footer phone color in dark mode */
+:root:not(.switch) .footer-nap a {
+  color: #FFD700;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,10 +66,6 @@
       <li>
         <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener" class="schedule-link">
           Schedule
-          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" class="align-super">
-            <path fill="currentColor" d="M14 4h6v6h-2V7.41L9.41 16 8 14.59 16.59 6H14V4Z"/>
-            <path fill="currentColor" d="M18 13v6H6V6h6V4H6a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h13a2 2 0 0 0 2-2v-7h-2Z"/>
-          </svg>
         </a>
       </li>
 


### PR DESCRIPTION
## Summary
- remove external link icon from nav schedule button
- tweak schedule button colors so hover remains gold
- ensure hero text and phone colors adjust per light/dark mode
- highlight footer phone and bottom call-to-action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed9109aec832992f5370db5446ee8