### PR TITLE
feat: update Lighthouse performance thresholds

### DIFF
--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -75,16 +75,16 @@ jobs:
             echo "" >> lighthouse-summary.md
           fi
 
-          # Add performance thresholds information
+          # Add performance thresholds information (updated to match .lighthouserc.js)
           echo "**Performance Requirements:**" >> lighthouse-summary.md
-          echo "- **Performance**: ≥90" >> lighthouse-summary.md
-          echo "- **Accessibility**: ≥90" >> lighthouse-summary.md
-          echo "- **Best Practices**: ≥95" >> lighthouse-summary.md
-          echo "- **SEO**: ≥95" >> lighthouse-summary.md
-          echo "- **LCP**: <2.5s" >> lighthouse-summary.md
-          echo "- **FCP**: <1.2s" >> lighthouse-summary.md
-          echo "- **CLS**: <0.1" >> lighthouse-summary.md
-          echo "- **TBT**: <300ms" >> lighthouse-summary.md
+          echo "- **Performance**: ≥90 (blocks PR)" >> lighthouse-summary.md
+          echo "- **LCP**: <2.5s (blocks PR)" >> lighthouse-summary.md
+          echo "- **FCP**: <1.2s (blocks PR)" >> lighthouse-summary.md
+          echo "- **CLS**: <0.1 (blocks PR)" >> lighthouse-summary.md
+          echo "- **Accessibility**: ≥95 (warning)" >> lighthouse-summary.md
+          echo "- **Best Practices**: ≥95 (warning)" >> lighthouse-summary.md
+          echo "- **SEO**: ≥95 (warning)" >> lighthouse-summary.md
+          echo "- **TBT**: <300ms (warning)" >> lighthouse-summary.md
           echo "" >> lighthouse-summary.md
 
           # Add lighthouse reports links if available

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -18,22 +18,24 @@ module.exports = {
       // Balanced performance budgets - critical issues block PRs, others warn
       assertions: {
         // CRITICAL (block PR) - Core performance that affects user experience
-        'categories:performance': ['error', {minScore: 0.85}],   // 85+ performance (more realistic)
-        'largest-contentful-paint': ['error', {maxNumericValue: 3000}], // LCP < 3s (Google's "Good" threshold)
-        'cumulative-layout-shift': ['error', {maxNumericValue: 0.2}],   // CLS < 0.2 (reasonable stability)
-        
+        'categories:performance': ['error', {minScore: 0.90}],   // 90+ performance (raised from 85)
+        'largest-contentful-paint': ['error', {maxNumericValue: 2500}], // LCP < 2.5s (stricter than Google's 3s)
+        'cumulative-layout-shift': ['error', {maxNumericValue: 0.1}],   // CLS < 0.1 (tighter stability)
+        'first-contentful-paint': ['error', {maxNumericValue: 1200}],   // FCP < 1.2s (critical render timing)
+
         // IMPORTANT (warn only) - Issues to track but don't block development
-        'categories:best-practices': ['warn', {minScore: 0.90}], // 90+ best practices
-        'categories:seo': ['warn', {minScore: 0.90}],            // 90+ SEO
-        'first-contentful-paint': ['warn', {maxNumericValue: 1500}],    // FCP < 1.5s
-        'total-blocking-time': ['warn', {maxNumericValue: 400}],        // TBT < 400ms
-        
-        // RESOURCE BUDGETS (warn only) - Monitor but don't block
-        'resource-summary:document:size': ['warn', {maxNumericValue: 75000}],   // HTML < 75KB
-        'resource-summary:stylesheet:size': ['warn', {maxNumericValue: 50000}], // CSS < 50KB
-        'resource-summary:script:size': ['warn', {maxNumericValue: 15000}],     // JS < 15KB
-        'resource-summary:stylesheet:count': ['warn', {maxNumericValue: 10}],
-        'resource-summary:script:count': ['warn', {maxNumericValue: 8}],
+        'categories:accessibility': ['warn', {minScore: 0.95}],  // 95+ accessibility (new addition)
+        'categories:best-practices': ['warn', {minScore: 0.95}], // 95+ best practices (raised from 90)
+        'categories:seo': ['warn', {minScore: 0.95}],            // 95+ SEO (raised from 90)
+        'total-blocking-time': ['warn', {maxNumericValue: 300}],        // TBT < 300ms (stricter)
+
+        // RESOURCE BUDGETS (stricter enforcement) - Monitor resource efficiency
+        'resource-summary:document:size': ['warn', {maxNumericValue: 60000}],   // HTML < 60KB (tighter)
+        'resource-summary:stylesheet:size': ['warn', {maxNumericValue: 40000}], // CSS < 40KB (reduced from 50KB)
+        'resource-summary:script:size': ['warn', {maxNumericValue: 12000}],     // JS < 12KB (reduced from 15KB)
+        'resource-summary:stylesheet:count': ['warn', {maxNumericValue: 8}],    // Max 8 CSS files (reduced from 10)
+        'resource-summary:script:count': ['warn', {maxNumericValue: 6}],        // Max 6 JS files (reduced from 8)
+        'resource-summary:image:size': ['warn', {maxNumericValue: 200000}],     // Images < 200KB (new budget)
       },
     },
     upload: {


### PR DESCRIPTION
Performance Thresholds Raised (doing it incrementally)

- Performance: 85% → 90% (blocks PR)
- LCP: 3000ms → 2500ms (blocks PR)
- CLS: 0.2 → 0.1 (blocks PR)
- FCP: 1500ms → 1200ms (new critical threshold)
- Accessibility: 90% → 95% (warning)
- Best Practices: 90% → 95% (warning)
- SEO: 90% → 95% (warning)

Current metrics:
- Performance: 100%
- LCP: 677ms (well under 2500ms limit)
- FCP: 537ms (well under 1200ms limit)
- CLS: 0.0 (perfect stability)

Based on the current metrics, we can raise the threshold even further, and I will do so next.