### PR TITLE
Test micro gold-trace on IT+HELP wordmark

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-09
 - Actor: AI+Developer
+- Scope: IT/HELP micro gold-trace experiment
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Added a restrained top-biased gold micro-trace to IT/HELP letter shadow stacks (dark + light variants) while keeping core navy fill, red plus, and `san diego` unchanged.
+- Why: Evaluate whether a tight gold edge cue increases perceived finish/premium quality without introducing noisy full-stroke artifacts.
+- Rollback: this branch/PR (`codex/ithelp-gold-trace-v1`).
+
+### 2026-02-09
+- Actor: AI+Developer
 - Scope: IT/HELP head-anchor presence pass
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -43,6 +43,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Current IT/HELP finish target: premium-dark navy depth with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).
+- IT/HELP gold treatment, if used, should be a micro-trace only (top/upper edges, sub-pixel feel), never a full heavy outline.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.
 - Gold-forward fallback snapshot (if we intentionally choose that direction): `main@a3b9ea2` from PR `#430`; use it as the restore baseline for logo color treatment.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -190,6 +190,9 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
+        0 -0.48px 0 rgba(194, 161, 90, 0.34),
+        -0.26px -0.16px 0 rgba(194, 161, 90, 0.24),
+         0.26px -0.16px 0 rgba(194, 161, 90, 0.24),
         0 -0.3px 0 rgba(196, 224, 252, 0.26),
         -0.28px 0 0 rgba(112, 156, 220, 0.18),
          0.28px 0 0 rgba(112, 156, 220, 0.18),
@@ -339,6 +342,9 @@ html.switch .logo-help {
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
+        0 -0.4px 0 rgba(194, 161, 90, 0.26),
+        -0.22px -0.14px 0 rgba(194, 161, 90, 0.18),
+         0.22px -0.14px 0 rgba(194, 161, 90, 0.18),
         0 -0.22px 0 rgba(170, 204, 238, 0.18),
         -0.2px 0 0 rgba(94, 138, 198, 0.12),
          0.2px 0 0 rgba(94, 138, 198, 0.12),


### PR DESCRIPTION
## Summary
- add a tight, top-biased gold micro-trace to IT+HELP letter shadows
- keep navy fill, red plus, and san diego unchanged
- avoid heavy full outlines; this is a restrained finishing cue only
- update style guide and evolution log

## Validation
- zola build