### PR TITLE
Fix home icon sizing on mobile

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -161,7 +161,7 @@ header > nav > div:nth-child(2) {
 .nav-wrapper ul li a     { display: flex; align-items: center; }
 .dropdown-toggle         { display: flex; align-items: center; gap: 0.25rem; cursor: pointer; }
 /* Edit house icon on mobile nav here */
-.home-icon svg           { display: block; width: 30px; height: 30px; margin-top: 0; }
+.home-icon svg           { display: block; width: 35px; height: 35px; margin-top: 0; }
 #mode                    { display: flex; align-items: center; margin-top: -0.25rem; }
 .dropdown-content        { /* stays unchanged */ }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
       <!-- home icon -->
       <li>
         <a href="{{ get_url(path='/') }}" aria-label="Home" class="home-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
             <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
           </svg>
         </a>


### PR DESCRIPTION
## Summary
- bump up home icon dimensions in custom SCSS
- let CSS control `<svg>` size by removing width/height attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1ea799a88329b228796e48c15e02