### PR TITLE
fix: zola absolute urls

### DIFF
--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           tool: zola
 
-      - name: Build site with Zola
+      - name: Build site with Zola (localhost URLs for CSP compliance)
         run: |
-          zola build
+          zola build --base-url "http://localhost:8080"
           if [ ! -d "public" ]; then
             echo "❌ Build failed - public directory not created"
             exit 1

--- a/scripts/validate-lighthouse.sh
+++ b/scripts/validate-lighthouse.sh
@@ -45,9 +45,9 @@ fi
 echo -e "${YELLOW}🧹 Cleaning previous build...${NC}"
 rm -rf public/
 
-# Build site
-echo -e "${YELLOW}🏗️  Building site with Zola...${NC}"
-if ! zola build; then
+# Build site with localhost base URL for proper CSP compliance
+echo -e "${YELLOW}🏗️  Building site with Zola (localhost URLs for testing)...${NC}"
+if ! zola build --base-url "http://localhost:8080"; then
     echo -e "${RED}❌ Zola build failed${NC}"
     exit 1
 fi


### PR DESCRIPTION
I needed to update the base URL because Zola is generating absolute production URLs (https://www.it-help.tech/) during testing, which the CSP correctly blocks as cross-origin requests, preventing me from collecting scores locally. 