### PR TITLE
Fix hero min-height spacing

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -33,7 +33,9 @@ h1, h2, h3, h4,
   text-wrap: balance;
 }
 .hero {
-  min-height: clamp(300px, 35vh, 480px);
+  /* Remove large minimum height so the hero heading only takes
+     up the space it needs without leaving a huge blank area. */
+  min-height: auto;
 }
 
 

--- a/static/css/cls-fixes.css
+++ b/static/css/cls-fixes.css
@@ -1,3 +1,3 @@
 /* --- stop layout shift --- */
 img.logo{width:356px;height:48px;max-width:none !important}
-h1.hero{font-size:clamp(1.6rem,2.5vw,2.25rem);max-width:40rem}
+h1.hero{font-size:clamp(1.6rem,2.5vw,2.25rem);max-width:40rem;min-height:auto}


### PR DESCRIPTION
## Summary
- remove large min-height from hero heading
- set `min-height:auto` for hero in compiled CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f7b5464e483298635b8e9e3bce3bc