### PR TITLE
Fix dark mode service link colors

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -367,9 +367,9 @@ html:not(.switch) .phone-line,
 }
 
 /* Home page service links: dark mode */
-html:not(.switch) .homepage-hero h3 > a {
+html:not(.switch) .homepage-hero h3 a {
   color: #fff !important;
 }
-html:not(.switch) .homepage-hero h3 > a:hover {
+html:not(.switch) .homepage-hero h3 a:hover {
   color: #FFD700 !important;
 }

--- a/static/css/override.min.css
+++ b/static/css/override.min.css
@@ -4,4 +4,4 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
 :html.switch .phone-line,:root.switch .phone-line{color:#0074D9!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:#FFD700!important}
-html:not(.switch) .homepage-hero h3>a{color:#fff!important}html:not(.switch) .homepage-hero h3>a:hover{color:#FFD700!important}
+html:not(.switch) .homepage-hero h3 a{color:#fff!important}html:not(.switch) .homepage-hero h3 a:hover{color:#FFD700!important}


### PR DESCRIPTION
## Summary
- adjust CSS selector for home service links so anchors are white in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68609efb6a548329bf70ec95be2bbb55