### PR TITLE
Fix San Diego optical centering under IT+HELP

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-08
 - Actor: AI+Developer
+- Scope: San Diego optical center correction (left shift)
+- Files:
+  - `static/css/late-overrides.css`
+- Change: Shifted `san diego` slightly left at desktop and mobile breakpoints to better align with the composite `IT+HELP` glyph mass.
+- Why: Screenshot review showed lockup still reading off-center even after spacing/size corrections.
+- Rollback: this branch/PR (`codex/san-diego-optical-center-v3`).
+
+### 2026-02-08
+- Actor: AI+Developer
 - Scope: San Diego vertical overshoot correction
 - Files:
   - `static/css/late-overrides.css`

--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -454,3 +454,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Kept the hero pill gold frame but made it crisper and more stable, then shifted the dark-mode pill interior from warm/muddy tint to a cool navy-blue translucent gradient so constellation/particle motion remains visible while text contrast stays strong.
 - Why: User reported brown/muddy pill fill and requested a blue-toned transparent interior with clear background-motion visibility, especially on mobile.
 - Rollback: this branch/PR (`codex/hero-pill-blue-translucency-v1`).
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: San Diego lockup de-compression and hierarchy correction
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Lowered `san diego` placement on desktop/mobile to remove the scrunched look under `IT+HELP`, and reduced its luminance/glow so it stays visibly subordinate to the primary logo text.
+- Why: User feedback showed the lockup was over-tight and `san diego` was popping too close to body-white levels.
+- Rollback: this branch/PR (`codex/san-diego-optical-center-v3`), commit `02ef35b` as pre-adjust reference.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -58,6 +58,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep the `san diego` size ratio to the IT/HELP mark visually consistent across breakpoints (desktop and mobile should read like the same lockup, not two different logo scales).
 - `san diego` must remain visually subordinate to `IT+HELP`: lower luminance, softer glow, and lighter emphasis than primary brand text.
 - Apply a small optical center nudge to `san diego` when needed so it sits centered under the composite `IT+HELP` glyph mass, not just mathematically centered text bounds.
+- Keep vertical lockup breathing room: `san diego` should never touch/scrunch into `IT+HELP`; favor a slightly lower placement over over-tight stacking.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
 - Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -349,20 +349,20 @@ html.switch .logo-help {
 
 .location {
     font-size: clamp(2.08rem, 4.05vw, 2.52rem);
-    margin-top: -22px;
+    margin-top: -17px;
     line-height: 0.94;
     text-transform: lowercase;
     position: relative;
-    font-weight: 560;
-    color: #879ab0;
+    font-weight: 550;
+    color: #7f92a9;
     letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
     transform: translateX(-0.012em);
     text-shadow:
-        0 -0.22px 0 rgba(196, 212, 230, 0.12),
-        0 1px 0 rgba(5, 14, 29, 0.80),
-        0 0 2px rgba(110, 134, 162, 0.16);
+        0 -0.18px 0 rgba(188, 205, 226, 0.10),
+        0 1px 0 rgba(4, 12, 27, 0.74),
+        0 0 1.5px rgba(90, 112, 140, 0.12);
 }
 
 html.switch .location {
@@ -672,7 +672,7 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -21px;
+    margin-top: -17px;
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -358,7 +358,7 @@ html.switch .logo-help {
     letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
-    transform: translateX(0.015em);
+    transform: translateX(-0.012em);
     text-shadow:
         0 -0.22px 0 rgba(196, 212, 230, 0.12),
         0 1px 0 rgba(5, 14, 29, 0.80),
@@ -676,7 +676,7 @@ html.switch .particle {
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;
-    transform: translateX(0.01em);
+    transform: translateX(-0.018em);
   }
   .tagline   {
     margin-top: 5px;


### PR DESCRIPTION
Summary:\n- Apply a focused optical-centering correction for san diego under the composite IT+HELP mark.\n- Shift san diego slightly left on desktop and mobile to resolve residual off-center appearance.\n\nValidation:\n- zola build passed.\n\nFiles:\n- static/css/late-overrides.css\n- PROJECT_EVOLUTION_LOG.md