### PR TITLE
Center hero & revive particles

### DIFF
--- a/static/css/hero-logo.css
+++ b/static/css/hero-logo.css
@@ -18,7 +18,6 @@
     padding: 60px;
     cursor: pointer;
     transition: transform 0.3s ease;
-    margin-top: 0;
     width: 100%;
     max-width: 560px;              /* matches original */
     margin: 0 auto;

--- a/static/css/hero-logo.css
+++ b/static/css/hero-logo.css
@@ -20,14 +20,17 @@
     transition: transform 0.3s ease;
     margin-top: 0;
     width: 100%;
+    max-width: 560px;              /* matches original */
+    margin: 0 auto;
 }
 
 /* ───────── LAYOUT / RESTORE DEMO LOOK ───────── */
 .hero-wrapper{
-  background:#0a0a0a;          /* same as demo */
-  text-align:center;
-  padding:80px 0 64px;
-  overflow:visible;            /* let bubbles float */
+  background:#0a0a0a;           /* demo backdrop */
+  display:flex;flex-direction:column;
+  align-items:center;
+  padding:96px 0 72px;
+  overflow:visible;             /* let bubbles float */
 }
 
 /* coloured spinning disc */
@@ -210,6 +213,7 @@
 
 .tagline-text {
     display: inline-block; /* pill snaps to content width */
+    white-space: nowrap;           /* pill never wraps */
     padding: 10px 20px;
     border: 2px solid transparent;
     background: linear-gradient(#0a0a0a, #0a0a0a) padding-box,
@@ -330,5 +334,12 @@
     .main-logo {
         letter-spacing: -0.03em;
     }
+}
+
+/* ↓ responsive font-sizes stop word-wrap on mobile */
+@media(max-width:640px){
+  .main-logo   {font-size:12vw;}
+  .location    {font-size:6vw;}
+  .tagline     {font-size:4.2vw;}
 }
 

--- a/static/js/hero-logo.js
+++ b/static/js/hero-logo.js
@@ -1,38 +1,24 @@
-// Particle animation - Math.random() is safe here as it's only for visual effects
-const particlesContainer = document.querySelector('.tech-particles');
+document.addEventListener('DOMContentLoaded', () => {
+  const particlesContainer = document.querySelector('.tech-particles');
 
-function createParticle() {
-    const particle = document.createElement('div');
-    particle.className = 'particle';
-    // Safe usage: visual-only positioning, no security implications
-    particle.style.left = Math.random() * 100 + '%';
-    particle.style.animationDelay = Math.random() * 4 + 's';
-    particle.style.animationDuration = (3 + Math.random() * 2) + 's';
-    particlesContainer.appendChild(particle);
-    
-    setTimeout(() => {
-        particle.remove();
-    }, 5000);
-}
+  function createParticle(){
+    const p=document.createElement('div');
+    p.className='particle';
+    p.style.left=Math.random()*100+'%';
+    p.style.animationDelay=Math.random()*4+'s';
+    p.style.animationDuration=3+Math.random()*2+'s';
+    particlesContainer.appendChild(p);
+    setTimeout(()=>p.remove(),5000);
+  }
+  setInterval(createParticle,600);
 
-// Create particles at optimized intervals
-setInterval(createParticle, 600);
-
-// Interactive hover effect
-const logoContainer = document.querySelector('.logo-container');
-
-logoContainer.addEventListener('mousemove', (e) => {
-    const rect = logoContainer.getBoundingClientRect();
-    const x = (e.clientX - rect.left) / rect.width - 0.5;
-    const y = (e.clientY - rect.top) / rect.height - 0.5;
-    
-    logoContainer.style.transform = `
-        perspective(1000px)
-        rotateY(${x * 10}deg)
-        rotateX(${-y * 10}deg)
-    `;
-});
-
-logoContainer.addEventListener('mouseleave', () => {
-    logoContainer.style.transform = 'perspective(1000px) rotateY(0) rotateX(0)';
+  /* hover-tilt */
+  const logo=document.querySelector('.logo-container');
+  logo.addEventListener('mousemove',e=>{
+    const r=logo.getBoundingClientRect();
+    const x=(e.clientX-r.left)/r.width-.5;
+    const y=(e.clientY-r.top )/r.height-.5;
+    logo.style.transform=`perspective(1000px) rotateY(${x*10}deg) rotateX(${-y*10}deg)`;
+  });
+  logo.addEventListener('mouseleave',()=>logo.style.transform='perspective(1000px)');
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,9 +28,9 @@
 
   {# ---------- HERO LOGO (no inline CSS/JS) ---------- #}
 
-  <div class="hero-wrapper">
+  <section class="hero-wrapper">
     {% include "partials/hero_logo.html" %}
-  </div>
+  </section>
 
   {# defer → non-blocking; keeps Lighthouse happy #}
   <script src="{{ get_url(path=`/js/hero-logo.js`) }}" defer></script>


### PR DESCRIPTION
## Summary
- use `<section>` wrapper for hero content
- center hero layout with flexbox
- keep tagline pill on one line and add responsive font sizes
- revive particle animation by running JS after DOM ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863424dc1088329bd5944f01b0ff497