### PR TITLE
Retune IT+HELP to deeper blue and smoother P edges

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP darker blue cohesion + P artifact cleanup
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Returned IT/HELP blue tokens to a deeper palette and replaced the dense directional gold text-shadow ring with a balanced drop-shadow perimeter model (dark + light variants) to smooth curved letter edges while preserving visible thin gold trim.
+- Why: User feedback indicated the prior pass looked too light blue and still showed top-edge artifacting on `P`.
+- Rollback: this branch/PR (`codex/ithelp-p-clean-darkblue-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP Safari artifact kill + headline emphasis pass
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#A8D6FF` (`--logo-blue-top`)
-  - Mid: `#6AAAF5` (`--logo-blue-mid`)
-  - Bottom: `#3476D0` (`--logo-blue-bottom`)
+  - Top: `#90C7FA` (`--logo-blue-top`)
+  - Mid: `#4F8EDD` (`--logo-blue-mid`)
+  - Bottom: `#245EA9` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)
@@ -46,6 +46,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - IT/HELP gold treatment, if used, should be a thin perimeter band around glyph edges (all sides) with blue fill visually dominant.
 - Build the strip as a larger outer gold ring under a smaller inner blue contour ring in `text-shadow` order so the perimeter remains visible in Safari.
 - Keep perimeter ring weights top/bottom balanced to avoid rough edge artifacts on rounded glyph shoulders (especially `P`) on desktop Safari.
+- Prefer a drop-shadow perimeter ring for IT/HELP edge treatment when Safari shows curved-edge artifacts from dense directional text-shadow stacks.
 - Apply micro-kerning and optical offsets to IT/HELP consistently across desktop and mobile; avoid relying on one breakpoint tune.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #A8D6FF;
