### PR TITLE
Fix hero tagline clarity and spacing after merge

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -318,6 +318,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: Hero readability/breathing correction pass on PR #445
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Removed blur-prone treatment from the hero tagline panel, increased true dark-mode translucency so constellation particles read through cleanly, removed glow blur from tagline highlight words for sharper legibility, restored breathing space between tagline pill and nav row, and increased mobile `san diego` size/placement for better logo ratio.
+- Why: User reported muddy/brown panel tone, blurred highlight words, cramped pill-to-nav spacing, and undersized mobile `san diego`.
+- Rollback: this branch/PR (`codex/hero-panel-and-icon-balance-v1`), commit `58147f3` as immediate pre-fix reference.
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: Hero control-row geometry + icon modernization
 - Files:
   - `templates/base.html`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -54,6 +54,8 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep IT/HELP edge outlining for readability and depth, but tune intensity before adding thickness.
 - Current target is a subdued edge treatment (~25% quieter than the original high-contrast pass) in `static/css/late-overrides.css`.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
+- Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
+- Highlight words inside the hero tagline (`tech problems`, `retainers`) should remain crisp; avoid glow blur on those terms.
 - Keep nav icon slots symmetric; if house vs sun optical size diverges, tune glyph size/stroke, not whitespace hacks.
 - Hero nav row uses fixed slot geometry (home slot, more, schedule, mode slot). Keep spacing in CSS grid; do not add manual whitespace characters in markup to fake alignment.
 - `More` label + chevron should stay in the Schedule blue family for control-row cohesion.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -328,7 +328,7 @@ html.switch .logo-help {
 
 .location {
     font-size: 2.5rem;
-    margin-top: -14px;
+    margin-top: -16px;
     text-transform: lowercase;
     position: relative;
     font-weight: 600;
@@ -350,7 +350,7 @@ html.switch .location {
 }
 
 .tagline {
-    margin-top: 4px;          /* closer to logo */
+    margin-top: 6px;          /* preserve breathing room under location */
     text-align: center;
     font-size: 1.1rem;
     letter-spacing: 0.05em;
@@ -373,12 +373,12 @@ html.switch .location {
     white-space: nowrap;
     color: #fff;
     padding: 10px 20px;
-    background-color: rgba(8, 14, 24, 0.9);
+    background-color: rgba(7, 13, 23, 0.78);
     border-radius: 28px;
-    border: 1px solid rgba(124, 162, 220, 0.22);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    backdrop-filter: blur(1.5px) saturate(110%);
-    -webkit-backdrop-filter: blur(1.5px) saturate(110%);
+    border: 1px solid rgba(120, 161, 220, 0.30);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.07),
+        0 8px 16px rgba(3, 8, 19, 0.34);
 }
 
 /* colour-scheme specific pill styling */
@@ -393,7 +393,7 @@ html.switch .location {
 @media (prefers-color-scheme:dark){
   .tagline-text{
     color:#fff;
-    background-color:rgba(8, 14, 24, 0.9);
+    background-color:rgba(7, 13, 23, 0.78);
   }
 }
 html.switch .tagline-text{
@@ -406,7 +406,7 @@ html.switch .tagline-text{
 }
 html:not(.switch) .tagline-text{
   color:#fff;
-  background-color:rgba(8, 14, 24, 0.9);
+  background-color:rgba(7, 13, 23, 0.78);
 }
 
 .tagline-border::before {
@@ -429,6 +429,12 @@ html:not(.switch) .tagline-text{
     color: var(--accent-gold);
     font-weight: 700;
     text-shadow: 0 0 10px rgba(213, 173, 54, 0.5);
+}
+
+/* Keep tagline highlights crisp: no glow blur on key words. */
+.tagline .highlight {
+    color: #C8A961;
+    text-shadow: none;
 }
 
 /* particles cover full logo box */
@@ -623,11 +629,12 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -12px;
-    font-size:7vw;
+    margin-top: -15px;
+    font-size:7.8vw;
+    letter-spacing: 0.045em;
   }
   .tagline   {
-    margin-top: 3px;
+    margin-top: 5px;
     font-size:4.6vw;
   }
 
@@ -710,6 +717,7 @@ html:not(.switch) h6 a.gold-link:active {
         inset 0 -1px 0 rgba(2, 8, 18, 0.6),
         0 10px 24px rgba(2, 8, 18, 0.50),
         0 2px 6px rgba(0, 0, 0, 0.34) !important;
+    margin: 0.44rem auto 0 !important;
 }
 
 .site-logo {


### PR DESCRIPTION
## Summary\n- remove muddy/soft hero pill look by reducing panel haze effects and restoring crisp text rendering\n- increase readable translucency without blur so constellation motion can show through cleanly\n- restore breathing room between hero tagline pill and nav row\n- improve mobile logo ratio by increasing and repositioning `san diego`\n- keep previous Sonar-clean selector structure\n\n## Validation\n- zola build