### PR TITLE
Royal-cobalt blue pass with stronger dimensional depth

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -258,3 +258,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Shifted shared blue tokens to a brighter signal-cobalt family, increased logo letter depth via highlight/shadow tuning, and aligned Schedule + link ramps to the same hue family with stronger action contrast.
 - Why: Keep cohesion while pushing the palette away from “boring/default blue” toward a cleaner premium look.
 - Rollback: this branch/PR (`codex/ithelp-blue-signature-v5`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Royal-cobalt depth pass (bigger visible shift)
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `STYLE_GUIDE.md`
+- Change: Darkened and saturated the shared blue family to a royal-cobalt profile, deepened logo letter shadows for stronger dimensionality, and retuned Schedule/link blues to remain cohesive while reading less “default sky blue.”
+- Why: Address user feedback that prior changes looked too subtle and still felt visually generic.
+- Rollback: this branch/PR (`codex/ithelp-blue-royal-cobalt-v6`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,24 +4,24 @@ Last updated: 2026-02-08
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (shared hue anchor): `#3E98FF`  
+- Primary Blue (shared hue anchor): `#2F7DF4`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#71B8FF` (`--logo-blue-top`)
-  - Mid: `#3A7EE6` (`--logo-blue-mid`)
-  - Bottom: `#1B469B` (`--logo-blue-bottom`)
+  - Top: `#66A7FF` (`--logo-blue-top`)
+  - Mid: `#2F6FDB` (`--logo-blue-mid`)
+  - Bottom: `#183C8F` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#89CCFF` (`--schedule-blue-top`)
-  - Mid: `#4AA3FF` (`--schedule-blue-mid`)
-  - Bottom: `#2E73E7` (`--schedule-blue-bottom`)
+  - Top: `#6AAFFF` (`--schedule-blue-top`)
+  - Mid: `#337FF5` (`--schedule-blue-mid`)
+  - Bottom: `#1F55C8` (`--schedule-blue-bottom`)
 - Body/Utility Link Blue (same hue family, action-biased):
-  - Dark mode link: `#9DD7FF` (`$a1d`)
-  - Dark mode hover: `#C9E9FF` (`$a2d`)
-  - Light mode link: `#2372DE` (`$a1`)
-  - Light mode hover: `#3A8AEE` (`$a2`)
+  - Dark mode link: `#87C3FF` (`$a1d`)
+  - Dark mode hover: `#B1DAFF` (`$a2d`)
+  - Light mode link: `#1C58C2` (`$a1`)
+  - Light mode hover: `#2B6FD8` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
 - Dark Background: `#0B0B0B`
@@ -35,7 +35,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should remain in the same family even when depth differs by role.
 - Standard text links (including phone/map links) should remain in-family with Schedule blue, only shifting brightness for contrast by theme.
-- Current blue target: signal-cobalt with stronger clarity/energy, no purple cast, and no neon glow.
+- Current blue target: royal-cobalt depth with stronger authority and no purple cast.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #4AA3FF;
-  --brand-primary-rgb: 74, 163, 255;
-  --brand-primary-glow: 160, 216, 255;
+  --brand-primary: #337FF5;
+  --brand-primary-rgb: 51, 127, 245;
+  --brand-primary-glow: 134, 191, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -83,10 +83,10 @@
   $c2d: #171717,// Background Color Secondary
   $c3d: #333333,// Table Rows, Block quote edge, Borders
   $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #9DD7FF,// link color
-  $a2d: #C9E9FF,// link hover/focus color
-  $a3d: #C9E9FF,// link h1-h2 hover/focus color
-  $a4d: #ADDFFF,// link visited color
+  $a1d: #87C3FF,// link color
+  $a2d: #B1DAFF,// link hover/focus color
+  $a3d: #B1DAFF,// link h1-h2 hover/focus color
+  $a4d: #98CEFF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #2372DE,// link color
-  $a2: #3A8AEE,// link hover/focus color
-  $a3: #3A8AEE,// link h1-h2 hover/focus color
-  $a4: #2372DE,// link visited color
+  $a1: #1C58C2,// link color
+  $a2: #2B6FD8,// link hover/focus color
+  $a3: #2B6FD8,// link h1-h2 hover/focus color
+  $a4: #1C58C2,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,15 +20,15 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #3E98FF;
-    --brand-blue-rgb: 62, 152, 255;
-    --brand-blue-glow: 160, 216, 255;
-    --schedule-blue-top: #89CCFF;
-    --schedule-blue-mid: #4AA3FF;
-    --schedule-blue-bottom: #2E73E7;
-    --logo-blue-top: #71B8FF;
-    --logo-blue-mid: #3A7EE6;
-    --logo-blue-bottom: #1B469B;
+    --brand-blue: #2F7DF4;
+    --brand-blue-rgb: 47, 125, 244;
+    --brand-blue-glow: 134, 191, 255;
+    --schedule-blue-top: #6AAFFF;
+    --schedule-blue-mid: #337FF5;
+    --schedule-blue-bottom: #1F55C8;
+    --logo-blue-top: #66A7FF;
+    --logo-blue-mid: #2F6FDB;
+    --logo-blue-bottom: #183C8F;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(171, 221, 255, 0.66) !important;
+    border: 1px solid rgba(149, 204, 255, 0.62) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.26),
+      inset 0 1px 0 rgba(255, 255, 255, 0.22),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 8px 18px rgba(28, 89, 221, 0.44) !important;
+      0 8px 18px rgba(24, 72, 192, 0.46) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #97D4FF 0%, #5BB0FF 52%, #3D83EE 100%) !important;
+    background-image: linear-gradient(180deg, #7DBBFF 0%, #478FF8 52%, #2D66D8 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }
@@ -171,13 +171,13 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.62px 0 rgba(218, 238, 255, 0.48),
-        0 1.16px 0 rgba(8, 30, 86, 0.88),
+        0 -0.58px 0 rgba(198, 223, 255, 0.4),
+        0 1.12px 0 rgba(7, 25, 72, 0.9),
         0 2px 4px rgba(2, 8, 24, 0.34),
-        0 8px 18px rgba(5, 14, 38, 0.4),
-       -0.22px 0 0 rgba(111, 181, 255, 0.32),
-        0.22px 0 0 rgba(111, 181, 255, 0.32),
-        0 0 1px rgba(88, 165, 255, 0.24);
+        0 8px 18px rgba(4, 13, 36, 0.44),
+       -0.2px 0 0 rgba(93, 157, 246, 0.26),
+        0.2px 0 0 rgba(93, 157, 246, 0.26),
+        0 0 0.92px rgba(72, 142, 236, 0.2);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -314,10 +314,10 @@ html.switch .logo-help {
     -webkit-text-fill-color: currentColor;
     background: none;
     text-shadow:
-        0 -0.5px 0 rgba(210, 233, 255, 0.4),
-        0 1.04px 0 rgba(11, 36, 102, 0.72),
+        0 -0.46px 0 rgba(188, 215, 250, 0.34),
+        0 1px 0 rgba(10, 33, 94, 0.66),
         0 2px 4px rgba(2, 8, 24, 0.26),
-        0 0 0.72px rgba(104, 173, 255, 0.34);
+        0 0 0.7px rgba(84, 146, 236, 0.28);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
## Summary
- move the blue system to a darker, richer royal-cobalt profile
- strengthen IT/HELP logo depth and reduce flat sky-blue impression
- keep Schedule and link blues in the same family for cohesion
- update STYLE_GUIDE.md and PROJECT_EVOLUTION_LOG.md

## Validation
- zola build passed

## Why
Prior pass was too subtle in real-world viewing; this pass is intentionally more visible while preserving trust posture and technical gates.