-    --logo-blue-mid: #6AAAF5;
-    --logo-blue-bottom: #3476D0;
+    --logo-blue-top: #90C7FA;
+    --logo-blue-mid: #4F8EDD;
+    --logo-blue-bottom: #245EA9;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-rgb: 194, 161, 90;
@@ -192,28 +192,20 @@ html.switch .logo-constellation {
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        /* compact inner contour keeps blue fill readable and crisp */
-        -0.22px 0 0 rgba(6, 20, 46, 0.48),
-         0.22px 0 0 rgba(6, 20, 46, 0.48),
-        0 -0.22px 0 rgba(6, 20, 46, 0.46),
-        0  0.22px 0 rgba(6, 20, 46, 0.38),
-        -0.20px -0.20px 0 rgba(6, 20, 46, 0.40),
-         0.20px -0.20px 0 rgba(6, 20, 46, 0.40),
-        -0.20px  0.20px 0 rgba(6, 20, 46, 0.32),
-         0.20px  0.20px 0 rgba(6, 20, 46, 0.32),
-        /* slightly thicker, balanced gold perimeter for cleaner ring visibility */
-        -0.64px 0 0 rgba(194, 161, 90, 0.76),
-         0.64px 0 0 rgba(194, 161, 90, 0.76),
-        0 -0.64px 0 rgba(194, 161, 90, 0.76),
-        0  0.64px 0 rgba(194, 161, 90, 0.64),
-        -0.56px -0.56px 0 rgba(194, 161, 90, 0.68),
-         0.56px -0.56px 0 rgba(194, 161, 90, 0.68),
-        -0.56px  0.56px 0 rgba(194, 161, 90, 0.56),
-         0.56px  0.56px 0 rgba(194, 161, 90, 0.56),
-        0 -0.18px 0 rgba(220, 239, 255, 0.36),
+        0 -0.16px 0 rgba(204, 230, 255, 0.30),
         0 0.95px 0 rgba(3, 14, 44, 0.84),
         0 3px 6px rgba(2, 8, 24, 0.26),
         0 8px 16px rgba(4, 12, 32, 0.28);
+    filter:
+        drop-shadow(-0.58px 0 0 rgba(194, 161, 90, 0.76))
+        drop-shadow(0.58px 0 0 rgba(194, 161, 90, 0.76))
+        drop-shadow(0 -0.58px 0 rgba(194, 161, 90, 0.72))
+        drop-shadow(0 0.58px 0 rgba(194, 161, 90, 0.62))
+        drop-shadow(-0.50px -0.50px 0 rgba(194, 161, 90, 0.68))
+        drop-shadow(0.50px -0.50px 0 rgba(194, 161, 90, 0.68))
+        drop-shadow(-0.50px 0.50px 0 rgba(194, 161, 90, 0.56))
+        drop-shadow(0.50px 0.50px 0 rgba(194, 161, 90, 0.56))
+        drop-shadow(0 0 0.9px rgba(194, 161, 90, 0.14));
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -350,32 +342,26 @@ html.switch .logo-constellation {
 
 html.switch .logo-it,
 html.switch .logo-help {
-    color: #4C86D2;
+    color: #3F78C1;
     background-image: none;
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
     text-shadow:
-        -0.20px 0 0 rgba(20, 44, 82, 0.38),
-         0.20px 0 0 rgba(20, 44, 82, 0.38),
-        0 -0.20px 0 rgba(20, 44, 82, 0.36),
-        0  0.20px 0 rgba(20, 44, 82, 0.30),
-        -0.18px -0.18px 0 rgba(20, 44, 82, 0.30),
-         0.18px -0.18px 0 rgba(20, 44, 82, 0.30),
-        -0.18px  0.18px 0 rgba(20, 44, 82, 0.24),
-         0.18px  0.18px 0 rgba(20, 44, 82, 0.24),
-        -0.52px 0 0 rgba(194, 161, 90, 0.56),
-         0.52px 0 0 rgba(194, 161, 90, 0.56),
-        0 -0.52px 0 rgba(194, 161, 90, 0.56),
-        0  0.52px 0 rgba(194, 161, 90, 0.46),
-        -0.46px -0.46px 0 rgba(194, 161, 90, 0.50),
-         0.46px -0.46px 0 rgba(194, 161, 90, 0.50),
-        -0.46px  0.46px 0 rgba(194, 161, 90, 0.40),
-         0.46px  0.46px 0 rgba(194, 161, 90, 0.40),
-        0 -0.14px 0 rgba(192, 223, 252, 0.28),
+        0 -0.14px 0 rgba(198, 226, 252, 0.24),
         0 0.8px 0 rgba(8, 24, 68, 0.50),
         0 1.6px 3.2px rgba(2, 8, 24, 0.14),
         0 4px 9px rgba(10, 26, 56, 0.08);
+    filter:
+        drop-shadow(-0.50px 0 0 rgba(194, 161, 90, 0.60))
+        drop-shadow(0.50px 0 0 rgba(194, 161, 90, 0.60))
+        drop-shadow(0 -0.50px 0 rgba(194, 161, 90, 0.56))
+        drop-shadow(0 0.50px 0 rgba(194, 161, 90, 0.48))
+        drop-shadow(-0.42px -0.42px 0 rgba(194, 161, 90, 0.52))
+        drop-shadow(0.42px -0.42px 0 rgba(194, 161, 90, 0.52))
+        drop-shadow(-0.42px 0.42px 0 rgba(194, 161, 90, 0.42))
+        drop-shadow(0.42px 0.42px 0 rgba(194, 161, 90, 0.42))
+        drop-shadow(0 0 0.7px rgba(194, 161, 90, 0.10));
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
Summary:\n- restore IT/HELP to deeper blue tokens for better page palette cohesion\n- replace dense directional perimeter stack with a balanced drop-shadow gold ring to smooth curved letter edges\n- keep blue solid-fill Safari-stable rendering path and visible thin gold trim\n- apply matching edge treatment in light-theme logo styles\n- update style guide and project evolution log\n\nValidation:\n- zola build