### PR TITLE
Add ultra-faint wraparound gold trace to IT+HELP

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-09
 - Actor: AI+Developer
+- Scope: IT/HELP wraparound micro-trace refinement
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Replaced the single top gold cue with an ultra-low-alpha 360-degree sub-pixel trace around IT/HELP glyph edges (dark + light variants) while preserving blue-dominant fill and existing kerning/offset geometry.
+- Why: User requested visible per-letter gold outlining without reintroducing an overall yellow/gold cast.
+- Rollback: this branch/PR (`codex/ithelp-gold-outline-micro-v1`).
+
+### 2026-02-09
+- Actor: AI+Developer
 - Scope: IT/HELP de-yellow correction (blue-first with ultra-faint trace)
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -43,7 +43,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Current IT/HELP finish target: blue-dominant fill with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).
-- IT/HELP gold treatment, if used, should be an ultra-faint micro-trace only (single top cue, near-invisible at normal distance), never a full heavy outline or gold-dominant read.
+- IT/HELP gold treatment, if used, should be an ultra-faint sub-pixel wrap trace (all sides with very low alpha), never a full heavy outline or gold-dominant read.
 - Apply micro-kerning and optical offsets to IT/HELP consistently across desktop and mobile; avoid relying on one breakpoint tune.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -192,7 +192,14 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.28px 0 rgba(194, 161, 90, 0.07),
+        -0.18px 0 0 rgba(194, 161, 90, 0.055),
+         0.18px 0 0 rgba(194, 161, 90, 0.055),
+        0 -0.18px 0 rgba(194, 161, 90, 0.075),
+        0  0.18px 0 rgba(194, 161, 90, 0.035),
+        -0.16px -0.16px 0 rgba(194, 161, 90, 0.048),
+         0.16px -0.16px 0 rgba(194, 161, 90, 0.048),
+        -0.16px  0.16px 0 rgba(194, 161, 90, 0.028),
+         0.16px  0.16px 0 rgba(194, 161, 90, 0.028),
         0 -0.3px 0 rgba(196, 224, 252, 0.30),
         -0.26px 0 0 rgba(112, 156, 220, 0.19),
          0.26px 0 0 rgba(112, 156, 220, 0.19),
@@ -342,7 +349,14 @@ html.switch .logo-help {
     background-clip: text;
     -webkit-text-fill-color: transparent;
     text-shadow:
-        0 -0.22px 0 rgba(194, 161, 90, 0.05),
+        -0.15px 0 0 rgba(194, 161, 90, 0.045),
+         0.15px 0 0 rgba(194, 161, 90, 0.045),
+        0 -0.15px 0 rgba(194, 161, 90, 0.06),
+        0  0.15px 0 rgba(194, 161, 90, 0.03),
+        -0.13px -0.13px 0 rgba(194, 161, 90, 0.038),
+         0.13px -0.13px 0 rgba(194, 161, 90, 0.038),
+        -0.13px  0.13px 0 rgba(194, 161, 90, 0.022),
+         0.13px  0.13px 0 rgba(194, 161, 90, 0.022),
         0 -0.22px 0 rgba(170, 204, 238, 0.20),
         -0.2px 0 0 rgba(94, 138, 198, 0.13),
          0.2px 0 0 rgba(94, 138, 198, 0.13),


### PR DESCRIPTION
## Summary
- keep IT+HELP blue-dominant
- replace top-only gold cue with a very low-alpha wraparound micro trace on all glyph edges
- preserve existing micro-kerning and optical offsets
- keep red plus and san diego unchanged

## Validation
- zola build