### PR TITLE
Fix dark mode header links

### DIFF
--- a/static/css/override.css
+++ b/static/css/override.css
@@ -367,9 +367,12 @@ html:not(.switch) .phone-line,
 }
 
 /* Home page service links: dark mode */
-html:not(.switch) .homepage-hero h3 a {
+html:not(.switch) h3 a,
+html:not(.switch) h3 a:visited {
   color: #fff !important;
 }
-html:not(.switch) .homepage-hero h3 a:hover {
+html:not(.switch) h3 a:hover,
+html:not(.switch) h3 a:active,
+html:not(.switch) h3 a:focus {
   color: #FFD700 !important;
 }

--- a/static/css/override.min.css
+++ b/static/css/override.min.css
@@ -4,4 +4,4 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
 :html.switch .phone-line,:root.switch .phone-line{color:#0074D9!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:#FFD700!important}
-html:not(.switch) .homepage-hero h3 a{color:#fff!important}html:not(.switch) .homepage-hero h3 a:hover{color:#FFD700!important}
+html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:not(.switch) h3 a:hover,html:not(.switch) h3 a:active,html:not(.switch) h3 a:focus{color:#FFD700!important}


### PR DESCRIPTION
## Summary
- ensure `Core Expertise` header links are white with gold hover in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860a16f7ac88329a7c78b70b878f3f1