### PR TITLE
Fix phone link color override

### DIFF
--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -31,16 +31,6 @@
   margin: 0.5rem 0 1rem;
 }
 
-/* Blue for light mode, gold for dark mode */
-:root.switch .phone-line,
-html.switch .phone-line {
-  color: #0074D9 !important;
-}
-
-:root:not(.switch) .phone-line,
-html:not(.switch) .phone-line {
-  color: #FFD700 !important;
-}
 
 :root.switch .homepage-hero > h1.hero {
   color: #D5AD36;
@@ -55,4 +45,14 @@ html:not(.switch) .phone-line {
 /* Portrait images for expertise section */
 .expertise-portrait {
   max-width: 220px;
+}
+
+/* Phone number color by mode - ensure final override */
+html.switch .phone-line,
+:root.switch .phone-line {
+  color: #0074D9 !important;
+}
+html:not(.switch) .phone-line,
+:root:not(.switch) .phone-line {
+  color: #FFD700 !important;
 }

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -32,15 +32,6 @@ body { overflow-x: hidden; }
   word-break:break-word !important;
 }
 
-/* Phone number color by mode */
-:root.switch .phone-line,
-html.switch .phone-line{
-  color:#0074D9 !important;
-}
-:root:not(.switch) .phone-line,
-html:not(.switch) .phone-line{
-  color:#FFD700 !important;
-}
 .homepage-hero h1 {
   max-width: 100% !important;
   overflow-wrap: break-word !important;
@@ -365,3 +356,13 @@ header.site-header{
   }
 }
 
+
+/* Ensure phone link color overrides */
+html.switch .phone-line,
+:root.switch .phone-line {
+  color: #0074D9 !important;
+}
+html:not(.switch) .phone-line,
+:root:not(.switch) .phone-line {
+  color: #FFD700 !important;
+}


### PR DESCRIPTION
## Summary
- ensure phone line colors override previous styles
- keep same rules in Sass so compiled CSS matches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe655f4fc832988cc651d682277c1