### PR TITLE
Fix mobile home icon size

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -161,7 +161,7 @@ header > nav > div:nth-child(2) {
 .nav-wrapper ul li a     { display: flex; align-items: center; }
 .dropdown-toggle         { display: flex; align-items: center; gap: 0.25rem; cursor: pointer; }
 /* Edit house icon on mobile nav here */
-.home-icon svg           { display: block; width: 28px; height: 28px; margin-top: 8px; }
+.home-icon svg           { display: block; width: 30px; height: 30px; margin-top: 0; }
 #mode                    { display: flex; align-items: center; margin-top: -0.25rem; }
 .dropdown-content        { /* stays unchanged */ }
 


### PR DESCRIPTION
## Summary
- enlarge the mobile house icon so it matches the theme toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1841f2e88329a68b1732853db84f