### PR TITLE
Tune IT+HELP to blue-dominant micro-trace with kerning

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-09
 - Actor: AI+Developer
+- Scope: IT/HELP blue-dominant micro-trace + kerning pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Rebalanced IT/HELP to stay clearly blue-first while retaining only a tiny gold edge cue, and introduced global micro-kerning/optical offset tuning (desktop + mobile) for tighter, more finished glyph geometry.
+- Why: User feedback indicated the prior pass read too gold; objective was blue letterfill with a subtle premium trace and cleaner optical spacing.
+- Rollback: this branch/PR (`codex/ithelp-blue-trace-kerning-v1`).
+
+### 2026-02-09
+- Actor: AI+Developer
 - Scope: IT/HELP micro gold-trace experiment
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -42,8 +42,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
-- Current IT/HELP finish target: premium-dark navy depth with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).
-- IT/HELP gold treatment, if used, should be a micro-trace only (top/upper edges, sub-pixel feel), never a full heavy outline.
+- Current IT/HELP finish target: blue-dominant fill with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).
+- IT/HELP gold treatment, if used, should be a micro-trace only (top/upper edges, sub-pixel feel), never a full heavy outline or gold-dominant read.
+- Apply micro-kerning and optical offsets to IT/HELP consistently across desktop and mobile; avoid relying on one breakpoint tune.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.
 - Gold-forward fallback snapshot (if we intentionally choose that direction): `main@a3b9ea2` from PR `#430`; use it as the restore baseline for logo color treatment.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -167,9 +167,11 @@ html.switch .logo-constellation {
 .main-logo {
     font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, 'Helvetica Neue', Arial, sans-serif;
     font-weight: 900;
-    font-size: 5.3rem;
+    font-size: 5.36rem;
     letter-spacing: 0;
-    --logo-letter-spacing: 0.009em;
+    --logo-letter-spacing: 0.0084em;
+    --logo-it-shift: 0.092em;
+    --logo-help-shift: -0.024em;
     --logo-plus-gap: 0em;
     position: relative;
     display: inline-block;
@@ -190,12 +192,12 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.48px 0 rgba(194, 161, 90, 0.34),
-        -0.26px -0.16px 0 rgba(194, 161, 90, 0.24),
-         0.26px -0.16px 0 rgba(194, 161, 90, 0.24),
-        0 -0.3px 0 rgba(196, 224, 252, 0.26),
-        -0.28px 0 0 rgba(112, 156, 220, 0.18),
-         0.28px 0 0 rgba(112, 156, 220, 0.18),
+        0 -0.34px 0 rgba(194, 161, 90, 0.16),
+        -0.18px -0.10px 0 rgba(194, 161, 90, 0.11),
+         0.18px -0.10px 0 rgba(194, 161, 90, 0.11),
+        0 -0.3px 0 rgba(196, 224, 252, 0.30),
+        -0.26px 0 0 rgba(112, 156, 220, 0.19),
+         0.26px 0 0 rgba(112, 156, 220, 0.19),
         0 0.95px 0 rgba(3, 14, 44, 0.88),
         0 2px 4px rgba(2, 8, 24, 0.30),
         0 6px 14px rgba(4, 12, 32, 0.34),
@@ -208,11 +210,11 @@ html.switch .logo-constellation {
 }
 
 .logo-it {
-    left: 0.1em;
+    left: var(--logo-it-shift);
 }
 
 .logo-help {
-    left: -0.03em;
+    left: var(--logo-help-shift);
 }
 
 .logo-it::before,
@@ -342,12 +344,12 @@ html.switch .logo-help {
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
-        0 -0.4px 0 rgba(194, 161, 90, 0.26),
-        -0.22px -0.14px 0 rgba(194, 161, 90, 0.18),
-         0.22px -0.14px 0 rgba(194, 161, 90, 0.18),
-        0 -0.22px 0 rgba(170, 204, 238, 0.18),
-        -0.2px 0 0 rgba(94, 138, 198, 0.12),
-         0.2px 0 0 rgba(94, 138, 198, 0.12),
+        0 -0.28px 0 rgba(194, 161, 90, 0.12),
+        -0.16px -0.09px 0 rgba(194, 161, 90, 0.08),
+         0.16px -0.09px 0 rgba(194, 161, 90, 0.08),
+        0 -0.22px 0 rgba(170, 204, 238, 0.20),
+        -0.2px 0 0 rgba(94, 138, 198, 0.13),
+         0.2px 0 0 rgba(94, 138, 198, 0.13),
         0 0.9px 0 rgba(8, 24, 68, 0.54),
         0 1.8px 3.6px rgba(2, 8, 24, 0.16),
         0 4px 9px rgba(10, 26, 56, 0.10);
@@ -680,7 +682,12 @@ html.switch .particle {
   }
 
   /* bigger, bolder */
-  .main-logo {font-size:20.4vw;}
+  .main-logo {
+    font-size: 20.6vw;
+    --logo-letter-spacing: 0.0082em;
+    --logo-it-shift: 0.09em;
+    --logo-help-shift: -0.022em;
+  }
   .location  {
     margin-top: -6px;
     font-size: clamp(2.22rem, 10.2vw, 2.58rem);


### PR DESCRIPTION
## Summary
- keep IT+HELP clearly blue-dominant and reduce gold trace intensity to micro-edge only
- apply global micro-kerning and optical offsets for IT and HELP across desktop/mobile
- keep red plus and san diego treatment unchanged
- update style guide and evolution log

## Validation
- zola build