### PR TITLE
Retone hero pill to cool blue translucency and crisp gold frame

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -336,3 +336,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Rebuilt the nav pill layout as fixed CSS slots (home/more/schedule/mode) so icon spacing is deterministic without manual text spaces, moved `More` + chevron into the same blue family as Schedule, added a deeper nav-shell treatment, and replaced the old filled home glyph with a cleaner outline house icon.
 - Why: User reported spacing fragility and requested a tighter, more modern control row while preserving dark-mode polish and mobile tap ergonomics.
 - Rollback: this branch/PR (`codex/nav-grid-modern-icon-blue-more`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Hero tagline pill de-muddy pass (blue translucency + crisp gold perimeter)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Kept the hero pill gold frame but made it crisper and more stable, then shifted the dark-mode pill interior from warm/muddy tint to a cool navy-blue translucent gradient so constellation/particle motion remains visible while text contrast stays strong.
+- Why: User reported brown/muddy pill fill and requested a blue-toned transparent interior with clear background-motion visibility, especially on mobile.
+- Rollback: this branch/PR (`codex/hero-pill-blue-translucency-v1`).

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -55,6 +55,8 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Current target is a subdued edge treatment (~25% quieter than the original high-contrast pass) in `static/css/late-overrides.css`.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
+- Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.
+- Hero tagline gold frame should read as a crisp solid perimeter on mobile and desktop.
 - Highlight words inside the hero tagline (`tech problems`, `retainers`) should remain crisp; avoid glow blur on those terms.
 - Keep nav icon slots symmetric; if house vs sun optical size diverges, tune glyph size/stroke, not whitespace hacks.
 - Hero nav row uses fixed slot geometry (home slot, more, schedule, mode slot). Keep spacing in CSS grid; do not add manual whitespace characters in markup to fake alignment.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -363,7 +363,10 @@ html.switch .location {
     display: inline-block; /* pill snaps to content width */
     padding: 2px; /* border thickness */
     border-radius: 30px;
-    background: var(--accent-gold);
+    background: #D2B56F;
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 238, 201, 0.28),
+        0 0 0 1px rgba(49, 36, 12, 0.36);
     position: relative;
     z-index: 0;
 }
@@ -373,12 +376,13 @@ html.switch .location {
     white-space: nowrap;
     color: #fff;
     padding: 10px 20px;
-    background-color: rgba(7, 13, 23, 0.78);
+    background: linear-gradient(180deg, rgba(10, 22, 42, 0.64) 0%, rgba(7, 17, 33, 0.58) 100%);
     border-radius: 28px;
-    border: 1px solid rgba(120, 161, 220, 0.30);
+    border: 1px solid rgba(123, 167, 232, 0.30);
     box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.07),
-        0 8px 16px rgba(3, 8, 19, 0.34);
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 -1px 0 rgba(2, 8, 19, 0.45),
+        0 8px 16px rgba(3, 8, 19, 0.30);
 }
 
 /* colour-scheme specific pill styling */
@@ -393,7 +397,7 @@ html.switch .location {
 @media (prefers-color-scheme:dark){
   .tagline-text{
     color:#fff;
-    background-color:rgba(7, 13, 23, 0.78);
+    background: linear-gradient(180deg, rgba(10, 22, 42, 0.64) 0%, rgba(7, 17, 33, 0.58) 100%);
   }
 }
 html.switch .tagline-text{
@@ -406,7 +410,7 @@ html.switch .tagline-text{
 }
 html:not(.switch) .tagline-text{
   color:#fff;
-  background-color:rgba(7, 13, 23, 0.78);
+  background: linear-gradient(180deg, rgba(10, 22, 42, 0.64) 0%, rgba(7, 17, 33, 0.58) 100%);
 }
 
 .tagline-border::before {


### PR DESCRIPTION
## Summary
- keep the hero pill gold perimeter but make it read as a crisp solid frame across desktop/mobile
- replace the warm/muddy pill interior with a cool navy-blue translucent fill
- keep text/highlight readability while allowing subtle constellation/particle visibility through the panel
- update style guide + evolution log for this visual rule

## Files
- static/css/late-overrides.css
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

## Validation
- zola build