### PR TITLE
Shift IT+HELP blue palette toward indigo (token-only)

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -70,3 +70,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Applied a small follow-up reduction (about 8-10% from the previous tuned state) to IT/HELP edge and sheen alpha values while preserving thickness/geometry for readability.
 - Why: Keep dimensional clarity for older eyes while reducing remaining visual shine/noise.
 - Rollback: this branch/PR (`codex/ithelp-logo-edge-micro-tune`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: Indigo blue token shift (no glow/glass pivot)
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/_extra.scss`
+  - `sass/css/abridge.scss`
+  - `STYLE_GUIDE.md`
+- Change: Shifted primary blue/link tokens from cyan-leaning web blue to a deeper indigo-leaning blue system for higher perceived depth and modernity, without adding glow effects or changing logo geometry.
+- Why: Reduce "legacy/web-default blue" feel while preserving trust posture and readability.
+- Rollback: this branch/PR (`codex/ithelp-indigo-blue-shift`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,7 +4,7 @@ Last updated: 2026-02-07
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (logo + navigation CTA): `#2B6FC8`  
+- Primary Blue (logo + navigation CTA): `#3A56D8`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
@@ -17,6 +17,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 
 ## Usage Rules
 - Use Primary Blue for links, logo text, and navigation CTA (Schedule).
+- Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - Use Gold in controlled doses: CTA button style and restrained logo trim only.
 - Red is reserved for the plus sign.
 - Avoid introducing new colors without updating this guide.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #2B6FC8;
-  --brand-primary-rgb: 43, 111, 200;
-  --brand-primary-glow: 126, 181, 242;
+  --brand-primary: #3A56D8;
+  --brand-primary-rgb: 58, 86, 216;
+  --brand-primary-glow: 142, 162, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;
@@ -11,12 +11,12 @@
 }
 
 :root:not(.switch) {
-  --a1-rgb: 105, 170, 255;
+  --a1-rgb: 137, 160, 255;
   --surface-rgb: 23, 23, 23;
 }
 
 :root.switch {
-  --a1-rgb: 15, 78, 138;
+  --a1-rgb: 47, 71, 168;
   --surface-rgb: 245, 245, 247;
 }
 

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #69AAFF,// link color
-  $a2d: #8BC3FF,// link hover/focus color
-  $a3d: #8BC3FF,// link h1-h2 hover/focus color
-  $a4d: #78B4FF,// link visited color
+  $a1d: #89A0FF,// link color
+  $a2d: #A5B4FF,// link hover/focus color
+  $a3d: #A5B4FF,// link h1-h2 hover/focus color
+  $a4d: #95AAFF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #0F4E8A,// link color
-  $a2: #1F6BB8,// link hover/focus color
-  $a3: #1F6BB8,// link h1-h2 hover/focus color
-  $a4: #0F4E8A,// link visited color
+  $a1: #2F47A8,// link color
+  $a2: #3A56D8,// link hover/focus color
+  $a3: #3A56D8,// link h1-h2 hover/focus color
+  $a4: #2F47A8,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,9 +20,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #2B6FC8;
-    --brand-blue-rgb: 43, 111, 200;
-    --brand-blue-glow: 126, 181, 242;
+    --brand-blue: #3A56D8;
+    --brand-blue-rgb: 58, 86, 216;
+    --brand-blue-glow: 142, 162, 255;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
     --accent-gold-glow: 224, 197, 138;


### PR DESCRIPTION
## Summary
- shift primary blue and link tokens from cyan-leaning web blue to indigo-leaning blue
- keep logo geometry, edge thickness, plus sign, and CTA structure unchanged
- no glow/glass effects added

## Files
- static/css/late-overrides.css
- sass/_extra.scss
- sass/css/abridge.scss
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

## Why
Reduce the legacy/default-blue feel while preserving trust posture, readability, and system discipline.

## Validation
- zola build