### PR TITLE
Fix schedule hover in dark mode

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -340,6 +340,9 @@ details[open] summary::before {
   :root.switch .schedule-link:hover {
     color: var(--a2) !important;
   }
+  :root:not(.switch) .schedule-link:hover {
+    color: var(--a2) !important;
+  }
 }
 
 .schedule-link:hover {


### PR DESCRIPTION
## Summary
- ensure the Schedule nav item turns gold when hovering in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f8e036cac8329ac3829b92d5d0094