### PR TITLE
Fix IT/HELP logo silver cast and restore true indigo tone

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -102,3 +102,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Split logo and Schedule into dedicated indigo depth ramps, reduced muddy/gray cast in IT/HELP lettering by tuning shadow/overlay balance, and removed logo gleam animation on the base letterforms for steadier type color.
 - Why: Improve perceived quality and type-consistent blue identity while preserving trust posture and technical score gates.
 - Rollback: this branch/PR (`codex/ithelp-logo-color-consistency-v2`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: IT/HELP logo de-silver correction
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Increased logo indigo saturation and reduced cool overlay intensity so IT/HELP letters read as blue (not silver/steel), while preserving gold edge and plus-sign treatment.
+- Why: Match intended brand blue expression and improve perceived type consistency against the Schedule CTA.
+- Rollback: this branch/PR (`codex/ithelp-logo-blue-de-silver`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Indigo Depth Ramp:
-  - Top: `#5B74F0` (`--logo-blue-top`)
-  - Mid: `#4A63DE` (`--logo-blue-mid`)
-  - Bottom: `#354AB8` (`--logo-blue-bottom`)
+  - Top: `#6A84FF` (`--logo-blue-top`)
+  - Mid: `#5070F0` (`--logo-blue-mid`)
+  - Bottom: `#3855CF` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#4B64E0` (`--schedule-blue-top`)
   - Mid: `#3E56CB` (`--schedule-blue-mid`)
@@ -28,6 +28,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use dedicated indigo ramps for depth, not a flat fill.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
+- Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Use Gold in controlled doses: CTA button style and restrained logo trim only.
 - Red is reserved for the plus sign.
 - Avoid introducing new colors without updating this guide.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -23,9 +23,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --brand-blue: #3A56D8;
     --brand-blue-rgb: 58, 86, 216;
     --brand-blue-glow: 142, 162, 255;
-    --logo-blue-top: #5B74F0;
-    --logo-blue-mid: #4A63DE;
-    --logo-blue-bottom: #354AB8;
+    --logo-blue-top: #6A84FF;
+    --logo-blue-mid: #5070F0;
+    --logo-blue-bottom: #3855CF;
     --schedule-blue-top: #4B64E0;
     --schedule-blue-mid: #3E56CB;
     --schedule-blue-bottom: #2F45AE;
@@ -170,21 +170,21 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.44),
-        0 3px 7px rgba(2, 8, 26, 0.34),
-        -0.15px -0.15px 0 rgba(164, 182, 255, 0.42),
-         0.15px -0.15px 0 rgba(164, 182, 255, 0.42),
-        -0.15px  0.15px 0 rgba(164, 182, 255, 0.42),
-         0.15px  0.15px 0 rgba(164, 182, 255, 0.42),
-            -0.54px  0 0 rgba(194, 161, 90, 0.69),
-             0.54px  0 0 rgba(194, 161, 90, 0.69),
-             0 -0.54px 0 rgba(194, 161, 90, 0.69),
-             0  0.54px 0 rgba(194, 161, 90, 0.69),
-            -0.54px -0.54px 0 rgba(194, 161, 90, 0.69),
-             0.54px -0.54px 0 rgba(194, 161, 90, 0.69),
-            -0.54px  0.54px 0 rgba(194, 161, 90, 0.69),
-             0.54px  0.54px 0 rgba(194, 161, 90, 0.69),
-             0 0 1.5px rgba(194, 161, 90, 0.30);
+        0 1px 0 rgba(0, 0, 0, 0.34),
+        0 2px 5px rgba(2, 8, 26, 0.26),
+        -0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
+         0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
+        -0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
+         0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
+            -0.52px  0 0 rgba(194, 161, 90, 0.66),
+             0.52px  0 0 rgba(194, 161, 90, 0.66),
+             0 -0.52px 0 rgba(194, 161, 90, 0.66),
+             0  0.52px 0 rgba(194, 161, 90, 0.66),
+            -0.52px -0.52px 0 rgba(194, 161, 90, 0.66),
+             0.52px -0.52px 0 rgba(194, 161, 90, 0.66),
+            -0.52px  0.52px 0 rgba(194, 161, 90, 0.66),
+             0.52px  0.52px 0 rgba(194, 161, 90, 0.66),
+             0 0 1.35px rgba(194, 161, 90, 0.26);
     animation: none;
     position: relative;
     left: 0.1em;
@@ -203,21 +203,21 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.44),
-        0 3px 7px rgba(2, 8, 26, 0.34),
-        -0.15px -0.15px 0 rgba(164, 182, 255, 0.42),
-         0.15px -0.15px 0 rgba(164, 182, 255, 0.42),
-        -0.15px  0.15px 0 rgba(164, 182, 255, 0.42),
-         0.15px  0.15px 0 rgba(164, 182, 255, 0.42),
-        -0.54px  0 0 rgba(194, 161, 90, 0.69),
-         0.54px  0 0 rgba(194, 161, 90, 0.69),
-         0 -0.54px 0 rgba(194, 161, 90, 0.69),
-         0  0.54px 0 rgba(194, 161, 90, 0.69),
-        -0.54px -0.54px 0 rgba(194, 161, 90, 0.69),
-         0.54px -0.54px 0 rgba(194, 161, 90, 0.69),
-        -0.54px  0.54px 0 rgba(194, 161, 90, 0.69),
-         0.54px  0.54px 0 rgba(194, 161, 90, 0.69),
-         0 0 1.5px rgba(194, 161, 90, 0.30);
+        0 1px 0 rgba(0, 0, 0, 0.34),
+        0 2px 5px rgba(2, 8, 26, 0.26),
+        -0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
+         0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
+        -0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
+         0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
+        -0.52px  0 0 rgba(194, 161, 90, 0.66),
+         0.52px  0 0 rgba(194, 161, 90, 0.66),
+         0 -0.52px 0 rgba(194, 161, 90, 0.66),
+         0  0.52px 0 rgba(194, 161, 90, 0.66),
+        -0.52px -0.52px 0 rgba(194, 161, 90, 0.66),
+         0.52px -0.52px 0 rgba(194, 161, 90, 0.66),
+        -0.52px  0.52px 0 rgba(194, 161, 90, 0.66),
+         0.52px  0.52px 0 rgba(194, 161, 90, 0.66),
+         0 0 1.35px rgba(194, 161, 90, 0.26);
     animation: none;
     position: relative;
     left: -0.03em;
