### PR TITLE
Fix 'More' nav hover color

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -279,6 +279,11 @@ details[open] summary::before {
   border-bottom: 2px solid #003366;
 }
 
+/* Change 'More' dropdown label to gold on hover */
+.dropdown-toggle:hover {
+  color: var(--a2);
+}
+
 section h2 {
   border-left: 4px solid #003366;
   padding-left: 0.5rem;


### PR DESCRIPTION
## Summary
- turn 'More' dropdown label gold on hover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f159dac44832995e3c68dde21eafd