### PR TITLE
Tighten hero nav geometry and modernize control row

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -304,3 +304,14 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Darkened Schedule button gradient, border, and glow/shadow intensity to fit the new deep navy surface while preserving high-contrast text and hover affordance.
 - Why: User reported the Schedule button still looked too light against the darker page and wanted a darker, more polished CTA.
 - Rollback: this branch/PR (`codex/ithelp-schedule-darken-v1`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Hero control-row geometry + icon modernization
+- Files:
+  - `templates/base.html`
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Rebuilt the nav pill layout as fixed CSS slots (home/more/schedule/mode) so icon spacing is deterministic without manual text spaces, moved `More` + chevron into the same blue family as Schedule, added a deeper nav-shell treatment, and replaced the old filled home glyph with a cleaner outline house icon.
+- Why: User reported spacing fragility and requested a tighter, more modern control row while preserving dark-mode polish and mobile tap ergonomics.
+- Rollback: this branch/PR (`codex/nav-grid-modern-icon-blue-more`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -53,6 +53,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Plus symbol vertical alignment target: `top: -0.055em` on `.logo-plus` to keep optical center aligned with IT/HELP cap height.
 - Keep IT/HELP edge outlining for readability and depth, but tune intensity before adding thickness.
 - Current target is a subdued edge treatment (~25% quieter than the original high-contrast pass) in `static/css/late-overrides.css`.
+- Hero nav row uses fixed slot geometry (home slot, more, schedule, mode slot). Keep spacing in CSS grid; do not add manual whitespace characters in markup to fake alignment.
+- `More` label + chevron should stay in the Schedule blue family for control-row cohesion.
+- Home glyph should stay as a modern outline icon (Apple-style weight/rounding) at a 44px-class touch target on mobile.
 
 ## Accessibility
 - Minimum contrast ratio for normal text: 4.5:1 (WCAG).

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -671,3 +671,120 @@ html:not(.switch) h6 a.gold-link:active {
     text-decoration-thickness: 1px; /* optional: tweak as you like */
     text-underline-offset: 2px;     /* lowers the line a bit (nice on Retina) */
 }
+
+/* Control-deck nav geometry: fixed icon slots, no text spacing hacks. */
+:root {
+    --nav-slot-size-mobile: 2.75rem;
+    --nav-slot-size-desktop: 2.45rem;
+    --nav-row-gap-mobile: 0.58rem;
+    --nav-row-gap-desktop: 0.56rem;
+    --nav-more-blue: var(--schedule-blue-top);
+}
+
+.nav-wrapper {
+    --nav-slot-size: var(--nav-slot-size-mobile);
+    --nav-row-gap: var(--nav-row-gap-mobile);
+    background: linear-gradient(180deg, rgba(24, 38, 60, 0.95) 0%, rgba(13, 23, 38, 0.96) 100%) !important;
+    border: 1px solid rgba(130, 172, 228, 0.26) !important;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.10),
+        inset 0 -1px 0 rgba(2, 8, 18, 0.6),
+        0 10px 24px rgba(2, 8, 18, 0.50),
+        0 2px 6px rgba(0, 0, 0, 0.34) !important;
+}
+
+.nav-wrapper .nav-pill-list {
+    display: grid !important;
+    grid-template-columns: var(--nav-slot-size) max-content max-content var(--nav-slot-size);
+    align-items: center !important;
+    justify-content: center !important;
+    column-gap: var(--nav-row-gap) !important;
+    width: 100% !important;
+    max-width: none !important;
+    padding: 0.08rem 0.56rem !important;
+    margin: 0 !important;
+}
+
+.nav-wrapper .nav-pill-list > li {
+    margin: 0 !important;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.nav-wrapper .nav-home,
+.nav-wrapper .nav-mode {
+    width: var(--nav-slot-size);
+    height: var(--nav-slot-size);
+}
+
+.nav-wrapper .home-icon {
+    width: 100% !important;
+    height: 100% !important;
+    margin: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    color: #F5FAFF !important;
+    border-radius: 0.7rem;
+}
+
+.nav-wrapper .home-icon svg {
+    width: calc(var(--nav-slot-size) * 0.68) !important;
+    height: calc(var(--nav-slot-size) * 0.68) !important;
+    margin: 0 !important;
+    display: block;
+}
+
+.nav-wrapper .nav-mode .mode-btn {
+    width: 100% !important;
+    height: 100% !important;
+    margin: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    font-size: 1.9rem !important;
+    line-height: 1 !important;
+}
+
+.nav-wrapper .nav-more details {
+    display: flex;
+    align-items: center;
+}
+
+.nav-wrapper .dropdown-toggle {
+    color: var(--nav-more-blue) !important;
+    font-weight: 800;
+    letter-spacing: 0.01em;
+    line-height: 1 !important;
+}
+
+.nav-wrapper .dropdown-toggle:hover,
+.nav-wrapper details[open] .dropdown-toggle {
+    color: #A8D7FF !important;
+}
+
+.nav-wrapper details summary {
+    list-style: none;
+}
+
+.nav-wrapper details summary::before {
+    border-right: 2.1px solid currentColor !important;
+    border-bottom: 2.1px solid currentColor !important;
+}
+
+.nav-wrapper ul li a:hover,
+.nav-wrapper ul li a:focus-visible {
+    border-bottom: 0 !important;
+}
+
+@media (min-width: 700px) {
+    .nav-wrapper {
+        --nav-slot-size: var(--nav-slot-size-desktop);
+        --nav-row-gap: var(--nav-row-gap-desktop);
+        width: 352px !important;
+        padding-left: 6px !important;
+        padding-right: 6px !important;
+    }
+}

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -673,15 +673,12 @@ html:not(.switch) h6 a.gold-link:active {
 }
 
 /* Control-deck nav geometry: fixed icon slots, no text spacing hacks. */
-:root {
+.nav-wrapper {
     --nav-slot-size-mobile: 2.75rem;
     --nav-slot-size-desktop: 2.45rem;
     --nav-row-gap-mobile: 0.58rem;
     --nav-row-gap-desktop: 0.56rem;
     --nav-more-blue: var(--schedule-blue-top);
-}
-
-.nav-wrapper {
     --nav-slot-size: var(--nav-slot-size-mobile);
     --nav-row-gap: var(--nav-row-gap-mobile);
     background: linear-gradient(180deg, rgba(24, 38, 60, 0.95) 0%, rgba(13, 23, 38, 0.96) 100%) !important;

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,18 +56,27 @@
   </div>
 
   <nav class="nav-wrapper">
-    <ul>
+    <ul class="nav-pill-list">
       <!-- home icon -->
-      <li>
+      <li class="nav-home">
         <a href="{{ get_url(path='/') }}" aria-label="Home" class="home-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
+          <svg xmlns="http://www.w3.org/2000/svg"
+               viewBox="0 0 24 24"
+               fill="none"
+               stroke="currentColor"
+               stroke-width="1.9"
+               stroke-linecap="round"
+               stroke-linejoin="round"
+               aria-hidden="true">
+            <path d="M3.5 10.5 12 3.5l8.5 7"/>
+            <path d="M5.5 9.5V20.5h13V9.5"/>
+            <path d="M9.5 20.5v-5h5v5"/>
           </svg>
         </a>
       </li>
 
       <!-- dropdown -->
-      <li class="dropdown">
+      <li class="nav-more dropdown">
         <details>
           <summary class="dropdown-toggle">More</summary>
           <ul class="dropdown-content">
@@ -81,14 +90,14 @@
       </li>
 
       <!-- schedule -->
-      <li>
+      <li class="nav-schedule">
         <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener" class="schedule-link">
           Schedule
         </a>
       </li>
 
       <!-- ALWAYS-ON sun / moon toggle -->
-      <li><button id="mode" class="mode-btn" type="button" aria-label="Toggle dark / light"></button></li>
+      <li class="nav-mode"><button id="mode" class="mode-btn" type="button" aria-label="Toggle dark / light"></button></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
## Summary\n- replace fragile nav spacing with fixed-slot grid geometry (home / more / schedule / mode)\n- color-match `More` + chevron to the Schedule blue family\n- modernize home icon to a cleaner outline glyph and keep mobile-friendly hit targets\n- add deeper nav-shell treatment for a tighter, more professional control row\n- document nav geometry rules in STYLE_GUIDE and PROJECT_EVOLUTION_LOG\n\n## Validation\n- zola build