@@ -242,12 +242,12 @@ html.switch .logo-constellation {
     inset: 0;
     color: transparent;
     background: linear-gradient(180deg,
-        rgba(178, 196, 255, 0.22) 0%,
-        rgba(153, 175, 255, 0.08) 36%,
-        rgba(153, 175, 255, 0) 68%);
+        rgba(138, 165, 255, 0.14) 0%,
+        rgba(126, 154, 246, 0.06) 36%,
+        rgba(126, 154, 246, 0) 68%);
     -webkit-background-clip: text;
     background-clip: text;
-    opacity: 0.44;
+    opacity: 0.26;
     pointer-events: none;
     z-index: 3;
     font: inherit;
@@ -389,21 +389,21 @@ html.switch .logo-help {
     -webkit-text-fill-color: var(--brand-blue);
     background: none;
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.42),
-        0 2px 5px rgba(2, 8, 24, 0.30),
-        -0.15px -0.15px 0 rgba(158, 176, 252, 0.38),
-         0.15px -0.15px 0 rgba(158, 176, 252, 0.38),
-        -0.15px  0.15px 0 rgba(158, 176, 252, 0.38),
-         0.15px  0.15px 0 rgba(158, 176, 252, 0.38),
-        -0.48px  0 0 rgba(194, 161, 90, 0.64),
-         0.48px  0 0 rgba(194, 161, 90, 0.64),
-         0 -0.48px 0 rgba(194, 161, 90, 0.64),
-         0  0.48px 0 rgba(194, 161, 90, 0.64),
-        -0.48px -0.48px 0 rgba(194, 161, 90, 0.64),
-         0.48px -0.48px 0 rgba(194, 161, 90, 0.64),
-        -0.48px  0.48px 0 rgba(194, 161, 90, 0.64),
-         0.48px  0.48px 0 rgba(194, 161, 90, 0.64),
-         0 0 1.35px rgba(194, 161, 90, 0.28);
+        0 1px 0 rgba(0, 0, 0, 0.32),
+        0 2px 4px rgba(2, 8, 24, 0.24),
+        -0.15px -0.15px 0 rgba(136, 160, 245, 0.46),
+         0.15px -0.15px 0 rgba(136, 160, 245, 0.46),
+        -0.15px  0.15px 0 rgba(136, 160, 245, 0.46),
+         0.15px  0.15px 0 rgba(136, 160, 245, 0.46),
+        -0.48px  0 0 rgba(194, 161, 90, 0.62),
+         0.48px  0 0 rgba(194, 161, 90, 0.62),
+         0 -0.48px 0 rgba(194, 161, 90, 0.62),
+         0  0.48px 0 rgba(194, 161, 90, 0.62),
+        -0.48px -0.48px 0 rgba(194, 161, 90, 0.62),
+         0.48px -0.48px 0 rgba(194, 161, 90, 0.62),
+        -0.48px  0.48px 0 rgba(194, 161, 90, 0.62),
+         0.48px  0.48px 0 rgba(194, 161, 90, 0.62),
+         0 0 1.25px rgba(194, 161, 90, 0.24);
     animation: none;
 }
 


### PR DESCRIPTION
Summary
- increase logo indigo ramp saturation so IT/HELP reads blue, not silver/steel
- reduce cool overlay alpha that was muting logo fill into a metallic cast
- rebalance logo shadow stack to keep dimensionality without dulling color
- keep Schedule button treatment, red plus, and gold edge intent unchanged

Files
- static/css/late-overrides.css
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

Validation
- zola build passed

Process note
- branched from up-to-date main after PR #426 merge