### PR TITLE
Hero pill v2: true gold stroke and cooler blue translucency

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -339,6 +339,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: Hero pill v2 anti-mud pass (true gold stroke + cooler translucency)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Converted hero pill perimeter to an explicit 2px gold border stroke and retuned the interior to a cooler, lighter navy-blue translucent gradient with reduced warm influence, preserving text crispness and particle visibility.
+- Why: User reported the previous pill still read muddy/brown on iPhone and requested a clearer blue-translucent interior with a solid gold line.
+- Rollback: this branch/PR (`codex/hero-pill-cool-blue-v2`).
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: Hero tagline pill de-muddy pass (blue translucency + crisp gold perimeter)
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -57,6 +57,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
 - Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.
 - Hero tagline gold frame should read as a crisp solid perimeter on mobile and desktop.
+- Implement hero tagline perimeter as a true gold border stroke (not a warm fill band) to avoid muddy color bleed on iPhone.
 - Highlight words inside the hero tagline (`tech problems`, `retainers`) should remain crisp; avoid glow blur on those terms.
 - Keep nav icon slots symmetric; if house vs sun optical size diverges, tune glyph size/stroke, not whitespace hacks.
 - Hero nav row uses fixed slot geometry (home slot, more, schedule, mode slot). Keep spacing in CSS grid; do not add manual whitespace characters in markup to fake alignment.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -361,12 +361,11 @@ html.switch .location {
 
 .tagline-border {
     display: inline-block; /* pill snaps to content width */
-    padding: 2px; /* border thickness */
+    padding: 0;
     border-radius: 30px;
-    background: #D2B56F;
-    box-shadow:
-        inset 0 0 0 1px rgba(255, 238, 201, 0.28),
-        0 0 0 1px rgba(49, 36, 12, 0.36);
+    border: 2px solid #D2B56F;
+    background: transparent;
+    box-shadow: 0 0 0 1px rgba(255, 238, 201, 0.14);
     position: relative;
     z-index: 0;
 }
@@ -374,15 +373,15 @@ html.switch .location {
 .tagline-text {
     display: block;
     white-space: nowrap;
+    margin: 1px;
     color: #fff;
     padding: 10px 20px;
-    background: linear-gradient(180deg, rgba(10, 22, 42, 0.64) 0%, rgba(7, 17, 33, 0.58) 100%);
-    border-radius: 28px;
-    border: 1px solid rgba(123, 167, 232, 0.30);
+    background: linear-gradient(180deg, rgba(8, 26, 54, 0.50) 0%, rgba(5, 16, 34, 0.42) 100%);
+    border-radius: 27px;
+    border: 1px solid rgba(130, 180, 246, 0.24);
     box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.08),
-        inset 0 -1px 0 rgba(2, 8, 19, 0.45),
-        0 8px 16px rgba(3, 8, 19, 0.30);
+        inset 0 1px 0 rgba(255, 255, 255, 0.07),
+        0 8px 16px rgba(3, 8, 19, 0.24);
 }
 
 /* colour-scheme specific pill styling */
@@ -397,7 +396,7 @@ html.switch .location {
 @media (prefers-color-scheme:dark){
   .tagline-text{
     color:#fff;
-    background: linear-gradient(180deg, rgba(10, 22, 42, 0.64) 0%, rgba(7, 17, 33, 0.58) 100%);
+    background: linear-gradient(180deg, rgba(8, 26, 54, 0.50) 0%, rgba(5, 16, 34, 0.42) 100%);
   }
 }
 html.switch .tagline-text{
@@ -410,7 +409,7 @@ html.switch .tagline-text{
 }
 html:not(.switch) .tagline-text{
   color:#fff;
-  background: linear-gradient(180deg, rgba(10, 22, 42, 0.64) 0%, rgba(7, 17, 33, 0.58) 100%);
+  background: linear-gradient(180deg, rgba(8, 26, 54, 0.50) 0%, rgba(5, 16, 34, 0.42) 100%);
 }
 
 .tagline-border::before {


### PR DESCRIPTION
## Summary
- convert hero pill perimeter to a true 2px gold stroke for a cleaner line on desktop/mobile
- remove warm/muddy tint by retuning interior to a cooler navy-blue translucent gradient
- keep pill text crisp and readable while preserving subtle background-motion visibility
- no layout or nav geometry changes

## Files
- static/css/late-overrides.css
- STYLE_GUIDE.md
- PROJECT_EVOLUTION_LOG.md

## Validation
- zola build