### PR TITLE
Deepen IT+HELP logo blue depth and Schedule CTA tone

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -82,3 +82,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Shifted primary blue/link tokens from cyan-leaning web blue to a deeper indigo-leaning blue system for higher perceived depth and modernity, without adding glow effects or changing logo geometry.
 - Why: Reduce "legacy/web-default blue" feel while preserving trust posture and readability.
 - Rollback: this branch/PR (`codex/ithelp-indigo-blue-shift`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: IT/HELP and Schedule blue depth pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Kept the existing primary blue token but introduced a tonal indigo ramp on the IT/HELP letter fill and Schedule button, added subtle dimensional button treatment, and replaced cyan-leaning micro highlights with indigo-leaning highlights.
+- Why: Remove remaining flat/"Windows 95" blue impression while preserving accessibility, performance, and calm authority.
+- Rollback: this branch/PR (`codex/ithelp-blue-depth-pass`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -9,6 +9,10 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
+- Indigo Depth Ramp (logo fill + Schedule button):
+  - Top: `#4A66E6` (`--brand-blue-top`)
+  - Base: `#3A56D8` (`--brand-blue`)
+  - Bottom: `#2B44B4` (`--brand-blue-bottom`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -18,6 +22,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 ## Usage Rules
 - Use Primary Blue for links, logo text, and navigation CTA (Schedule).
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
+- High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the 3-step indigo ramp for depth, not a flat fill.
 - Use Gold in controlled doses: CTA button style and restrained logo trim only.
 - Red is reserved for the plus sign.
 - Avoid introducing new colors without updating this guide.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -23,6 +23,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --brand-blue: #3A56D8;
     --brand-blue-rgb: 58, 86, 216;
     --brand-blue-glow: 142, 162, 255;
+    --brand-blue-top: #4A66E6;
+    --brand-blue-bottom: #2B44B4;
+    --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
     --accent-gold-glow: 224, 197, 138;
@@ -46,6 +49,21 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 
 .schedule-link {
     background-color: var(--brand-blue) !important;
+    background-image: linear-gradient(180deg, var(--brand-blue-top) 0%, var(--brand-blue) 52%, var(--brand-blue-bottom) 100%) !important;
+    border: 1px solid rgba(160, 176, 255, 0.55) !important;
+    color: var(--brand-blue-ink) !important;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.18),
+      0 1px 2px rgba(0, 0, 0, 0.35),
+      0 8px 18px rgba(var(--brand-blue-rgb), 0.28) !important;
+}
+
+.schedule-link:hover,
+.schedule-link:focus-visible {
+    background-image: linear-gradient(180deg, #516DF0 0%, #4360E2 52%, #314EC3 100%) !important;
+    color: var(--brand-blue-ink) !important;
+    filter: none !important;
 }
 
 /* ───────── LAYOUT / RESTORE DEMO LOOK ───────── */
@@ -151,10 +169,10 @@ html.switch .logo-constellation {
         0 1px 0 rgba(0, 0, 0, 0.55),
         0 3px 6px rgba(0, 0, 0, 0.35),
         0 -1px 0 rgba(255, 255, 255, 0.12),
-        -0.16px -0.16px 0 rgba(120, 180, 255, 0.3),
-         0.16px -0.16px 0 rgba(120, 180, 255, 0.3),
-        -0.16px  0.16px 0 rgba(120, 180, 255, 0.3),
-         0.16px  0.16px 0 rgba(120, 180, 255, 0.3),
+        -0.16px -0.16px 0 rgba(132, 152, 255, 0.34),
+         0.16px -0.16px 0 rgba(132, 152, 255, 0.34),
+        -0.16px  0.16px 0 rgba(132, 152, 255, 0.34),
+         0.16px  0.16px 0 rgba(132, 152, 255, 0.34),
             -0.56px  0 0 rgba(194, 161, 90, 0.73),
              0.56px  0 0 rgba(194, 161, 90, 0.73),
              0 -0.56px 0 rgba(194, 161, 90, 0.73),
@@ -185,10 +203,10 @@ html.switch .logo-constellation {
         0 1px 0 rgba(0, 0, 0, 0.55),
         0 3px 6px rgba(0, 0, 0, 0.35),
         0 -1px 0 rgba(255, 255, 255, 0.12),
-        -0.16px -0.16px 0 rgba(120, 180, 255, 0.3),
-         0.16px -0.16px 0 rgba(120, 180, 255, 0.3),
-        -0.16px  0.16px 0 rgba(120, 180, 255, 0.3),
-         0.16px  0.16px 0 rgba(120, 180, 255, 0.3),
+        -0.16px -0.16px 0 rgba(132, 152, 255, 0.34),
+         0.16px -0.16px 0 rgba(132, 152, 255, 0.34),
+        -0.16px  0.16px 0 rgba(132, 152, 255, 0.34),
+         0.16px  0.16px 0 rgba(132, 152, 255, 0.34),
         -0.56px  0 0 rgba(194, 161, 90, 0.73),
          0.56px  0 0 rgba(194, 161, 90, 0.73),
          0 -0.56px 0 rgba(194, 161, 90, 0.73),
@@ -372,10 +390,10 @@ html.switch .logo-help {
         0 1px 0 rgba(0, 0, 0, 0.45),
         0 2px 5px rgba(0, 0, 0, 0.28),
         0 -1px 0 rgba(255, 255, 255, 0.1),
-        -0.16px -0.16px 0 rgba(120, 180, 255, 0.28),
-         0.16px -0.16px 0 rgba(120, 180, 255, 0.28),
-        -0.16px  0.16px 0 rgba(120, 180, 255, 0.28),
-         0.16px  0.16px 0 rgba(120, 180, 255, 0.28),
+        -0.16px -0.16px 0 rgba(126, 145, 244, 0.3),
+         0.16px -0.16px 0 rgba(126, 145, 244, 0.3),
+        -0.16px  0.16px 0 rgba(126, 145, 244, 0.3),
+         0.16px  0.16px 0 rgba(126, 145, 244, 0.3),
         -0.48px  0 0 rgba(194, 161, 90, 0.66),
          0.48px  0 0 rgba(194, 161, 90, 0.66),
          0 -0.48px 0 rgba(194, 161, 90, 0.66),
@@ -386,6 +404,24 @@ html.switch .logo-help {
          0.48px  0.48px 0 rgba(194, 161, 90, 0.66),
          0 0 1.4px rgba(194, 161, 90, 0.30);
     animation: logo-gleam 6s ease-in-out infinite;
+}
+
+/* Indigo tonal fill adds depth without introducing glow effects. */
+@supports (-webkit-background-clip: text) {
+    .logo-it,
+    .logo-help,
+    html.switch .logo-it,
+    html.switch .logo-help {
+        background: linear-gradient(
+            180deg,
+            var(--brand-blue-top) 0%,
+            var(--brand-blue) 46%,
+            var(--brand-blue-bottom) 100%
+        );
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+    }
 }
 
 


### PR DESCRIPTION
Summary
- Add a tonal indigo ramp to IT and HELP letter fill (no glow/glass effects)
- Replace cyan-leaning micro-edge highlights with indigo highlights for a less flat/legacy look
- Give the Schedule button a subtle dimensional gradient and edge treatment while preserving readable contrast
- Document the ramp in STYLE_GUIDE.md and log this pass in PROJECT_EVOLUTION_LOG.md

Files
- static/css/late-overrides.css
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

Validation
- zola build passed

Notes
- Red plus sign unchanged
- Gold edge outline kept
- No JS, trackers, CSP-hostile changes, or framework additions