### PR TITLE
Fix phone link color on iOS

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -113,6 +113,7 @@
 
 {# --- Meta tags --- #}
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="format-detection" content="telephone=no">
 
 {# --- Security headers --- #}
 {%- if config.extra.security_header_referrer %}


### PR DESCRIPTION
## Summary
- disable automatic telephone detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860051ed73c832992ac45266f36aab3