### PR TITLE
Refine San Diego lockup alignment under IT+HELP

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: San Diego lockup alignment correction (visible pass)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Made a stronger lockup adjustment by raising `san diego` closer to `IT+HELP`, reducing luminance/glow further, rebalancing desktop/mobile size ratio, and adding a slight optical center nudge for better alignment under the composite mark.
+- Why: User feedback indicated previous adjustments were too subtle and still looked misaligned across desktop/mobile.
+- Rollback: this branch/PR (`codex/san-diego-lockup-align-v2`).
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: San Diego hierarchy correction (subdued under primary mark)
 - Files:
   - `static/css/late-overrides.css`

--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: San Diego vertical overshoot correction
+- Files:
+  - `static/css/late-overrides.css`
+- Change: Reduced the prior upward shift of `san diego` to restore breathing room under `IT+HELP` while keeping the lockup tighter than the earlier baseline.
+- Why: Screenshot review showed the previous pass pushed `san diego` too close to the main mark.
+- Rollback: this branch/PR (`codex/san-diego-lockup-align-v2`).
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: San Diego lockup alignment correction (visible pass)
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -57,6 +57,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - `san diego` lockup should read as steel-blue gray (not flat gray), with a tight optical gap under IT/HELP and consistent desktop/mobile proportion.
 - Keep the `san diego` size ratio to the IT/HELP mark visually consistent across breakpoints (desktop and mobile should read like the same lockup, not two different logo scales).
 - `san diego` must remain visually subordinate to `IT+HELP`: lower luminance, softer glow, and lighter emphasis than primary brand text.
+- Apply a small optical center nudge to `san diego` when needed so it sits centered under the composite `IT+HELP` glyph mass, not just mathematically centered text bounds.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
 - Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -348,25 +348,26 @@ html.switch .logo-help {
 
 
 .location {
-    font-size: clamp(2.22rem, 4.35vw, 2.72rem);
-    margin-top: -20px;
+    font-size: clamp(2.08rem, 4.05vw, 2.52rem);
+    margin-top: -26px;
     line-height: 0.94;
     text-transform: lowercase;
     position: relative;
     font-weight: 560;
-    color: #8fa2b8;
+    color: #879ab0;
     letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
+    transform: translateX(0.015em);
     text-shadow:
-        0 -0.24px 0 rgba(198, 214, 232, 0.14),
-        0 1px 0 rgba(5, 14, 29, 0.78),
-        0 0 3px rgba(116, 140, 168, 0.18);
+        0 -0.22px 0 rgba(196, 212, 230, 0.12),
+        0 1px 0 rgba(5, 14, 29, 0.80),
+        0 0 2px rgba(110, 134, 162, 0.16);
 }
 
 html.switch .location {
-    color: #4b5b6d;
-    text-shadow: 0 0 4px rgba(86, 103, 126, 0.18);
+    color: #48586b;
+    text-shadow: 0 0 3px rgba(86, 103, 126, 0.15);
 }
 
 @keyframes shine {
@@ -671,10 +672,11 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -20px;
-    font-size: clamp(2.08rem, 9.5vw, 2.40rem);
+    margin-top: -24px;
+    font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;
+    transform: translateX(0.01em);
   }
   .tagline   {
     margin-top: 5px;

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -349,7 +349,7 @@ html.switch .logo-help {
 
 .location {
     font-size: clamp(2.08rem, 4.05vw, 2.52rem);
-    margin-top: -26px;
+    margin-top: -22px;
     line-height: 0.94;
     text-transform: lowercase;
     position: relative;
@@ -672,7 +672,7 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -24px;
+    margin-top: -21px;
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;


### PR DESCRIPTION
Summary:\n- Correct vertical overshoot from prior pass by lowering san diego slightly while keeping a tight lockup.\n- Preserve hierarchy: san diego remains visually subordinate to IT+HELP.\n\nValidation:\n- zola build passed.\n\nFiles:\n- static/css/late-overrides.css\n- PROJECT_EVOLUTION_LOG.md