### PR TITLE
Fix phone link color in dark mode

### DIFF
--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -26,16 +26,19 @@
 }
 
 /* ensure phone number line has breathing room */
+/* Style phone links consistently */
 .phone-line {
   margin: 0.5rem 0 1rem;
-  color: #FFD700;
 }
 
-:root.switch .phone-line {
-  color: #FFD700;
+/* Blue for light mode, gold for dark mode */
+:root.switch .phone-line,
+html.switch .phone-line {
+  color: #0074D9 !important;
 }
 
-:root:not(.switch) .phone-line {
+:root:not(.switch) .phone-line,
+html:not(.switch) .phone-line {
   color: #FFD700 !important;
 }
 

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -23,7 +23,7 @@ body { overflow-x: hidden; }
     background: #fff !important;
   }
 }
-.homepage-hero .phone-line,
+.phone-line,
 .homepage-hero .cta-button{
   text-align:center !important;
   margin-inline:auto !important;
@@ -32,8 +32,13 @@ body { overflow-x: hidden; }
   word-break:break-word !important;
 }
 
-/* Ensure the phone number is gold in dark mode */
-:root:not(.switch) .homepage-hero .phone-line{
+/* Phone number color by mode */
+:root.switch .phone-line,
+html.switch .phone-line{
+  color:#0074D9 !important;
+}
+:root:not(.switch) .phone-line,
+html:not(.switch) .phone-line{
   color:#FFD700 !important;
 }
 .homepage-hero h1 {

--- a/static/css/override.min.css
+++ b/static/css/override.min.css
@@ -3,4 +3,4 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 @media (min-width:700px){.page-title,.post-title,h1.page-title,h1.post-title{text-align:center!important;margin-left:auto!important;margin-right:auto!important;width:100%!important;max-width:100%!important;overflow-wrap:break-word!important;word-break:break-word!important}}
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
-:root:not(.switch) .homepage-hero .phone-line{color:#FFD700!important}
+:root.switch .phone-line,html.switch .phone-line{color:#0074D9!important}:root:not(.switch) .phone-line,html:not(.switch) .phone-line{color:#FFD700!important}


### PR DESCRIPTION
## Summary
- update `.phone-line` styles so light mode remains blue
- set dark mode phone line color to gold

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fe2c343688329af258672e49fe88e