### PR TITLE
Fix hero heading layout

### DIFF
--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -14,8 +14,6 @@
 .homepage-hero > .phone-line,
 .homepage-hero > p:has(.cta-button) { /* This targets the <p> containing the button */
   text-align: center;
-  /* Reserve space to stop layout shift */
-  min-height: calc(2 * 1em * 1.2);
   margin-left: auto;
   margin-right: auto;
 }

--- a/static/css/cls-fixes.css
+++ b/static/css/cls-fixes.css
@@ -1,3 +1,3 @@
 /* --- stop layout shift --- */
 img.logo{width:356px;height:48px;max-width:none !important}
-h1.hero{font-size:clamp(1.6rem,2.5vw,2.25rem);max-width:40rem;min-height:calc(2*1em*1.2)}
+h1.hero{font-size:clamp(1.6rem,2.5vw,2.25rem);max-width:40rem}


### PR DESCRIPTION
## Summary
- remove height reservation from hero heading
- keep compiled layout fix stylesheet in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f77932b4883298a8c0e9b41cdf631