### PR TITLE
Increase logo/CTA blue character with cobalt-indigo depth

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -198,3 +198,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Shifted the shared blue system to a richer electric-indigo ramp for logo/Schedule/links and moved `.logo-plus` up (`top: -0.055em`) for better vertical optical centering between `IT` and `HELP`.
 - Why: Keep full color cohesion while removing the “boring/default blue” feel and tightening logo geometry.
 - Rollback: this branch/PR (`codex/ithelp-premium-indigo-plus-align`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: Cobalt-indigo high-chroma depth pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `STYLE_GUIDE.md`
+- Change: Moved the shared blue system to a stronger cobalt-indigo palette, increased top/bottom depth contrast in IT/HELP lettering shadows, and boosted Schedule CTA gradient contrast while keeping all links in the same hue family.
+- Why: Address remaining “boring/default blue” perception without introducing glow-heavy effects or breaking cohesion.
+- Rollback: this branch/PR (`codex/ithelp-cobalt-indigo-v2`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,24 +4,24 @@ Last updated: 2026-02-07
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (logo + navigation CTA): `#536CFF`  
+- Primary Blue (logo + navigation CTA): `#6570FF`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Indigo Depth Ramp:
-  - Top: `#6E84FF` (`--logo-blue-top`)
-  - Mid: `#536CFF` (`--logo-blue-mid`)
-  - Bottom: `#3D53CF` (`--logo-blue-bottom`)
+  - Top: `#8795FF` (`--logo-blue-top`)
+  - Mid: `#6570FF` (`--logo-blue-mid`)
+  - Bottom: `#424EDB` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#6E84FF` (`--schedule-blue-top`)
-  - Mid: `#536CFF` (`--schedule-blue-mid`)
-  - Bottom: `#3D53CF` (`--schedule-blue-bottom`)
+  - Top: `#8795FF` (`--schedule-blue-top`)
+  - Mid: `#6570FF` (`--schedule-blue-mid`)
+  - Bottom: `#424EDB` (`--schedule-blue-bottom`)
 - Body/Utility Link Blue (same hue family):
-  - Dark mode link: `#97ABFF` (`$a1d`)
-  - Dark mode hover: `#B8C7FF` (`$a2d`)
-  - Light mode link: `#3B53BC` (`$a1`)
-  - Light mode hover: `#536CFF` (`$a2`)
+  - Dark mode link: `#AAB7FF` (`$a1d`)
+  - Dark mode hover: `#C8D1FF` (`$a2d`)
+  - Light mode link: `#4050C7` (`$a1`)
+  - Light mode hover: `#6570FF` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -33,6 +33,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
 - Standard text links (including phone/map links) should stay in the same indigo hue family as logo/Schedule, with brightness shifts only for contrast by theme.
+- Current blue target: cobalt-indigo with higher chroma and stronger top/bottom depth, avoiding cyan drift and avoiding neon glow.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #536CFF;
-  --brand-primary-rgb: 83, 108, 255;
-  --brand-primary-glow: 173, 188, 255;
+  --brand-primary: #6570FF;
+  --brand-primary-rgb: 101, 112, 255;
+  --brand-primary-glow: 188, 197, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;
@@ -11,12 +11,12 @@
 }
 
 :root:not(.switch) {
-  --a1-rgb: 151, 171, 255;
+  --a1-rgb: 170, 183, 255;
   --surface-rgb: 23, 23, 23;
 }
 
 :root.switch {
-  --a1-rgb: 59, 83, 188;
+  --a1-rgb: 64, 80, 199;
   --surface-rgb: 245, 245, 247;
 }
 

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #97ABFF,// link color
-  $a2d: #B8C7FF,// link hover/focus color
-  $a3d: #B8C7FF,// link h1-h2 hover/focus color
-  $a4d: #A3B5FF,// link visited color
+  $a1d: #AAB7FF,// link color
+  $a2d: #C8D1FF,// link hover/focus color
+  $a3d: #C8D1FF,// link h1-h2 hover/focus color
+  $a4d: #B7C3FF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #3B53BC,// link color
-  $a2: #536CFF,// link hover/focus color
-  $a3: #536CFF,// link h1-h2 hover/focus color
-  $a4: #3B53BC,// link visited color
+  $a1: #4050C7,// link color
+  $a2: #6570FF,// link hover/focus color
+  $a3: #6570FF,// link h1-h2 hover/focus color
+  $a4: #4050C7,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,15 +20,15 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #536CFF;
-    --brand-blue-rgb: 83, 108, 255;
-    --brand-blue-glow: 173, 188, 255;
-    --schedule-blue-top: #6E84FF;
-    --schedule-blue-mid: #536CFF;
-    --schedule-blue-bottom: #3D53CF;
-    --logo-blue-top: #6E84FF;
-    --logo-blue-mid: #536CFF;
-    --logo-blue-bottom: #3D53CF;
+    --brand-blue: #6570FF;
+    --brand-blue-rgb: 101, 112, 255;
+    --brand-blue-glow: 188, 197, 255;
+    --schedule-blue-top: #8795FF;
+    --schedule-blue-mid: #6570FF;
+    --schedule-blue-bottom: #424EDB;
+    --logo-blue-top: #8795FF;
+    --logo-blue-mid: #6570FF;
+    --logo-blue-bottom: #424EDB;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(170, 186, 255, 0.6) !important;
+    border: 1px solid rgba(189, 201, 255, 0.68) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.24),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 7px 16px rgba(45, 72, 177, 0.36) !important;
+      0 8px 18px rgba(57, 79, 204, 0.44) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #7A8FFF 0%, #6076FC 52%, #495FDD 100%) !important;
+    background-image: linear-gradient(180deg, #94A0FF 0%, #7280FF 52%, #5563EA 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }
@@ -171,12 +171,12 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.55px 0 rgba(205, 218, 255, 0.34),
-        0 1.1px 0 rgba(28, 40, 96, 0.74),
-        0 2px 4px rgba(2, 8, 26, 0.26),
-        0 7px 16px rgba(7, 13, 36, 0.36),
-       -0.2px 0 0 rgba(122, 147, 255, 0.24),
-        0.2px 0 0 rgba(122, 147, 255, 0.24);
+        0 -0.65px 0 rgba(227, 234, 255, 0.46),
+        0 1.15px 0 rgba(24, 33, 96, 0.88),
+        0 2px 4px rgba(2, 8, 26, 0.33),
+        0 8px 18px rgba(7, 13, 36, 0.42),
+       -0.22px 0 0 rgba(155, 178, 255, 0.34),
+        0.22px 0 0 rgba(155, 178, 255, 0.34);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -313,10 +313,10 @@ html.switch .logo-help {
     -webkit-text-fill-color: currentColor;
     background: none;
     text-shadow:
-        0 -0.45px 0 rgba(207, 219, 255, 0.3),
-        0 1px 0 rgba(31, 45, 108, 0.64),
-        0 2px 4px rgba(2, 8, 24, 0.2),
-        0 0 0.68px rgba(118, 143, 232, 0.28);
+        0 -0.5px 0 rgba(219, 229, 255, 0.35),
+        0 1.05px 0 rgba(30, 43, 112, 0.7),
+        0 2px 4px rgba(2, 8, 24, 0.24),
+        0 0 0.72px rgba(138, 161, 255, 0.32);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
Summary: move the shared blue system from safe indigo to higher-chroma cobalt-indigo; increase IT/HELP letter depth contrast (top highlight + darker base + side edge tint) so logo feels less flat; strengthen Schedule gradient contrast while preserving hue cohesion with links and logo; retain plus vertical centering from previous pass. Validation: zola build passed.