### PR TITLE
Remove purple cast and retune to clean cobalt-blue

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -210,3 +210,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Moved the shared blue system to a stronger cobalt-indigo palette, increased top/bottom depth contrast in IT/HELP lettering shadows, and boosted Schedule CTA gradient contrast while keeping all links in the same hue family.
 - Why: Address remaining “boring/default blue” perception without introducing glow-heavy effects or breaking cohesion.
 - Rollback: this branch/PR (`codex/ithelp-cobalt-indigo-v2`).
+
+### 2026-02-07
+- Actor: AI+Developer
+- Scope: De-purple to clean cobalt-blue pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `STYLE_GUIDE.md`
+- Change: Reduced purple hue bias across shared blue tokens, shifted logo/button/link palette to a cleaner cobalt-blue family, and retuned logo shadow tint channels to cool-blue values.
+- Why: Correct user-reported purple cast while preserving cohesion and depth.
+- Rollback: this branch/PR (`codex/ithelp-cobalt-no-purple`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,24 +4,24 @@ Last updated: 2026-02-07
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (logo + navigation CTA): `#6570FF`  
+- Primary Blue (logo + navigation CTA): `#3D74FF`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Indigo Depth Ramp:
-  - Top: `#8795FF` (`--logo-blue-top`)
-  - Mid: `#6570FF` (`--logo-blue-mid`)
-  - Bottom: `#424EDB` (`--logo-blue-bottom`)
+  - Top: `#5E90FF` (`--logo-blue-top`)
+  - Mid: `#3D74FF` (`--logo-blue-mid`)
+  - Bottom: `#244CC9` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#8795FF` (`--schedule-blue-top`)
-  - Mid: `#6570FF` (`--schedule-blue-mid`)
-  - Bottom: `#424EDB` (`--schedule-blue-bottom`)
+  - Top: `#5E90FF` (`--schedule-blue-top`)
+  - Mid: `#3D74FF` (`--schedule-blue-mid`)
+  - Bottom: `#244CC9` (`--schedule-blue-bottom`)
 - Body/Utility Link Blue (same hue family):
-  - Dark mode link: `#AAB7FF` (`$a1d`)
-  - Dark mode hover: `#C8D1FF` (`$a2d`)
-  - Light mode link: `#4050C7` (`$a1`)
-  - Light mode hover: `#6570FF` (`$a2`)
+  - Dark mode link: `#90BBFF` (`$a1d`)
+  - Dark mode hover: `#B7D4FF` (`$a2d`)
+  - Light mode link: `#2E58C2` (`$a1`)
+  - Light mode hover: `#3D74FF` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -33,7 +33,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
 - Standard text links (including phone/map links) should stay in the same indigo hue family as logo/Schedule, with brightness shifts only for contrast by theme.
-- Current blue target: cobalt-indigo with higher chroma and stronger top/bottom depth, avoiding cyan drift and avoiding neon glow.
+- Current blue target: clean cobalt-blue (cool and premium), avoiding both purple cast and cyan/neon drift.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #6570FF;
-  --brand-primary-rgb: 101, 112, 255;
-  --brand-primary-glow: 188, 197, 255;
+  --brand-primary: #3D74FF;
+  --brand-primary-rgb: 61, 116, 255;
+  --brand-primary-glow: 156, 205, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;
@@ -11,12 +11,12 @@
 }
 
 :root:not(.switch) {
-  --a1-rgb: 170, 183, 255;
+  --a1-rgb: 144, 187, 255;
   --surface-rgb: 23, 23, 23;
 }
 
 :root.switch {
-  --a1-rgb: 64, 80, 199;
+  --a1-rgb: 46, 88, 194;
   --surface-rgb: 245, 245, 247;
 }
 

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #AAB7FF,// link color
-  $a2d: #C8D1FF,// link hover/focus color
-  $a3d: #C8D1FF,// link h1-h2 hover/focus color
-  $a4d: #B7C3FF,// link visited color
+  $a1d: #90BBFF,// link color
+  $a2d: #B7D4FF,// link hover/focus color
+  $a3d: #B7D4FF,// link h1-h2 hover/focus color
+  $a4d: #A2C6FF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #4050C7,// link color
-  $a2: #6570FF,// link hover/focus color
-  $a3: #6570FF,// link h1-h2 hover/focus color
-  $a4: #4050C7,// link visited color
+  $a1: #2E58C2,// link color
+  $a2: #3D74FF,// link hover/focus color
+  $a3: #3D74FF,// link h1-h2 hover/focus color
+  $a4: #2E58C2,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,15 +20,15 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #6570FF;
-    --brand-blue-rgb: 101, 112, 255;
-    --brand-blue-glow: 188, 197, 255;
-    --schedule-blue-top: #8795FF;
-    --schedule-blue-mid: #6570FF;
-    --schedule-blue-bottom: #424EDB;
-    --logo-blue-top: #8795FF;
-    --logo-blue-mid: #6570FF;
-    --logo-blue-bottom: #424EDB;
+    --brand-blue: #3D74FF;
+    --brand-blue-rgb: 61, 116, 255;
+    --brand-blue-glow: 156, 205, 255;
+    --schedule-blue-top: #5E90FF;
+    --schedule-blue-mid: #3D74FF;
+    --schedule-blue-bottom: #244CC9;
+    --logo-blue-top: #5E90FF;
+    --logo-blue-mid: #3D74FF;
+    --logo-blue-bottom: #244CC9;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(189, 201, 255, 0.68) !important;
+    border: 1px solid rgba(170, 206, 255, 0.62) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.24),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 8px 18px rgba(57, 79, 204, 0.44) !important;
+      0 8px 18px rgba(37, 80, 214, 0.42) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #94A0FF 0%, #7280FF 52%, #5563EA 100%) !important;
+    background-image: linear-gradient(180deg, #6EA0FF 0%, #4E84FF 52%, #305FDA 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }
@@ -171,12 +171,12 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.65px 0 rgba(227, 234, 255, 0.46),
-        0 1.15px 0 rgba(24, 33, 96, 0.88),
+        0 -0.65px 0 rgba(223, 237, 255, 0.46),
+        0 1.15px 0 rgba(20, 41, 110, 0.88),
         0 2px 4px rgba(2, 8, 26, 0.33),
-        0 8px 18px rgba(7, 13, 36, 0.42),
-       -0.22px 0 0 rgba(155, 178, 255, 0.34),
-        0.22px 0 0 rgba(155, 178, 255, 0.34);
+        0 8px 18px rgba(6, 16, 42, 0.42),
+       -0.22px 0 0 rgba(129, 180, 255, 0.34),
+        0.22px 0 0 rgba(129, 180, 255, 0.34);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -313,10 +313,10 @@ html.switch .logo-help {
     -webkit-text-fill-color: currentColor;
     background: none;
     text-shadow:
-        0 -0.5px 0 rgba(219, 229, 255, 0.35),
-        0 1.05px 0 rgba(30, 43, 112, 0.7),
+        0 -0.5px 0 rgba(212, 230, 255, 0.35),
+        0 1.05px 0 rgba(25, 45, 120, 0.7),
         0 2px 4px rgba(2, 8, 24, 0.24),
-        0 0 0.72px rgba(138, 161, 255, 0.32);
+        0 0 0.72px rgba(125, 172, 255, 0.32);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
Summary: replace purple-leaning blue tokens with cleaner cobalt-blue values across logo, Schedule CTA, and links; retune logo shadow tint channels to cool-blue so letter depth reads blue rather than violet; preserve plus alignment and full token cohesion. Validation: zola build passed.