### PR TITLE
De-yellow IT+HELP while keeping micro-kerning

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-09
 - Actor: AI+Developer
+- Scope: IT/HELP de-yellow correction (blue-first with ultra-faint trace)
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Reduced gold trace contribution to a single very low-alpha top cue and restored a brighter blue logo ramp so IT/HELP reads clearly blue at normal viewing distance while retaining micro-kerning/offset tuning.
+- Why: User feedback showed the prior pass still looked too yellow in real-device renderings.
+- Rollback: this branch/PR (`codex/ithelp-deyellow-v1`).
+
+### 2026-02-09
+- Actor: AI+Developer
 - Scope: IT/HELP blue-dominant micro-trace + kerning pass
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#7DB4ED` (`--logo-blue-top`)
-  - Mid: `#3D79CC` (`--logo-blue-mid`)
-  - Bottom: `#1C4F9D` (`--logo-blue-bottom`)
+  - Top: `#90C7FA` (`--logo-blue-top`)
+  - Mid: `#4A86D8` (`--logo-blue-mid`)
+  - Bottom: `#1F56A8` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)
@@ -43,7 +43,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Current IT/HELP finish target: blue-dominant fill with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).
-- IT/HELP gold treatment, if used, should be a micro-trace only (top/upper edges, sub-pixel feel), never a full heavy outline or gold-dominant read.
+- IT/HELP gold treatment, if used, should be an ultra-faint micro-trace only (single top cue, near-invisible at normal distance), never a full heavy outline or gold-dominant read.
 - Apply micro-kerning and optical offsets to IT/HELP consistently across desktop and mobile; avoid relying on one breakpoint tune.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #7DB4ED;
-    --logo-blue-mid: #3D79CC;
-    --logo-blue-bottom: #1C4F9D;
+    --logo-blue-top: #90C7FA;
+    --logo-blue-mid: #4A86D8;
+    --logo-blue-bottom: #1F56A8;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -192,9 +192,7 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.34px 0 rgba(194, 161, 90, 0.16),
-        -0.18px -0.10px 0 rgba(194, 161, 90, 0.11),
-         0.18px -0.10px 0 rgba(194, 161, 90, 0.11),
+        0 -0.28px 0 rgba(194, 161, 90, 0.07),
         0 -0.3px 0 rgba(196, 224, 252, 0.30),
         -0.26px 0 0 rgba(112, 156, 220, 0.19),
          0.26px 0 0 rgba(112, 156, 220, 0.19),
@@ -339,14 +337,12 @@ html.switch .logo-constellation {
 html.switch .logo-it,
 html.switch .logo-help {
     color: var(--logo-blue-mid);
-    background-image: linear-gradient(180deg, #79AEE0 0%, #3E78C8 50%, #22589F 100%);
+    background-image: linear-gradient(180deg, #8FC6F6 0%, #4A8CD9 50%, #245EA9 100%);
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
-        0 -0.28px 0 rgba(194, 161, 90, 0.12),
-        -0.16px -0.09px 0 rgba(194, 161, 90, 0.08),
-         0.16px -0.09px 0 rgba(194, 161, 90, 0.08),
+        0 -0.22px 0 rgba(194, 161, 90, 0.05),
         0 -0.22px 0 rgba(170, 204, 238, 0.20),
         -0.2px 0 0 rgba(94, 138, 198, 0.13),
          0.2px 0 0 rgba(94, 138, 198, 0.13),


### PR DESCRIPTION
## Summary
- remove yellow cast from IT+HELP by reducing gold edge contribution to near-invisible top cue
- restore brighter blue logo ramp so letterfill reads clearly blue
- keep micro-kerning/optical offsets in place across desktop/mobile
- keep red plus and san diego unchanged

## Validation
- zola build