### PR TITLE
Apply post-455 San Diego hierarchy refinements

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: San Diego hierarchy correction (subdued under primary mark)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Reduced `san diego` brightness/glow and lowered visual weight so it stays legible but clearly subordinate to `IT+HELP`.
+- Why: User feedback showed `san diego` was reading too close to white and visually competing with the main brand text.
+- Rollback: this branch/PR (`codex/plus-jiggle-logo-depth-v1`).
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: San Diego lockup proportional consistency + tighter vertical relationship
 - Files:
   - `static/css/late-overrides.css`

--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: San Diego lockup proportional consistency + tighter vertical relationship
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Raised `san diego` closer to `IT+HELP` and adjusted its desktop/mobile sizing so both breakpoints read as the same proportional lockup.
+- Why: Remove remaining mismatch in logo representation between desktop and mobile while keeping clean hero spacing.
+- Rollback: this branch/PR (`codex/plus-jiggle-logo-depth-v1`).
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: Hero pill edge cleanup + Schedule CTA depth/geometry refinement
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -56,6 +56,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Current target is a subdued edge treatment (~25% quieter than the original high-contrast pass) in `static/css/late-overrides.css`.
 - `san diego` lockup should read as steel-blue gray (not flat gray), with a tight optical gap under IT/HELP and consistent desktop/mobile proportion.
 - Keep the `san diego` size ratio to the IT/HELP mark visually consistent across breakpoints (desktop and mobile should read like the same lockup, not two different logo scales).
+- `san diego` must remain visually subordinate to `IT+HELP`: lower luminance, softer glow, and lighter emphasis than primary brand text.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
 - Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -55,6 +55,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep IT/HELP edge outlining for readability and depth, but tune intensity before adding thickness.
 - Current target is a subdued edge treatment (~25% quieter than the original high-contrast pass) in `static/css/late-overrides.css`.
 - `san diego` lockup should read as steel-blue gray (not flat gray), with a tight optical gap under IT/HELP and consistent desktop/mobile proportion.
+- Keep the `san diego` size ratio to the IT/HELP mark visually consistent across breakpoints (desktop and mobile should read like the same lockup, not two different logo scales).
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
 - Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -353,20 +353,20 @@ html.switch .logo-help {
     line-height: 0.94;
     text-transform: lowercase;
     position: relative;
-    font-weight: 600;
-    color: #a8b9cc;
+    font-weight: 560;
+    color: #8fa2b8;
     letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
     text-shadow:
-        0 -0.32px 0 rgba(214, 226, 240, 0.25),
-        0 1px 0 rgba(7, 17, 34, 0.66),
-        0 0 6px rgba(138, 166, 198, 0.28);
+        0 -0.24px 0 rgba(198, 214, 232, 0.14),
+        0 1px 0 rgba(5, 14, 29, 0.78),
+        0 0 3px rgba(116, 140, 168, 0.18);
 }
 
 html.switch .location {
-    color: #4d5c6d;
-    text-shadow: 0 0 5px rgba(86, 103, 126, 0.22);
+    color: #4b5b6d;
+    text-shadow: 0 0 4px rgba(86, 103, 126, 0.18);
 }
 
 @keyframes shine {

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -348,19 +348,20 @@ html.switch .logo-help {
 
 
 .location {
-    font-size: clamp(2.35rem, 4.75vw, 2.95rem);
-    margin-top: -17px;
+    font-size: clamp(2.22rem, 4.35vw, 2.72rem);
+    margin-top: -20px;
+    line-height: 0.94;
     text-transform: lowercase;
     position: relative;
     font-weight: 600;
     color: #a8b9cc;
-    letter-spacing: 0.042em;
+    letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
     text-shadow:
         0 -0.32px 0 rgba(214, 226, 240, 0.25),
-        0 1px 0 rgba(7, 17, 34, 0.64),
-        0 0 7px rgba(138, 166, 198, 0.32);
+        0 1px 0 rgba(7, 17, 34, 0.66),
+        0 0 6px rgba(138, 166, 198, 0.28);
 }
 
 html.switch .location {
@@ -670,9 +671,10 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -16px;
-    font-size: clamp(1.95rem, 8.7vw, 2.32rem);
-    letter-spacing: 0.042em;
+    margin-top: -20px;
+    font-size: clamp(2.08rem, 9.5vw, 2.40rem);
+    line-height: 0.94;
+    letter-spacing: 0.038em;
   }
   .tagline   {
     margin-top: 5px;


### PR DESCRIPTION
Summary:\n- Bring in the two follow-up commits made after #455 merged.\n- Tighten san diego lockup spacing/scale consistency across desktop and mobile.\n- Subdue san diego brightness/glow so IT+HELP remains dominant.\n\nWhy:\n- #455 merged earlier with only the first commit from this branch.\n- These follow-up refinements are currently on branch only and need a new PR to reach main.\n\nValidation:\n- zola build passed.\n\nFiles:\n- static/css/late-overrides.css\n- STYLE_GUIDE.md\n- PROJECT_EVOLUTION_LOG.md