### PR TITLE
Reduce gap between tagline and nav

### DIFF
--- a/static/css/hero-logo.css
+++ b/static/css/hero-logo.css
@@ -30,7 +30,7 @@
   background:inherit;
   display:flex;flex-direction:column;
   align-items:center;
-  padding:0 0 24px;            /* flush to top on desktop */
+  padding:0 0 12px;            /* tighter bottom spacing */
   overflow:visible;             /* let bubbles float */
 }
 
@@ -363,7 +363,7 @@ html:not(.switch) .tagline-text{
 
 /* ↓ responsive font-sizes stop word-wrap on mobile */
 @media(max-width:640px){
-  .hero-wrapper{padding:0 0 12px;}      /* flush to top, tighter bottom */
+  .hero-wrapper{padding:0 0 6px;}       /* flush to top, even tighter bottom */
 
   /* bigger, bolder */
   .main-logo {font-size:20vw;}


### PR DESCRIPTION
## Summary
- tighten hero wrapper padding to decrease vertical space between the tagline pill and the navigation bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68635cce160483298237e9e7588a82f6