### PR TITLE
Fix schedule button visibility in light mode

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -261,6 +261,12 @@ details[open] summary::before {
   border-radius: 0.25rem;
 }
 
+@media (min-width: 700px) {
+  :root.switch .schedule-link {
+    color: #fff !important;
+  }
+}
+
 .schedule-link:hover {
   color: var(--a2);
 }


### PR DESCRIPTION
## Summary
- ensure Schedule link text is white on light-mode desktop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f0f9b08208329a132cd0267e1f2b4