### PR TITLE
Role-based blue pass: deeper logo authority + brighter action links

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -234,3 +234,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Shifted shared blue tokens to a crisper ice-cobalt family, increased blue energy in logo/CTA gradients, and aligned link tokens to the same hue family with contrast-safe light-mode values.
 - Why: Keep cohesive control while pushing toward a more exciting, less “generic” blue impression.
 - Rollback: this branch/PR (`codex/ithelp-ice-cobalt-v1`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Role-based blue depth pass (authority logo + action CTA/links)
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `STYLE_GUIDE.md`
+- Change: Introduced a role-based blue system within one hue family: deeper logo ramp for authority, brighter Schedule/link ramp for action clarity, and matching shadow/border tuning for cleaner depth.
+- Why: Preserve full color cohesion while reducing “flat/boring default blue” perception and keeping trust-oriented visual psychology.
+- Rollback: this branch/PR (`codex/ithelp-role-based-blue-v1`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,27 +1,27 @@
 # Style Guide (Living)
-Last updated: 2026-02-07
+Last updated: 2026-02-08
 
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (logo + navigation CTA): `#2E86FF`  
+- Primary Blue (shared hue anchor): `#3A86F0`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
-- Logo Indigo Depth Ramp:
-  - Top: `#64ACFF` (`--logo-blue-top`)
-  - Mid: `#2E86FF` (`--logo-blue-mid`)
-  - Bottom: `#1E58D6` (`--logo-blue-bottom`)
+- Logo Authority Blue Ramp (deeper tone for premium trust feel):
+  - Top: `#5B9CF2` (`--logo-blue-top`)
+  - Mid: `#3470D3` (`--logo-blue-mid`)
+  - Bottom: `#1D4DA9` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#64ACFF` (`--schedule-blue-top`)
-  - Mid: `#2E86FF` (`--schedule-blue-mid`)
-  - Bottom: `#1E58D6` (`--schedule-blue-bottom`)
-- Body/Utility Link Blue (same hue family):
-  - Dark mode link: `#8CCBFF` (`$a1d`)
-  - Dark mode hover: `#B4DFFF` (`$a2d`)
-  - Light mode link: `#225FCB` (`$a1`)
-  - Light mode hover: `#2C73E8` (`$a2`)
+  - Top: `#72B9FF` (`--schedule-blue-top`)
+  - Mid: `#3E95FF` (`--schedule-blue-mid`)
+  - Bottom: `#2A68E0` (`--schedule-blue-bottom`)
+- Body/Utility Link Blue (same hue family, action-biased):
+  - Dark mode link: `#8DCAFF` (`$a1d`)
+  - Dark mode hover: `#B6E1FF` (`$a2d`)
+  - Light mode link: `#1F63CF` (`$a1`)
+  - Light mode hover: `#2D79EA` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -29,11 +29,13 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Secondary Text: `#B2BAC5` (e.g., "SAN DIEGO")
 
 ## Usage Rules
-- Use Primary Blue for links, logo text, and navigation CTA (Schedule).
+- Keep one hue family but use role-based depth:
+  - Logo = deeper authority blue.
+  - Schedule/link actions = brighter action blue.
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
-- High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should use the same indigo ramp family for immediate visual consistency.
-- Standard text links (including phone/map links) should stay in the same indigo hue family as logo/Schedule, with brightness shifts only for contrast by theme.
-- Current blue target: ice-cobalt blue (crisper and more energetic) while avoiding purple cast and neon glow.
+- High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should remain in the same family even when depth differs by role.
+- Standard text links (including phone/map links) should remain in-family with Schedule blue, only shifting brightness for contrast by theme.
+- Current blue target: premium cobalt-indigo with no purple cast and no neon glow.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #2E86FF;
-  --brand-primary-rgb: 46, 134, 255;
-  --brand-primary-glow: 147, 209, 255;
+  --brand-primary: #3E95FF;
+  --brand-primary-rgb: 62, 149, 255;
+  --brand-primary-glow: 151, 208, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #8CCBFF,// link color
-  $a2d: #B4DFFF,// link hover/focus color
-  $a3d: #B4DFFF,// link h1-h2 hover/focus color
-  $a4d: #9DD6FF,// link visited color
+  $a1d: #8DCAFF,// link color
+  $a2d: #B6E1FF,// link hover/focus color
+  $a3d: #B6E1FF,// link h1-h2 hover/focus color
+  $a4d: #9ED5FF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #225FCB,// link color
-  $a2: #2C73E8,// link hover/focus color
-  $a3: #2C73E8,// link h1-h2 hover/focus color
-  $a4: #225FCB,// link visited color
+  $a1: #1F63CF,// link color
+  $a2: #2D79EA,// link hover/focus color
+  $a3: #2D79EA,// link h1-h2 hover/focus color
+  $a4: #1F63CF,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,15 +20,15 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #2E86FF;
-    --brand-blue-rgb: 46, 134, 255;
-    --brand-blue-glow: 147, 209, 255;
-    --schedule-blue-top: #64ACFF;
-    --schedule-blue-mid: #2E86FF;
-    --schedule-blue-bottom: #1E58D6;
-    --logo-blue-top: #64ACFF;
-    --logo-blue-mid: #2E86FF;
-    --logo-blue-bottom: #1E58D6;
+    --brand-blue: #3A86F0;
+    --brand-blue-rgb: 58, 134, 240;
+    --brand-blue-glow: 151, 208, 255;
+    --schedule-blue-top: #72B9FF;
+    --schedule-blue-mid: #3E95FF;
+    --schedule-blue-bottom: #2A68E0;
+    --logo-blue-top: #5B9CF2;
+    --logo-blue-mid: #3470D3;
+    --logo-blue-bottom: #1D4DA9;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(158, 214, 255, 0.66) !important;
+    border: 1px solid rgba(162, 215, 255, 0.62) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.24),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 8px 18px rgba(29, 87, 228, 0.44) !important;
+      0 8px 18px rgba(27, 84, 214, 0.42) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #77B8FF 0%, #4A94FF 52%, #2A6DE6 100%) !important;
+    background-image: linear-gradient(180deg, #84C5FF 0%, #53A4FF 52%, #3679EA 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }
@@ -171,12 +171,12 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.65px 0 rgba(217, 238, 255, 0.48),
-        0 1.15px 0 rgba(15, 45, 124, 0.86),
-        0 2px 4px rgba(2, 8, 26, 0.33),
-        0 8px 18px rgba(6, 16, 42, 0.42),
-       -0.22px 0 0 rgba(109, 190, 255, 0.36),
-        0.22px 0 0 rgba(109, 190, 255, 0.36);
+        0 -0.58px 0 rgba(208, 230, 255, 0.42),
+        0 1.12px 0 rgba(10, 33, 92, 0.86),
+        0 2px 4px rgba(2, 8, 24, 0.34),
+        0 8px 18px rgba(5, 14, 38, 0.42),
+       -0.2px 0 0 rgba(95, 166, 255, 0.28),
+        0.2px 0 0 rgba(95, 166, 255, 0.28);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -313,10 +313,10 @@ html.switch .logo-help {
     -webkit-text-fill-color: currentColor;
     background: none;
     text-shadow:
-        0 -0.5px 0 rgba(205, 231, 255, 0.36),
-        0 1.05px 0 rgba(18, 48, 132, 0.68),
-        0 2px 4px rgba(2, 8, 24, 0.24),
-        0 0 0.72px rgba(102, 185, 255, 0.34);
+        0 -0.46px 0 rgba(200, 228, 255, 0.34),
+        0 1px 0 rgba(13, 39, 108, 0.68),
+        0 2px 4px rgba(2, 8, 24, 0.25),
+        0 0 0.7px rgba(94, 160, 248, 0.3);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
## Summary
- introduce a role-based blue system within one hue family
- deepen IT/HELP logo blue ramp for authority and premium depth
- keep Schedule and text links in a brighter action ramp for clarity
- retune logo/button shadows and borders to avoid flat or purple cast
- sync color tokens in sass/css/abridge.scss and sass/_extra.scss
- update STYLE_GUIDE.md and add log entry in PROJECT_EVOLUTION_LOG.md

## Validation
- zola build passed

## Notes
- keeps the red plus unchanged and vertically centered target intact
- preserves no-stroke Safari-safe logo rendering to avoid glyph artifacts