### PR TITLE
Signal-cobalt blue pass for stronger premium cohesion

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -246,3 +246,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Introduced a role-based blue system within one hue family: deeper logo ramp for authority, brighter Schedule/link ramp for action clarity, and matching shadow/border tuning for cleaner depth.
 - Why: Preserve full color cohesion while reducing “flat/boring default blue” perception and keeping trust-oriented visual psychology.
 - Rollback: this branch/PR (`codex/ithelp-role-based-blue-v1`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Signal-cobalt signature pass (higher energy, no purple cast)
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `STYLE_GUIDE.md`
+- Change: Shifted shared blue tokens to a brighter signal-cobalt family, increased logo letter depth via highlight/shadow tuning, and aligned Schedule + link ramps to the same hue family with stronger action contrast.
+- Why: Keep cohesion while pushing the palette away from “boring/default blue” toward a cleaner premium look.
+- Rollback: this branch/PR (`codex/ithelp-blue-signature-v5`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,24 +4,24 @@ Last updated: 2026-02-08
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (shared hue anchor): `#3A86F0`  
+- Primary Blue (shared hue anchor): `#3E98FF`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#5B9CF2` (`--logo-blue-top`)
-  - Mid: `#3470D3` (`--logo-blue-mid`)
-  - Bottom: `#1D4DA9` (`--logo-blue-bottom`)
+  - Top: `#71B8FF` (`--logo-blue-top`)
+  - Mid: `#3A7EE6` (`--logo-blue-mid`)
+  - Bottom: `#1B469B` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#72B9FF` (`--schedule-blue-top`)
-  - Mid: `#3E95FF` (`--schedule-blue-mid`)
-  - Bottom: `#2A68E0` (`--schedule-blue-bottom`)
+  - Top: `#89CCFF` (`--schedule-blue-top`)
+  - Mid: `#4AA3FF` (`--schedule-blue-mid`)
+  - Bottom: `#2E73E7` (`--schedule-blue-bottom`)
 - Body/Utility Link Blue (same hue family, action-biased):
-  - Dark mode link: `#8DCAFF` (`$a1d`)
-  - Dark mode hover: `#B6E1FF` (`$a2d`)
-  - Light mode link: `#1F63CF` (`$a1`)
-  - Light mode hover: `#2D79EA` (`$a2`)
+  - Dark mode link: `#9DD7FF` (`$a1d`)
+  - Dark mode hover: `#C9E9FF` (`$a2d`)
+  - Light mode link: `#2372DE` (`$a1`)
+  - Light mode hover: `#3A8AEE` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -35,7 +35,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should remain in the same family even when depth differs by role.
 - Standard text links (including phone/map links) should remain in-family with Schedule blue, only shifting brightness for contrast by theme.
-- Current blue target: premium cobalt-indigo with no purple cast and no neon glow.
+- Current blue target: signal-cobalt with stronger clarity/energy, no purple cast, and no neon glow.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #3E95FF;
-  --brand-primary-rgb: 62, 149, 255;
-  --brand-primary-glow: 151, 208, 255;
+  --brand-primary: #4AA3FF;
+  --brand-primary-rgb: 74, 163, 255;
+  --brand-primary-glow: 160, 216, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #8DCAFF,// link color
-  $a2d: #B6E1FF,// link hover/focus color
-  $a3d: #B6E1FF,// link h1-h2 hover/focus color
-  $a4d: #9ED5FF,// link visited color
+  $a1d: #9DD7FF,// link color
+  $a2d: #C9E9FF,// link hover/focus color
+  $a3d: #C9E9FF,// link h1-h2 hover/focus color
+  $a4d: #ADDFFF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #1F63CF,// link color
-  $a2: #2D79EA,// link hover/focus color
-  $a3: #2D79EA,// link h1-h2 hover/focus color
-  $a4: #1F63CF,// link visited color
+  $a1: #2372DE,// link color
+  $a2: #3A8AEE,// link hover/focus color
+  $a3: #3A8AEE,// link h1-h2 hover/focus color
+  $a4: #2372DE,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,15 +20,15 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #3A86F0;
-    --brand-blue-rgb: 58, 134, 240;
-    --brand-blue-glow: 151, 208, 255;
-    --schedule-blue-top: #72B9FF;
-    --schedule-blue-mid: #3E95FF;
-    --schedule-blue-bottom: #2A68E0;
-    --logo-blue-top: #5B9CF2;
-    --logo-blue-mid: #3470D3;
-    --logo-blue-bottom: #1D4DA9;
+    --brand-blue: #3E98FF;
+    --brand-blue-rgb: 62, 152, 255;
+    --brand-blue-glow: 160, 216, 255;
+    --schedule-blue-top: #89CCFF;
+    --schedule-blue-mid: #4AA3FF;
+    --schedule-blue-bottom: #2E73E7;
+    --logo-blue-top: #71B8FF;
+    --logo-blue-mid: #3A7EE6;
+    --logo-blue-bottom: #1B469B;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(162, 215, 255, 0.62) !important;
+    border: 1px solid rgba(171, 221, 255, 0.66) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.24),
+      inset 0 1px 0 rgba(255, 255, 255, 0.26),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 8px 18px rgba(27, 84, 214, 0.42) !important;
+      0 8px 18px rgba(28, 89, 221, 0.44) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #84C5FF 0%, #53A4FF 52%, #3679EA 100%) !important;
+    background-image: linear-gradient(180deg, #97D4FF 0%, #5BB0FF 52%, #3D83EE 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }
@@ -171,12 +171,13 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.58px 0 rgba(208, 230, 255, 0.42),
-        0 1.12px 0 rgba(10, 33, 92, 0.86),
+        0 -0.62px 0 rgba(218, 238, 255, 0.48),
+        0 1.16px 0 rgba(8, 30, 86, 0.88),
         0 2px 4px rgba(2, 8, 24, 0.34),
-        0 8px 18px rgba(5, 14, 38, 0.42),
-       -0.2px 0 0 rgba(95, 166, 255, 0.28),
-        0.2px 0 0 rgba(95, 166, 255, 0.28);
+        0 8px 18px rgba(5, 14, 38, 0.4),
+       -0.22px 0 0 rgba(111, 181, 255, 0.32),
+        0.22px 0 0 rgba(111, 181, 255, 0.32),
+        0 0 1px rgba(88, 165, 255, 0.24);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -313,10 +314,10 @@ html.switch .logo-help {
     -webkit-text-fill-color: currentColor;
     background: none;
     text-shadow:
-        0 -0.46px 0 rgba(200, 228, 255, 0.34),
-        0 1px 0 rgba(13, 39, 108, 0.68),
-        0 2px 4px rgba(2, 8, 24, 0.25),
-        0 0 0.7px rgba(94, 160, 248, 0.3);
+        0 -0.5px 0 rgba(210, 233, 255, 0.4),
+        0 1.04px 0 rgba(11, 36, 102, 0.72),
+        0 2px 4px rgba(2, 8, 24, 0.26),
+        0 0 0.72px rgba(104, 173, 255, 0.34);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
## Summary
- shift IT/HELP, Schedule, and link blues to a stronger signal-cobalt family
- keep role-based depth: deeper logo blue, brighter action blue
- increase logo depth clarity with tuned shadow stack while keeping Safari-safe rendering
- update style documentation and evolution log

## Validation
- zola build passed

## Notes
- red plus stays unchanged and vertically centered
- no new scripts, no CSP-risk changes