### PR TITLE
Blue-led logo cohesion pass with explicit gold fallback reference

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -143,3 +143,14 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Replaced stroke-based logo edge with shadow-based edge treatment to prevent Safari glyph artifacts (notably on `P`), and removed the in-content top-level DNS Tool heading so the template `h1` is the single visible page title.
 - Why: Improve rendering reliability and keep SEO/semantic heading structure clean with one `h1` per page.
 - Rollback: this branch/PR (`codex/ithelp-logo-p-artifact-fix`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: Blue-led cohesion refinement for IT/HELP logo
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Reduced gold edge-shadow intensity on IT/HELP lettering and increased subtle blue edge support so the logo reads clearly blue while retaining a restrained gold trim.
+- Why: Improve color cohesion with the Schedule CTA and preserve a cleaner, more professional blue-first visual system.
+- Rollback: this branch/PR (`codex/ithelp-color-cohesion-blue-led`).
+- Gold fallback reference: `main@a3b9ea2` (PR `#430`) preserves the current gold-forward logo treatment if we decide to revert to that direction.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -29,8 +29,10 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
+- Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
+- Gold-forward fallback snapshot (if we intentionally choose that direction): `main@a3b9ea2` from PR `#430`; use it as the restore baseline for logo color treatment.
 - Use Gold in controlled doses: CTA button style and restrained logo trim only.
 - Red is reserved for the plus sign.
 - Avoid introducing new colors without updating this guide.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -171,13 +171,13 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.26),
-        0 2px 4px rgba(2, 8, 26, 0.18),
-        -0.34px  0 0 rgba(194, 161, 90, 0.56),
-         0.34px  0 0 rgba(194, 161, 90, 0.56),
-         0 -0.34px 0 rgba(194, 161, 90, 0.56),
-         0  0.34px 0 rgba(194, 161, 90, 0.56),
-         0 0 0.8px rgba(194, 161, 90, 0.22);
+        0 1px 0 rgba(0, 0, 0, 0.24),
+        0 2px 4px rgba(2, 8, 26, 0.16),
+        -0.24px  0 0 rgba(194, 161, 90, 0.24),
+         0.24px  0 0 rgba(194, 161, 90, 0.24),
+         0 -0.24px 0 rgba(194, 161, 90, 0.24),
+         0  0.24px 0 rgba(194, 161, 90, 0.24),
+         0 0 0.72px rgba(122, 147, 255, 0.26);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -313,13 +313,13 @@ html.switch .logo-help {
     -webkit-text-fill-color: currentColor;
     background: none;
     text-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.22),
-        0 2px 4px rgba(2, 8, 24, 0.14),
-        -0.30px  0 0 rgba(194, 161, 90, 0.50),
-         0.30px  0 0 rgba(194, 161, 90, 0.50),
-         0 -0.30px 0 rgba(194, 161, 90, 0.50),
-         0  0.30px 0 rgba(194, 161, 90, 0.50),
-         0 0 0.75px rgba(194, 161, 90, 0.20);
+        0 1px 0 rgba(0, 0, 0, 0.20),
+        0 2px 4px rgba(2, 8, 24, 0.12),
+        -0.22px  0 0 rgba(194, 161, 90, 0.22),
+         0.22px  0 0 rgba(194, 161, 90, 0.22),
+         0 -0.22px 0 rgba(194, 161, 90, 0.22),
+         0  0.22px 0 rgba(194, 161, 90, 0.22),
+         0 0 0.68px rgba(118, 143, 232, 0.24);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
Summary
- reduce gold edge intensity so IT/HELP reads blue-first and better matches the Schedule CTA
- keep a restrained gold trim for depth and brand continuity
- add explicit gold fallback reference in docs so this look can be restored quickly if desired

Files
- static/css/late-overrides.css
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

Validation
- zola build passed

Fallback note
- gold-forward baseline explicitly recorded as main@a3b9ea2 (PR #430)