### PR TITLE
Refine San Diego centering parity and steel-gray separation

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -474,3 +474,14 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Dropped `san diego` further away from `IT+HELP` on desktop and mobile (`margin-top` relaxed by ~5-6px) and darkened/desaturated the label/shadow so it no longer reads as the same visual tier as the primary mark.
 - Why: User confirmed the lockup still looked too tight and that `san diego` remained too close to the IT/HELP color family.
 - Rollback: this branch/PR (`codex/san-diego-drop-and-separate-v1`), previous baseline commit `8ceadfa`.
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Cross-breakpoint centering parity + steel-gray `san diego` tone
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+  - `PROJECT_EVOLUTION_LOG.md`
+- Change: Unified desktop/mobile `san diego` horizontal nudge and vertical offset to the same lockup logic, then shifted `san diego` to a clearer steel gray-blue tone with softer shadow so it reads as a secondary line rather than the same brand-blue tier as `IT+HELP`.
+- Why: User requested matching centering behavior across desktop/mobile and clearer color separation from the IT/HELP logo fill.
+- Rollback: this branch/PR (`codex/san-diego-center-and-steel-v2`), baseline commit `bbdd35d`.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -59,6 +59,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - `san diego` must remain visually subordinate to `IT+HELP`: lower luminance, softer glow, and lighter emphasis than primary brand text.
 - Apply a small optical center nudge to `san diego` when needed so it sits centered under the composite `IT+HELP` glyph mass, not just mathematically centered text bounds.
 - Keep vertical lockup breathing room: `san diego` should never touch/scrunch into `IT+HELP`; favor a slightly lower placement over over-tight stacking.
+- Tone target for `san diego`: steel gray-blue (not brand-logo blue) so hierarchy stays clear even when the lockup is centered and tight.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.
 - Hero tagline panel interior in dark mode should stay cool navy-blue translucent; avoid warm/brown casts.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -354,20 +354,20 @@ html.switch .logo-help {
     text-transform: lowercase;
     position: relative;
     font-weight: 545;
-    color: #6f8299;
+    color: #687688;
     letter-spacing: 0.038em;
     margin-left: auto;
     margin-right: auto;
-    transform: translateX(-0.012em);
+    transform: translateX(-0.01em);
     text-shadow:
-        0 -0.14px 0 rgba(170, 188, 210, 0.08),
-        0 1px 0 rgba(4, 11, 24, 0.78),
-        0 0 1px rgba(78, 98, 124, 0.08);
+        0 -0.14px 0 rgba(158, 174, 194, 0.08),
+        0 1px 0 rgba(4, 10, 22, 0.80),
+        0 0 1px rgba(70, 86, 110, 0.07);
 }
 
 html.switch .location {
-    color: #445467;
-    text-shadow: 0 0 2px rgba(76, 94, 116, 0.13);
+    color: #404d5b;
+    text-shadow: 0 0 2px rgba(66, 82, 102, 0.12);
 }
 
 @keyframes shine {
@@ -672,11 +672,11 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -12px;
+    margin-top: -11px;
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;
-    transform: translateX(-0.018em);
+    transform: translateX(-0.01em);
   }
   .tagline   {
     margin-top: 5px;


### PR DESCRIPTION
Summary:\n- unify San Diego centering nudge across desktop and mobile for consistent lockup alignment\n- shift San Diego to a clearer steel gray-blue tone so it is visibly distinct from IT+HELP brand blue\n- keep hierarchy subordinate while preserving readability\n- update STYLE_GUIDE and PROJECT_EVOLUTION_LOG\n\nValidation:\n- zola build passed