### PR TITLE
Hard-align IT/HELP logo blue with Schedule CTA color

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -112,3 +112,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Increased logo indigo saturation and reduced cool overlay intensity so IT/HELP letters read as blue (not silver/steel), while preserving gold edge and plus-sign treatment.
 - Why: Match intended brand blue expression and improve perceived type consistency against the Schedule CTA.
 - Rollback: this branch/PR (`codex/ithelp-logo-blue-de-silver`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: IT/HELP + Schedule hard blue alignment
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Aligned IT/HELP logo ramp directly to the Schedule button ramp and reduced cool overlay/shadow wash that desaturated the logo letters.
+- Why: Deliver clear, unmistakable blue identity with immediate color parity between logo and Schedule CTA.
+- Rollback: this branch/PR (`codex/ithelp-logo-button-blue-unify`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Indigo Depth Ramp:
-  - Top: `#6A84FF` (`--logo-blue-top`)
-  - Mid: `#5070F0` (`--logo-blue-mid`)
-  - Bottom: `#3855CF` (`--logo-blue-bottom`)
+  - Top: `#4B64E0` (`--logo-blue-top`)
+  - Mid: `#3E56CB` (`--logo-blue-mid`)
+  - Bottom: `#2F45AE` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#4B64E0` (`--schedule-blue-top`)
   - Mid: `#3E56CB` (`--schedule-blue-mid`)
@@ -26,7 +26,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 ## Usage Rules
 - Use Primary Blue for links, logo text, and navigation CTA (Schedule).
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
-- High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use dedicated indigo ramps for depth, not a flat fill.
+- High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Use Gold in controlled doses: CTA button style and restrained logo trim only.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -23,12 +23,12 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --brand-blue: #3A56D8;
     --brand-blue-rgb: 58, 86, 216;
     --brand-blue-glow: 142, 162, 255;
-    --logo-blue-top: #6A84FF;
-    --logo-blue-mid: #5070F0;
-    --logo-blue-bottom: #3855CF;
     --schedule-blue-top: #4B64E0;
     --schedule-blue-mid: #3E56CB;
     --schedule-blue-bottom: #2F45AE;
+    --logo-blue-top: #4B64E0;
+    --logo-blue-mid: #3E56CB;
+    --logo-blue-bottom: #2F45AE;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -170,12 +170,12 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.34),
-        0 2px 5px rgba(2, 8, 26, 0.26),
-        -0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
-         0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
-        -0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
-         0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
+        0 1px 0 rgba(0, 0, 0, 0.30),
+        0 2px 4px rgba(2, 8, 26, 0.22),
+        -0.15px -0.15px 0 rgba(122, 147, 255, 0.34),
+         0.15px -0.15px 0 rgba(122, 147, 255, 0.34),
+        -0.15px  0.15px 0 rgba(122, 147, 255, 0.34),
+         0.15px  0.15px 0 rgba(122, 147, 255, 0.34),
             -0.52px  0 0 rgba(194, 161, 90, 0.66),
              0.52px  0 0 rgba(194, 161, 90, 0.66),
              0 -0.52px 0 rgba(194, 161, 90, 0.66),
@@ -203,12 +203,12 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.34),
-        0 2px 5px rgba(2, 8, 26, 0.26),
-        -0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
-         0.15px -0.15px 0 rgba(140, 165, 255, 0.52),
-        -0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
-         0.15px  0.15px 0 rgba(140, 165, 255, 0.52),
+        0 1px 0 rgba(0, 0, 0, 0.30),
+        0 2px 4px rgba(2, 8, 26, 0.22),
+        -0.15px -0.15px 0 rgba(122, 147, 255, 0.34),
+         0.15px -0.15px 0 rgba(122, 147, 255, 0.34),
+        -0.15px  0.15px 0 rgba(122, 147, 255, 0.34),
+         0.15px  0.15px 0 rgba(122, 147, 255, 0.34),
         -0.52px  0 0 rgba(194, 161, 90, 0.66),
          0.52px  0 0 rgba(194, 161, 90, 0.66),
          0 -0.52px 0 rgba(194, 161, 90, 0.66),
@@ -242,12 +242,12 @@ html.switch .logo-constellation {
     inset: 0;
     color: transparent;
     background: linear-gradient(180deg,
-        rgba(138, 165, 255, 0.14) 0%,
-        rgba(126, 154, 246, 0.06) 36%,
-        rgba(126, 154, 246, 0) 68%);
+        rgba(124, 148, 240, 0.08) 0%,
+        rgba(118, 144, 236, 0.03) 36%,
+        rgba(118, 144, 236, 0) 68%);
     -webkit-background-clip: text;
     background-clip: text;
-    opacity: 0.26;
+    opacity: 0.14;
     pointer-events: none;
     z-index: 3;
     font: inherit;
@@ -389,12 +389,12 @@ html.switch .logo-help {
     -webkit-text-fill-color: var(--brand-blue);
     background: none;
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.32),
-        0 2px 4px rgba(2, 8, 24, 0.24),
-        -0.15px -0.15px 0 rgba(136, 160, 245, 0.46),
-         0.15px -0.15px 0 rgba(136, 160, 245, 0.46),
-        -0.15px  0.15px 0 rgba(136, 160, 245, 0.46),
-         0.15px  0.15px 0 rgba(136, 160, 245, 0.46),
+        0 1px 0 rgba(0, 0, 0, 0.30),
+        0 2px 4px rgba(2, 8, 24, 0.22),
+        -0.15px -0.15px 0 rgba(118, 143, 232, 0.30),
+         0.15px -0.15px 0 rgba(118, 143, 232, 0.30),
+        -0.15px  0.15px 0 rgba(118, 143, 232, 0.30),
+         0.15px  0.15px 0 rgba(118, 143, 232, 0.30),
         -0.48px  0 0 rgba(194, 161, 90, 0.62),
          0.48px  0 0 rgba(194, 161, 90, 0.62),
          0 -0.48px 0 rgba(194, 161, 90, 0.62),


### PR DESCRIPTION
Summary
- align IT/HELP logo ramp to the same blue ramp family used by Schedule CTA
- reduce cool overlay/shadow wash that was muting the logo into steel/silver
- preserve gold edge, red plus, and existing CTA geometry

Files
- static/css/late-overrides.css
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

Validation
- zola build passed

Goal
- perfect color clarity on hero: IT/HELP and Schedule read as the same intentional blue system