### PR TITLE
Darken Schedule CTA to fit deep-navy theme

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -294,3 +294,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Anchored IT/HELP + Schedule + links to DNS Tool’s non-purple blue family (`#58A6FF` anchor), and shifted site dark surfaces from flat black to deep navy-charcoal (`#0D1117` / `#161B22`) for cleaner contrast and less muddiness.
 - Why: User requested a non-purple blue outcome and approved background changes if needed to reach a polished final look.
 - Rollback: this branch/PR (`codex/ithelp-true-blue-v8`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Darken Schedule CTA on navy background
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Darkened Schedule button gradient, border, and glow/shadow intensity to fit the new deep navy surface while preserving high-contrast text and hover affordance.
+- Why: User reported the Schedule button still looked too light against the darker page and wanted a darker, more polished CTA.
+- Rollback: this branch/PR (`codex/ithelp-schedule-darken-v1`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -14,9 +14,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
   - Mid: `#58A6FF` (`--logo-blue-mid`)
   - Bottom: `#2E72C9` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
-  - Top: `#8FD7FF` (`--schedule-blue-top`)
-  - Mid: `#58A6FF` (`--schedule-blue-mid`)
-  - Bottom: `#2F74CF` (`--schedule-blue-bottom`)
+  - Top: `#6CAFEF` (`--schedule-blue-top`)
+  - Mid: `#3F86D8` (`--schedule-blue-mid`)
+  - Bottom: `#2359A9` (`--schedule-blue-bottom`)
 - Body/Utility Link Blue (same hue family, action-biased):
   - Dark mode link: `#79B8FF` (`$a1d`)
   - Dark mode hover: `#A5D0FF` (`$a2d`)
@@ -31,7 +31,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 ## Usage Rules
 - Keep one hue family but use role-based depth:
   - Logo = deeper authority blue.
-  - Schedule/link actions = brighter action blue.
+  - Schedule/link actions = clearly actionable blue, but on dark pages prefer a darker CTA tone to avoid glowing too bright.
 - IT/HELP lettering should use a 3-stop gradient fill (top/mid/bottom logo ramp) for clear dimensionality at a glance.
 - Blue direction: indigo-leaning (avoid consumer "UI chrome" blues and avoid cyan drift).
 - Current lock target: true non-purple blue aligned to DNS Tool `--status-info` (`#58A6FF`) as the anchor.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -23,9 +23,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --brand-blue: #58A6FF;
     --brand-blue-rgb: 88, 166, 255;
     --brand-blue-glow: 176, 218, 255;
-    --schedule-blue-top: #8FD7FF;
-    --schedule-blue-mid: #58A6FF;
-    --schedule-blue-bottom: #2F74CF;
+    --schedule-blue-top: #6CAFEF;
+    --schedule-blue-mid: #3F86D8;
+    --schedule-blue-bottom: #2359A9;
     --logo-blue-top: #8ED6FF;
     --logo-blue-mid: #58A6FF;
     --logo-blue-bottom: #2E72C9;
@@ -54,18 +54,18 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
 .schedule-link {
     background-color: var(--schedule-blue-mid) !important;
     background-image: linear-gradient(180deg, var(--schedule-blue-top) 0%, var(--schedule-blue-mid) 52%, var(--schedule-blue-bottom) 100%) !important;
-    border: 1px solid rgba(185, 226, 255, 0.66) !important;
+    border: 1px solid rgba(138, 186, 238, 0.62) !important;
     color: var(--brand-blue-ink) !important;
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.28);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18),
       0 1px 2px rgba(0, 0, 0, 0.34),
-      0 8px 18px rgba(34, 100, 196, 0.44) !important;
+      0 8px 18px rgba(18, 52, 110, 0.42) !important;
 }
 
 .schedule-link:hover,
 .schedule-link:focus-visible {
-    background-image: linear-gradient(180deg, #A2DFFF 0%, #68B4FF 52%, #3E86DC 100%) !important;
+    background-image: linear-gradient(180deg, #7ABDF8 0%, #4C95E2 52%, #2D68BC 100%) !important;
     color: var(--brand-blue-ink) !important;
     filter: none !important;
 }


### PR DESCRIPTION
## Summary
- darken Schedule button gradient, border, and drop shadow on dark mode
- keep text contrast high and hover state clearly clickable
- keep logo, background, particles, and other blue tokens unchanged
- update STYLE_GUIDE.md and PROJECT_EVOLUTION_LOG.md

## Validation
- zola build passed

## Why
User feedback: Schedule button still looked too light against the new darker page aesthetic.