### PR TITLE
Apply premium-dark navy finish to IT+HELP wordmark

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-09
 - Actor: AI+Developer
+- Scope: IT/HELP premium-dark navy variant
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Shifted IT/HELP logo ramp to deeper navy-cobalt values and reduced gloss intensity in contour/depth shadows (dark and light theme variants) to produce a calmer, more finished premium-dark wordmark.
+- Why: User requested a less shiny, deeper navy treatment to improve perceived refinement of the primary logo text.
+- Rollback: this branch/PR (`codex/ithelp-premium-dark-v1`).
+
+### 2026-02-09
+- Actor: AI+Developer
 - Scope: IT/HELP wordmark refinement (crisper contour + cobalt ramp)
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#8FC9FF` (`--logo-blue-top`)
-  - Mid: `#5A9CF6` (`--logo-blue-mid`)
-  - Bottom: `#2B68BF` (`--logo-blue-bottom`)
+  - Top: `#7DB4ED` (`--logo-blue-top`)
+  - Mid: `#3D79CC` (`--logo-blue-mid`)
+  - Bottom: `#1C4F9D` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)
@@ -42,6 +42,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
+- Current IT/HELP finish target: premium-dark navy depth with low-gloss edge highlights (reduce sparkle before increasing contrast).
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.
 - Gold-forward fallback snapshot (if we intentionally choose that direction): `main@a3b9ea2` from PR `#430`; use it as the restore baseline for logo color treatment.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #8FC9FF;
-    --logo-blue-mid: #5A9CF6;
-    --logo-blue-bottom: #2B68BF;
+    --logo-blue-top: #7DB4ED;
+    --logo-blue-mid: #3D79CC;
+    --logo-blue-bottom: #1C4F9D;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -190,13 +190,13 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.4px 0 rgba(206, 230, 252, 0.36),
-        -0.32px 0 0 rgba(126, 169, 229, 0.24),
-         0.32px 0 0 rgba(126, 169, 229, 0.24),
-        0 1px 0 rgba(4, 17, 52, 0.90),
-        0 2px 5px rgba(2, 8, 24, 0.34),
-        0 7px 16px rgba(4, 12, 32, 0.38),
-        0 0 4px rgba(74, 142, 242, 0.1);
+        0 -0.3px 0 rgba(196, 224, 252, 0.24),
+        -0.28px 0 0 rgba(112, 156, 220, 0.17),
+         0.28px 0 0 rgba(112, 156, 220, 0.17),
+        0 0.95px 0 rgba(3, 14, 44, 0.88),
+        0 2px 4px rgba(2, 8, 24, 0.30),
+        0 6px 14px rgba(4, 12, 32, 0.34),
+        0 0 2px rgba(70, 132, 224, 0.06);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -334,17 +334,17 @@ html.switch .logo-constellation {
 html.switch .logo-it,
 html.switch .logo-help {
     color: var(--logo-blue-mid);
-    background-image: linear-gradient(180deg, #89C3F5 0%, #4D8FE1 50%, #2866B7 100%);
+    background-image: linear-gradient(180deg, #79AEE0 0%, #3E78C8 50%, #22589F 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
-        0 -0.28px 0 rgba(176, 210, 244, 0.24),
-        -0.24px 0 0 rgba(104, 149, 210, 0.16),
-         0.24px 0 0 rgba(104, 149, 210, 0.16),
-        0 1px 0 rgba(8, 27, 74, 0.60),
-        0 2px 4px rgba(2, 8, 24, 0.2),
-        0 5px 11px rgba(12, 30, 65, 0.14);
+        0 -0.22px 0 rgba(170, 204, 238, 0.18),
+        -0.2px 0 0 rgba(94, 138, 198, 0.12),
+         0.2px 0 0 rgba(94, 138, 198, 0.12),
+        0 0.9px 0 rgba(8, 24, 68, 0.54),
+        0 1.8px 3.6px rgba(2, 8, 24, 0.16),
+        0 4px 9px rgba(10, 26, 56, 0.10);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
## Summary
- shift IT+HELP logo ramp to deeper navy-cobalt values
- reduce gloss/sheen in wordmark shadow stack for a calmer finish
- keep red plus unchanged and keep san diego styling unchanged
- update style guide and evolution log for the new finish target

## Validation
- zola build