### PR TITLE
Fix Safari P artifact in logo and remove duplicate DNS Tool heading

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -132,3 +132,14 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Replaced multi-layer pseudo-text rendering on IT/HELP with single-layer letter rendering, retained indigo ramp fill, and kept restrained gold edge via stroke/shadow to remove ghosting/double-glyph artifacts.
 - Why: Improve professional finish and color clarity while preventing visual duplication artifacts in real-world browsers/screenshots.
 - Rollback: this branch/PR (`codex/ithelp-logo-clean-typography`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: Safari glyph artifact fix + DNS Tool heading hierarchy cleanup
+- Files:
+  - `static/css/late-overrides.css`
+  - `content/dns-tool.md`
+  - `STYLE_GUIDE.md`
+- Change: Replaced stroke-based logo edge with shadow-based edge treatment to prevent Safari glyph artifacts (notably on `P`), and removed the in-content top-level DNS Tool heading so the template `h1` is the single visible page title.
+- Why: Improve rendering reliability and keep SEO/semantic heading structure clean with one `h1` per page.
+- Rollback: this branch/PR (`codex/ithelp-logo-p-artifact-fix`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -28,6 +28,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
+- Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Use Gold in controlled doses: CTA button style and restrained logo trim only.

--- a/content/dns-tool.md
+++ b/content/dns-tool.md
@@ -7,8 +7,6 @@ extra:
   skip_author: true
 ---
 
-# DNS Tool - DNS & Email Security Auditor
-
 DNS Tool is a **professional-grade DNS, email, and brand security auditor** designed to answer one question clearly: *can this domain be trusted on the internet today?*
 
 It analyzes real-world DNS behavior, not just static records, and presents the results in a single, defensible report.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -173,8 +173,13 @@ html.switch .logo-constellation {
     text-shadow:
         0 1px 0 rgba(0, 0, 0, 0.26),
         0 2px 4px rgba(2, 8, 26, 0.18),
-        0 0 0.9px rgba(194, 161, 90, 0.26);
-    -webkit-text-stroke: 0.48px rgba(194, 161, 90, 0.58);
+        -0.34px  0 0 rgba(194, 161, 90, 0.56),
+         0.34px  0 0 rgba(194, 161, 90, 0.56),
+         0 -0.34px 0 rgba(194, 161, 90, 0.56),
+         0  0.34px 0 rgba(194, 161, 90, 0.56),
+         0 0 0.8px rgba(194, 161, 90, 0.22);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
     animation: none;
     position: relative;
     z-index: 2;
@@ -310,8 +315,13 @@ html.switch .logo-help {
     text-shadow:
         0 1px 0 rgba(0, 0, 0, 0.22),
         0 2px 4px rgba(2, 8, 24, 0.14),
-        0 0 0.8px rgba(194, 161, 90, 0.24);
-    -webkit-text-stroke: 0.44px rgba(194, 161, 90, 0.54);
+        -0.30px  0 0 rgba(194, 161, 90, 0.50),
+         0.30px  0 0 rgba(194, 161, 90, 0.50),
+         0 -0.30px 0 rgba(194, 161, 90, 0.50),
+         0  0.30px 0 rgba(194, 161, 90, 0.50),
+         0 0 0.75px rgba(194, 161, 90, 0.20);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
     animation: none;
 }
 


### PR DESCRIPTION
Summary
- Replace webkit text stroke on IT/HELP logo with shadow-based edge treatment to eliminate Safari glyph artifacts (notably on P)
- Keep current blue ramp and gold edge intent while improving rendering reliability
- Remove top-level in-content heading from DNS Tool page so template page title is the single visible page title

Files
- static/css/late-overrides.css
- content/dns-tool.md
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

Validation
- zola build passed

SEO and semantics
- Keeps one visible H1 on dns-tool page while preserving title metadata and schema JSON-LD