### PR TITLE
Refine San Diego to tagline vertical clearance

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-02-09
+- Actor: AI+Developer
+- Scope: San Diego-to-tagline clearance refinement
+- Files:
+  - `static/css/late-overrides.css`
+- Change: Increased hero tagline top spacing on desktop and mobile so the `san diego` descenders hold a clearer visual gap above the pill border while preserving existing lockup centering and hierarchy.
+- Why: Continue vertical rhythm tuning from PR `#463` so spacing reads cleanly in real desktop and iPhone renderings.
+- Rollback: this branch/PR (`codex/san-diego-descender-clearance-v1`, PR `#463`).
+
 ### 2026-02-08
 - Actor: AI+Developer
 - Scope: San Diego optical center correction (left shift)

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -376,7 +376,7 @@ html.switch .location {
 }
 
 .tagline {
-    margin-top: 13px;         /* extra clearance below descenders in "san diego" */
+    margin-top: 15px;         /* preserve visible descender clearance under "san diego" */
     text-align: center;
     font-size: 1.1rem;
     letter-spacing: 0.05em;
@@ -679,7 +679,7 @@ html.switch .particle {
     transform: translateX(-0.01em);
   }
   .tagline   {
-    margin-top: 11px;
+    margin-top: 13px;
     font-size:4.6vw;
   }
 


### PR DESCRIPTION
## Summary\n- increase hero tagline top margin on desktop from 13px to 15px\n- increase hero tagline top margin on mobile from 11px to 13px\n- keep lockup centering and hierarchy untouched\n- add project evolution log entry for the refinement\n\n## Validation\n- zola build