### PR TITLE
Reduce gap between hero logo and navbar

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -112,7 +112,7 @@ header > nav > div:nth-child(2) {
 
 .site-header {
   min-height: 65px;
-  padding-top: 0.25rem !important;
+  padding-top: 0 !important;      /* tighter gap below logo */
   margin: 0 0 0.25rem 0 !important;
   position: relative !important;
   display: flex !important;

--- a/static/css/hero-logo.css
+++ b/static/css/hero-logo.css
@@ -15,7 +15,7 @@
 
 .logo-container {
     position: relative;
-    padding: 20px;              /* tightens block on all viewports */
+    padding: 20px 20px 4px;     /* less bottom space below tagline */
     cursor: pointer;
     transition: transform 0.3s ease;
     width: 100%;

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -69,6 +69,7 @@ body { overflow-x: hidden; }
     width:350px !important;
     margin:0 auto !important;
     max-width:none !important;
+    padding-top:0 !important;
   }
 }
 @media (max-width:699px){
@@ -227,6 +228,7 @@ main {
   }
   header.site-header{
     width: 348px !important;
+    padding-top:0 !important;
   }
   .nav-wrapper .home-icon{
     width: 35px;
@@ -330,6 +332,7 @@ article > h1 {
 
 header.site-header{
   min-height:65px;
+  padding-top:0;
 }
 .owl{
   width:100px;


### PR DESCRIPTION
## Summary
- tighten hero logo padding so it sits closer to the navbar
- remove top padding from `.site-header`
- keep compiled CSS in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68636182a7c48329a5dddf68263aa1ab