### PR TITLE
Fix dark mode link colors on homepage

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -365,3 +365,11 @@ html:not(.switch) .phone-line,
 :root:not(.switch) .phone-line {
   color: #FFD700 !important;
 }
+
+/* Home page service links: dark mode */
+html:not(.switch) .homepage-hero h3 > a {
+  color: #fff !important;
+}
+html:not(.switch) .homepage-hero h3 > a:hover {
+  color: #FFD700 !important;
+}

--- a/static/css/override.min.css
+++ b/static/css/override.min.css
@@ -4,3 +4,4 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
 :html.switch .phone-line,:root.switch .phone-line{color:#0074D9!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:#FFD700!important}
+html:not(.switch) .homepage-hero h3>a{color:#fff!important}html:not(.switch) .homepage-hero h3>a:hover{color:#FFD700!important}


### PR DESCRIPTION
## Summary
- ensure dark mode service links match header style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686099ce2c4c8329a465d8715989b8d6