### PR TITLE
Rebalance hero vertical spacing across logo, tagline, and nav

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -495,3 +495,14 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 - Change: Lowered `san diego` by an additional 2px on desktop and mobile (`margin-top: -11px -> -9px`) to add breathing room above the tagline pill while preserving centering and hierarchy tuning from the previous pass.
 - Why: User confirmed overall direction but requested a small additional downward move because the logo lockup still felt slightly tight.
 - Rollback: this branch/PR (`codex/san-diego-micro-drop-v1`), baseline commit `0aa7dac`.
+
+### 2026-02-08
+- Actor: AI+Developer
+- Scope: Hero stack rhythm rebalance (logo block -> tagline pill -> nav pill)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+  - `PROJECT_EVOLUTION_LOG.md`
+- Change: Lowered `san diego` another step (`margin-top: -9px -> -6px` desktop/mobile), increased logo-to-tagline spacing (`.tagline margin-top` desktop/mobile), and increased tagline-to-nav separation (`.nav-wrapper margin-top`) so the lockup reads as three clean tiers without descender collisions.
+- Why: User reported the `g` descender in `san diego` still touching/crowding the gold tagline pill and requested full top-down spacing normalization.
+- Rollback: this branch/PR (`codex/hero-stack-spacing-v1`), baseline commit `5901cf7`.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -59,6 +59,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - `san diego` must remain visually subordinate to `IT+HELP`: lower luminance, softer glow, and lighter emphasis than primary brand text.
 - Apply a small optical center nudge to `san diego` when needed so it sits centered under the composite `IT+HELP` glyph mass, not just mathematically centered text bounds.
 - Keep vertical lockup breathing room: `san diego` should never touch/scrunch into `IT+HELP`; favor a slightly lower placement over over-tight stacking.
+- Keep explicit descender clearance: the `g` in `san diego` should never approach the hero tagline border; preserve visible gap in both desktop and mobile lockups.
 - Tone target for `san diego`: steel gray-blue (not brand-logo blue) so hierarchy stays clear even when the lockup is centered and tight.
 - Hero tagline panel should remain dark-first and high-legibility, but may use light translucency in dark mode; do not make it fully transparent.
 - Hero tagline panel should be translucent enough to reveal background motion subtly, but never use backdrop blur that softens tagline readability.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -349,7 +349,7 @@ html.switch .logo-help {
 
 .location {
     font-size: clamp(2.08rem, 4.05vw, 2.52rem);
-    margin-top: -9px;
+    margin-top: -6px;
     line-height: 0.94;
     text-transform: lowercase;
     position: relative;
@@ -376,7 +376,7 @@ html.switch .location {
 }
 
 .tagline {
-    margin-top: 6px;          /* preserve breathing room under location */
+    margin-top: 10px;         /* preserve clear descender clearance under "san diego" */
     text-align: center;
     font-size: 1.1rem;
     letter-spacing: 0.05em;
@@ -672,14 +672,14 @@ html.switch .particle {
   /* bigger, bolder */
   .main-logo {font-size:20vw;}
   .location  {
-    margin-top: -9px;
+    margin-top: -6px;
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);
     line-height: 0.94;
     letter-spacing: 0.038em;
     transform: translateX(-0.01em);
   }
   .tagline   {
-    margin-top: 5px;
+    margin-top: 8px;
     font-size:4.6vw;
   }
 
@@ -762,7 +762,7 @@ html:not(.switch) h6 a.gold-link:active {
         inset 0 -1px 0 rgba(2, 8, 18, 0.66),
         0 7px 16px rgba(2, 8, 18, 0.45),
         0 2px 5px rgba(0, 0, 0, 0.30) !important;
-    margin: 0.44rem auto 0 !important;
+    margin: 0.56rem auto 0 !important;
 }
 
 .site-logo {


### PR DESCRIPTION
Summary:\n- lower san diego another step to remove descender crowding against the tagline pill\n- increase logo-to-tagline spacing for clean lockup breathing room\n- increase tagline-to-nav separation so the hero reads as three distinct tiers\n- update STYLE_GUIDE and PROJECT_EVOLUTION_LOG\n\nValidation:\n- zola build passed