### PR TITLE
Use new light logo in light mode

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -142,6 +142,11 @@ header > nav > div:nth-child(2) {
   border-radius: 0 !important;
 }
 
+/* Swap logos based on light/dark mode */
+.logo-light { display: none; }
+html.switch .logo-dark { display: none; }
+html.switch .logo-light { display: block; }
+
 /* Footer owl graphic */
 .owl {
   width: 100px;

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -376,3 +376,8 @@ html:not(.switch) h3 a:active,
 html:not(.switch) h3 a:focus {
   color: #FFD700 !important;
 }
+
+/* Logo swap for light mode */
+.logo-light{display:none}
+html.switch .logo-dark{display:none}
+html.switch .logo-light{display:block}

--- a/static/css/override.min.css
+++ b/static/css/override.min.css
@@ -4,4 +4,4 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
 :html.switch .phone-line,:root.switch .phone-line{color:#0074D9!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:#FFD700!important}
-html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:not(.switch) h3 a:hover,html:not(.switch) h3 a:active,html:not(.switch) h3 a:focus{color:#FFD700!important}
+html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:not(.switch) h3 a:hover,html:not(.switch) h3 a:active,html:not(.switch) h3 a:focus{color:#FFD700!important}.logo-light{display:none}html.switch .logo-dark{display:none}html.switch .logo-light{display:block}

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,12 +28,16 @@
 <header class="site-header" role="banner">
   <div class="site-logo">
     {%- if config.extra.logo.file %}
-      <a href="{{ get_url(path='/') }}">
-        <img src="{{ get_url(path='logo.svg') }}"
-             width="356" height="48"
-             alt="IT Help San Diego"
-             class="logo" decoding="async">
-      </a>
+        <a href="{{ get_url(path='/') }}" class="logo-link">
+          <img src="{{ get_url(path='logo.svg') }}"
+               width="356" height="48"
+               alt="IT Help San Diego"
+               class="logo logo-dark" decoding="async">
+          <img src="{{ get_url(path='logo-light.svg') }}"
+               width="356" height="48"
+               alt="IT Help San Diego"
+               class="logo logo-light" decoding="async">
+        </a>
     {%- endif %}
   </div>
 


### PR DESCRIPTION
## Summary
- show separate logo for light mode
- add theme-based logo swap CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860b41cf6548329b0ce279a071c1066