### PR TITLE
Use DNS true-blue anchor and deep navy surfaces for IT/HELP

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -282,3 +282,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Switched IT/HELP letters from flat fill to a 3-stop electric-cobalt gradient fill, boosted schedule/button contrast in the same family, and retuned link blues for full-page cohesion.
 - Why: Prior passes were perceived as too subtle/boring; this pass is intentionally obvious while staying performant and accessibility-safe.
 - Rollback: this branch/PR (`codex/ithelp-logo-dimension-v7`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: DNS-aligned true blue + deep navy background pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `sass/css/abridge.scss`
+  - `sass/_extra.scss`
+  - `STYLE_GUIDE.md`
+- Change: Anchored IT/HELP + Schedule + links to DNS Tool’s non-purple blue family (`#58A6FF` anchor), and shifted site dark surfaces from flat black to deep navy-charcoal (`#0D1117` / `#161B22`) for cleaner contrast and less muddiness.
+- Why: User requested a non-purple blue outcome and approved background changes if needed to reach a polished final look.
+- Rollback: this branch/PR (`codex/ithelp-true-blue-v8`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -4,27 +4,27 @@ Last updated: 2026-02-08
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
 ## Brand Colors
-- Primary Blue (shared hue anchor): `#3A85FF`  
+- Primary Blue (shared hue anchor): `#58A6FF`  
   - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#A9DEFF` (`--logo-blue-top`)
-  - Mid: `#4A8FFF` (`--logo-blue-mid`)
-  - Bottom: `#1F4EC0` (`--logo-blue-bottom`)
+  - Top: `#8ED6FF` (`--logo-blue-top`)
+  - Mid: `#58A6FF` (`--logo-blue-mid`)
+  - Bottom: `#2E72C9` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#8BCBFF` (`--schedule-blue-top`)
-  - Mid: `#4A9CFF` (`--schedule-blue-mid`)
-  - Bottom: `#245FD1` (`--schedule-blue-bottom`)
+  - Top: `#8FD7FF` (`--schedule-blue-top`)
+  - Mid: `#58A6FF` (`--schedule-blue-mid`)
+  - Bottom: `#2F74CF` (`--schedule-blue-bottom`)
 - Body/Utility Link Blue (same hue family, action-biased):
-  - Dark mode link: `#9FD8FF` (`$a1d`)
-  - Dark mode hover: `#CAE9FF` (`$a2d`)
-  - Light mode link: `#2A6FDC` (`$a1`)
-  - Light mode hover: `#3F88EE` (`$a2`)
+  - Dark mode link: `#79B8FF` (`$a1d`)
+  - Dark mode hover: `#A5D0FF` (`$a2d`)
+  - Light mode link: `#2B6FCD` (`$a1`)
+  - Light mode hover: `#4A8EDF` (`$a2`)
 - Gold Accent (reserved accent): `#C2A15A`
 - Plus Red (plus symbol only): `#FF0066`
-- Dark Background: `#0B0B0B`
+- Dark Background: `#0D1117` (primary), `#161B22` (elevated surface)
 - Light Text: `#FFFFFF`
 - Secondary Text: `#B2BAC5` (e.g., "SAN DIEGO")
 
@@ -34,9 +34,10 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
   - Schedule/link actions = brighter action blue.
 - IT/HELP lettering should use a 3-stop gradient fill (top/mid/bottom logo ramp) for clear dimensionality at a glance.
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
+- Current lock target: true non-purple blue aligned to DNS Tool `--status-info` (`#58A6FF`) as the anchor.
 - High-emphasis blue surfaces (IT/HELP lettering and Schedule button) should remain in the same family even when depth differs by role.
 - Standard text links (including phone/map links) should remain in-family with Schedule blue, only shifting brightness for contrast by theme.
-- Current blue target: electric-cobalt clarity with visible depth and no purple cast.
+- Current blue target: DNS-aligned true blue (non-purple), with depth from shading rather than violet tint.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,9 +1,9 @@
 /* --- ALL CUSTOM STYLES --------------------------------------- */
 
 :root {
-  --brand-primary: #4A9CFF;
-  --brand-primary-rgb: 74, 156, 255;
-  --brand-primary-glow: 152, 204, 255;
+  --brand-primary: #58A6FF;
+  --brand-primary-rgb: 88, 166, 255;
+  --brand-primary-glow: 176, 218, 255;
   --brand-accent: #C2A15A;
   --brand-accent-rgb: 194, 161, 90;
   --brand-accent-glow: 224, 197, 138;
@@ -11,8 +11,8 @@
 }
 
 :root:not(.switch) {
-  --a1-rgb: 140, 203, 255;
-  --surface-rgb: 23, 23, 23;
+  --a1-rgb: 88, 166, 255;
+  --surface-rgb: 22, 27, 34;
 }
 
 :root.switch {

--- a/sass/css/abridge.scss
+++ b/sass/css/abridge.scss
@@ -79,14 +79,14 @@
   /// Dark Colors
   $f1d: #E8E8E8,// Font Color Primary
   $f2d: #ffffff,// Font Color Headers
-  $c1d: #111111,// Background Color Primary
-  $c2d: #171717,// Background Color Secondary
-  $c3d: #333333,// Table Rows, Block quote edge, Borders
-  $c4d: #444444,// Disabled Buttons, Borders, mark background
-  $a1d: #9FD8FF,// link color
-  $a2d: #CAE9FF,// link hover/focus color
-  $a3d: #CAE9FF,// link h1-h2 hover/focus color
-  $a4d: #B2E0FF,// link visited color
+  $c1d: #0D1117,// Background Color Primary
+  $c2d: #161B22,// Background Color Secondary
+  $c3d: #30363D,// Table Rows, Block quote edge, Borders
+  $c4d: #3E4550,// Disabled Buttons, Borders, mark background
+  $a1d: #79B8FF,// link color
+  $a2d: #A5D0FF,// link hover/focus color
+  $a3d: #A5D0FF,// link h1-h2 hover/focus color
+  $a4d: #8CC3FF,// link visited color
   //$cgd: #593,// ins green, success
   //$crd: #e33,// del red, errors
 
@@ -97,10 +97,10 @@
   $c2: #F5F5F7,// Background Color Secondary
   $c3: #E5E5E7,// Table Rows, Block quote edge, Borders
   $c4: #E5E5E7,// Disabled Buttons, Borders, mark background
-  $a1: #2A6FDC,// link color
-  $a2: #3F88EE,// link hover/focus color
-  $a3: #3F88EE,// link h1-h2 hover/focus color
-  $a4: #2A6FDC,// link visited color
+  $a1: #2B6FCD,// link color
+  $a2: #4A8EDF,// link hover/focus color
+  $a3: #4A8EDF,// link h1-h2 hover/focus color
+  $a4: #2B6FCD,// link visited color
   //$cg: #373,// ins green, success
   //$cr: #d33,// del red, errors
 

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -20,15 +20,15 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 }
 
 :root {
-    --brand-blue: #3A85FF;
-    --brand-blue-rgb: 58, 133, 255;
-    --brand-blue-glow: 152, 204, 255;
-    --schedule-blue-top: #8BCBFF;
-    --schedule-blue-mid: #4A9CFF;
-    --schedule-blue-bottom: #245FD1;
-    --logo-blue-top: #A9DEFF;
-    --logo-blue-mid: #4A8FFF;
-    --logo-blue-bottom: #1F4EC0;
+    --brand-blue: #58A6FF;
+    --brand-blue-rgb: 88, 166, 255;
+    --brand-blue-glow: 176, 218, 255;
+    --schedule-blue-top: #8FD7FF;
+    --schedule-blue-mid: #58A6FF;
+    --schedule-blue-bottom: #2F74CF;
+    --logo-blue-top: #8ED6FF;
+    --logo-blue-mid: #58A6FF;
+    --logo-blue-bottom: #2E72C9;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(170, 220, 255, 0.66) !important;
+    border: 1px solid rgba(185, 226, 255, 0.66) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.24),
+      inset 0 1px 0 rgba(255, 255, 255, 0.25),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 8px 18px rgba(26, 77, 207, 0.46) !important;
+      0 8px 18px rgba(34, 100, 196, 0.44) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #99D5FF 0%, #5BADFF 52%, #3674E6 100%) !important;
+    background-image: linear-gradient(180deg, #A2DFFF 0%, #68B4FF 52%, #3E86DC 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }
@@ -173,11 +173,11 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.45px 0 rgba(209, 233, 255, 0.44),
-        0 1.1px 0 rgba(8, 26, 76, 0.9),
+        0 -0.44px 0 rgba(205, 232, 255, 0.42),
+        0 1.08px 0 rgba(6, 23, 64, 0.88),
         0 2px 5px rgba(2, 8, 24, 0.34),
-        0 9px 20px rgba(4, 13, 36, 0.44),
-        0 0 12px rgba(78, 153, 255, 0.24);
+        0 9px 20px rgba(4, 12, 32, 0.42),
+        0 0 10px rgba(88, 166, 255, 0.2);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -311,15 +311,15 @@ html.switch .logo-constellation {
 html.switch .logo-it,
 html.switch .logo-help {
     color: var(--logo-blue-mid);
-    background-image: linear-gradient(180deg, #8BC8FF 0%, #3E83F3 52%, #214DAF 100%);
+    background-image: linear-gradient(180deg, #84CCFF 0%, #4B97FF 52%, #2B6BC3 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
-        0 -0.36px 0 rgba(172, 205, 242, 0.26),
-        0 1px 0 rgba(8, 30, 86, 0.62),
+        0 -0.34px 0 rgba(176, 210, 244, 0.24),
+        0 1px 0 rgba(8, 27, 74, 0.62),
         0 2px 4px rgba(2, 8, 24, 0.24),
-        0 0 6px rgba(76, 140, 232, 0.18);
+        0 0 5px rgba(78, 150, 242, 0.16);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
## Summary
- align IT/HELP, Schedule CTA, and links to DNS Tool true-blue anchor (#58A6FF family)
- remove purple drift and keep blue direction unambiguous
- shift dark site surfaces from flat black to deep navy-charcoal for cleaner premium contrast
- keep particle/constellation behavior intact
- update STYLE_GUIDE.md and PROJECT_EVOLUTION_LOG.md

## Validation
- zola build passed

## Context
This pass follows user direction: non-purple blue first, and background allowed to change if needed for a polished result.