### PR TITLE
Fix schedule button hover color

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -265,6 +265,9 @@ details[open] summary::before {
   :root.switch .schedule-link {
     color: #fff !important;
   }
+  :root.switch .schedule-link:hover {
+    color: var(--a2) !important;
+  }
 }
 
 .schedule-link:hover {


### PR DESCRIPTION
## Summary
- ensure the Schedule button shows yellow text on hover in light mode desktop

## Testing
- `npm test`
- `zola build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1271e0748329a9eb729bb84e5b7e