### PR TITLE
Unify page link blues with IT/HELP and Schedule indigo system

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -174,3 +174,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Removed `role="img"` usage on the hero logo wrapper and marked the logo/location cluster as decorative with `aria-hidden="true"`.
 - Why: Clear Sonar rule violation and keep semantic accessibility output clean.
 - Rollback: this branch/PR (`codex/ithelp-blue-unify-v3`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: Link-palette indigo cohesion pass (logo/button/link alignment)
+- Files:
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Shifted dark/light link tokens to the same indigo hue family used by IT/HELP and Schedule, and updated phone-link override to follow shared link tokens instead of a separate cyan-leaning blue.
+- Why: Remove color mismatch between logo/button and in-content links while keeping contrast-safe per-theme brightness.
+- Rollback: this branch/PR (`codex/ithelp-link-blue-cohesion-v1`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -17,6 +17,11 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
   - Top: `#5A72F2` (`--schedule-blue-top`)
   - Mid: `#445FE4` (`--schedule-blue-mid`)
   - Bottom: `#3149BB` (`--schedule-blue-bottom`)
+- Body/Utility Link Blue (same hue family):
+  - Dark mode link: `#7F97FF` (`$a1d`)
+  - Dark mode hover: `#A8BAFF` (`$a2d`)
+  - Light mode link: `#3048AF` (`$a1`)
+  - Light mode hover: `#445FE4` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -27,6 +32,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Use Primary Blue for links, logo text, and navigation CTA (Schedule).
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
+- Standard text links (including phone/map links) should stay in the same indigo hue family as logo/Schedule, with brightness shifts only for contrast by theme.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #3A56D8;
-  --brand-primary-rgb: 58, 86, 216;
-  --brand-primary-glow: 142, 162, 255;
+  --brand-primary: #445FE4;
+  --brand-primary-rgb: 68, 95, 228;
+  --brand-primary-glow: 156, 177, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;
@@ -11,12 +11,12 @@
 }
 
 :root:not(.switch) {
-  --a1-rgb: 137, 160, 255;
+  --a1-rgb: 127, 151, 255;
   --surface-rgb: 23, 23, 23;
 }
 
 :root.switch {
-  --a1-rgb: 47, 71, 168;
+  --a1-rgb: 48, 72, 175;
   --surface-rgb: 245, 245, 247;
 }
 

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #89A0FF,// link color
-  $a2d: #A5B4FF,// link hover/focus color
-  $a3d: #A5B4FF,// link h1-h2 hover/focus color
-  $a4d: #95AAFF,// link visited color
+  $a1d: #7F97FF,// link color
+  $a2d: #A8BAFF,// link hover/focus color
+  $a3d: #A8BAFF,// link h1-h2 hover/focus color
+  $a4d: #8EA5FF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #2F47A8,// link color
-  $a2: #3A56D8,// link hover/focus color
-  $a3: #3A56D8,// link h1-h2 hover/focus color
-  $a4: #2F47A8,// link visited color
+  $a1: #3048AF,// link color
+  $a2: #445FE4,// link hover/focus color
+  $a3: #445FE4,// link h1-h2 hover/focus color
+  $a4: #3048AF,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -4,7 +4,7 @@ body{overflow-x:hidden}.homepage-hero{display:block!important;align-items:flex-s
 @media (min-width:700px){.page-title,.post-title,h1.page-title,h1.post-title{text-align:center!important;margin-left:auto!important;margin-right:auto!important;width:100%!important;max-width:100%!important;overflow-wrap:break-word!important;word-break:break-word!important}}
 
 html.switch .dropdown-content li a:hover{color:var(--a2)!important;background:#fff!important}
-html.switch .phone-line,:root.switch .phone-line{color:#1F6BB8!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:#8BC3FF!important}
+html.switch .phone-line,:root.switch .phone-line{color:var(--a1)!important}html:not(.switch) .phone-line,:root:not(.switch) .phone-line{color:var(--a1)!important}
 html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:not(.switch) h3 a:hover,html:not(.switch) h3 a:active,html:not(.switch) h3 a:focus{color:var(--a2)!important}
 .logo-light{display:none!important}.logo-dark{display:block!important}html.switch .logo-dark{display:none!important}html.switch .logo-light{display:block!important}
 


### PR DESCRIPTION
Summary: align dark/light link tokens to the same indigo hue family as IT/HELP and Schedule CTA; update phone-line override to use shared link token (var(--a1)) instead of separate cyan-leaning values; update STYLE_GUIDE and PROJECT_EVOLUTION_LOG for rollback trace. Validation: zola build passed.