### PR TITLE
Lower and subdue San Diego lockup under IT+HELP

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -464,3 +464,13 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Lowered `san diego` placement on desktop/mobile to remove the scrunched look under `IT+HELP`, and reduced its luminance/glow so it stays visibly subordinate to the primary logo text.
 - Why: User feedback showed the lockup was over-tight and `san diego` was popping too close to body-white levels.
 - Rollback: this branch/PR (`codex/san-diego-optical-center-v3`), commit `02ef35b` as pre-adjust reference.
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Stronger vertical drop + stronger tonal separation for `san diego`
+- Files:
+  - `static/css/late-overrides.css`
+  - `PROJECT_EVOLUTION_LOG.md`
+- Change: Dropped `san diego` further away from `IT+HELP` on desktop and mobile (`margin-top` relaxed by ~5-6px) and darkened/desaturated the label/shadow so it no longer reads as the same visual tier as the primary mark.
+- Why: User confirmed the lockup still looked too tight and that `san diego` remained too close to the IT/HELP color family.
+- Rollback: this branch/PR (`codex/san-diego-drop-and-separate-v1`), previous baseline commit `8ceadfa`.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -349,25 +349,25 @@ html.switch .logo-help {
 
 .location {
     font-size: clamp(2.08rem, 4.05vw, 2.52rem);
-    margin-top: -17px;
+    margin-top: -11px;
     line-height: 0.94;
     text-transform: lowercase;
     position: relative;
-    font-weight: 550;
-    color: #7f92a9;
+    font-weight: 545;
+    color: #6f8299;
     letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
     transform: translateX(-0.012em);
     text-shadow:
-        0 -0.18px 0 rgba(188, 205, 226, 0.10),
-        0 1px 0 rgba(4, 12, 27, 0.74),
-        0 0 1.5px rgba(90, 112, 140, 0.12);
+        0 -0.14px 0 rgba(170, 188, 210, 0.08),
+        0 1px 0 rgba(4, 11, 24, 0.78),
+        0 0 1px rgba(78, 98, 124, 0.08);
 }
 
 html.switch .location {
-    color: #48586b;
-    text-shadow: 0 0 3px rgba(86, 103, 126, 0.15);
+    color: #445467;
+    text-shadow: 0 0 2px rgba(76, 94, 116, 0.13);
 }
 
 @keyframes shine {
@@ -672,7 +672,7 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -17px;
+    margin-top: -12px;
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;


### PR DESCRIPTION
Summary:\n- lower san diego further on desktop and mobile to remove remaining scrunch under IT+HELP\n- darken/desaturate san diego so it reads clearly subordinate to the primary logo text\n- log change in PROJECT_EVOLUTION_LOG.md\n\nValidation:\n- zola build passed