### PR TITLE
Fix home icon size on mobile

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -160,7 +160,7 @@ header > nav > div:nth-child(2) {
 .nav-wrapper ul li       { position: relative; display: flex; align-items: center; }
 .nav-wrapper ul li a     { display: flex; align-items: center; }
 .dropdown-toggle         { display: flex; align-items: center; gap: 0.25rem; cursor: pointer; }
-/* Edit house icon on mobile nav here */
+/* Edit home icon on mobile nav here */
 .home-icon svg           { display: block; width: 35px; height: 35px; margin-top: 0; }
 #mode                    { display: flex; align-items: center; margin-top: -0.25rem; }
 .dropdown-content        { /* stays unchanged */ }

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -157,8 +157,8 @@ body { overflow-x: hidden; }
     margin-top: 0 !important;
   }
   .nav-wrapper .home-icon svg{
-    width: 30px !important;
-    height: 30px !important;
+    width: 35px !important;
+    height: 35px !important;
     margin-top: 0px !important;
   }
 }


### PR DESCRIPTION
## Summary
- unify naming from "house icon" to "home icon"
- make the home icon bigger on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f218c28b48329877bc10a00165304