### PR TITLE
Fix dark mode phone color

### DIFF
--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -29,7 +29,7 @@
 /* Style phone links consistently */
 .phone-line {
   margin: 0.5rem 0 1rem;
-  // NO color property here!
+  color: var(--phone-line-color);
 }
 
 
@@ -48,12 +48,10 @@
   max-width: 220px;
 }
 
-/* Phone number color by mode - ensure final override */
-html.switch .phone-line,
-:root.switch .phone-line {
-  color: #0074D9 !important;
+/* Phone number color variables */
+:root.switch {
+  --phone-line-color: #0074D9;
 }
-html:not(.switch) .phone-line,
-:root:not(.switch) .phone-line {
-  color: #FFD700 !important;
+:root:not(.switch) {
+  --phone-line-color: #FFD700;
 }

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -31,6 +31,9 @@ body { overflow-x: hidden; }
   overflow-wrap:break-word !important;
   word-break:break-word !important;
 }
+.phone-line {
+  color: var(--phone-line-color) !important;
+}
 
 .homepage-hero h1 {
   max-width: 100% !important;
@@ -356,12 +359,10 @@ header.site-header{
   }
 }
 
-/* Phone number color by mode - ensure final override */
-html.switch .phone-line,
-:root.switch .phone-line {
-  color: #0074D9 !important;
+/* Phone number color variables */
+:root.switch {
+  --phone-line-color: #0074D9;
 }
-html:not(.switch) .phone-line,
-:root:not(.switch) .phone-line {
-  color: #FFD700 !important;
+:root:not(.switch) {
+  --phone-line-color: #FFD700;
 }

--- a/static/css/override.min.css
+++ b/static/css/override.min.css
@@ -3,4 +3,4 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 @media (min-width:700px){.page-title,.post-title,h1.page-title,h1.post-title{text-align:center!important;margin-left:auto!important;margin-right:auto!important;width:100%!important;max-width:100%!important;overflow-wrap:break-word!important;word-break:break-word!important}}
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
-html.switch .phone-line,:root.switch .phone-line{color:#0074D9!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:#FFD700!important}
+:root.switch{--phone-line-color:#0074D9}:root:not(.switch){--phone-line-color:#FFD700}.phone-line{color:var(--phone-line-color)!important}


### PR DESCRIPTION
## Summary
- set `--phone-line-color` variable for light/dark modes
- apply phone color with CSS variable in override styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff642bad883298efcc99d62e4cfe9