### PR TITLE
Refine IT+HELP wordmark contour and cobalt tone

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-09
 - Actor: AI+Developer
+- Scope: IT/HELP wordmark refinement (crisper contour + cobalt ramp)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Tightened IT/HELP letter contour/depth shadows for cleaner edge definition and shifted logo blues to a richer cobalt ramp (dark and light theme variants) while keeping the red plus and `san diego` treatment unchanged.
+- Why: Improve perceived polish and reduce the slightly gray/soft impression in the primary brand wordmark.
+- Rollback: this branch/PR (`codex/ithelp-wordmark-refine-v1`).
+
+### 2026-02-09
+- Actor: AI+Developer
 - Scope: In-content gold CTA depth/geometry refinement
 - Files:
   - `sass/_extra.scss`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#7FBDFE` (`--logo-blue-top`)
-  - Mid: `#4A8EF2` (`--logo-blue-mid`)
-  - Bottom: `#225CAE` (`--logo-blue-bottom`)
+  - Top: `#8FC9FF` (`--logo-blue-top`)
+  - Mid: `#5A9CF6` (`--logo-blue-mid`)
+  - Bottom: `#2B68BF` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #7FBDFE;
-    --logo-blue-mid: #4A8EF2;
-    --logo-blue-bottom: #225CAE;
+    --logo-blue-top: #8FC9FF;
+    --logo-blue-mid: #5A9CF6;
+    --logo-blue-bottom: #2B68BF;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -169,7 +169,7 @@ html.switch .logo-constellation {
     font-weight: 900;
     font-size: 5rem;
     letter-spacing: 0;
-    --logo-letter-spacing: 0.012em;
+    --logo-letter-spacing: 0.01em;
     --logo-plus-gap: 0em;
     position: relative;
     display: inline-block;
@@ -183,18 +183,20 @@ html.switch .logo-constellation {
 .logo-it,
 .logo-help {
     color: var(--logo-blue-mid);
-    background-image: linear-gradient(180deg, var(--logo-blue-top) 0%, var(--logo-blue-mid) 52%, var(--logo-blue-bottom) 100%);
+    background-image: linear-gradient(180deg, var(--logo-blue-top) 0%, var(--logo-blue-mid) 50%, var(--logo-blue-bottom) 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.5px 0 rgba(206, 230, 252, 0.42),
-        0 1.14px 0 rgba(4, 17, 52, 0.92),
-        0 2.4px 6px rgba(2, 8, 24, 0.40),
-        0 10px 22px rgba(4, 12, 32, 0.46),
-        0 0 8px rgba(74, 142, 242, 0.14);
+        0 -0.4px 0 rgba(206, 230, 252, 0.36),
+        -0.32px 0 0 rgba(126, 169, 229, 0.24),
+         0.32px 0 0 rgba(126, 169, 229, 0.24),
+        0 1px 0 rgba(4, 17, 52, 0.90),
+        0 2px 5px rgba(2, 8, 24, 0.34),
+        0 7px 16px rgba(4, 12, 32, 0.38),
+        0 0 4px rgba(74, 142, 242, 0.1);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -332,15 +334,17 @@ html.switch .logo-constellation {
 html.switch .logo-it,
 html.switch .logo-help {
     color: var(--logo-blue-mid);
-    background-image: linear-gradient(180deg, #78B7EB 0%, #3E7FDC 52%, #2156A7 100%);
+    background-image: linear-gradient(180deg, #89C3F5 0%, #4D8FE1 50%, #2866B7 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
-        0 -0.34px 0 rgba(176, 210, 244, 0.24),
-        0 1px 0 rgba(8, 27, 74, 0.62),
-        0 2px 4px rgba(2, 8, 24, 0.24),
-        0 0 5px rgba(78, 150, 242, 0.16);
+        0 -0.28px 0 rgba(176, 210, 244, 0.24),
+        -0.24px 0 0 rgba(104, 149, 210, 0.16),
+         0.24px 0 0 rgba(104, 149, 210, 0.16),
+        0 1px 0 rgba(8, 27, 74, 0.60),
+        0 2px 4px rgba(2, 8, 24, 0.2),
+        0 5px 11px rgba(12, 30, 65, 0.14);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
## Summary
- sharpen IT+HELP contour treatment for a crisper, less hazy finish
- shift logo ramp to a richer cobalt blue while staying in the established hue family
- keep red plus unchanged and keep san diego styling unchanged
- update STYLE_GUIDE and PROJECT_EVOLUTION_LOG per visual change workflow

## Validation
- zola build