### PR TITLE
Force visible gold wrap on IT+HELP with explicit stroke

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP explicit gold stroke visibility pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Replaced IT/HELP drop-shadow perimeter ring with direct `-webkit-text-stroke` gold outlines (dark + light variants) keyed to `--accent-gold-solid`, while retaining blue fill and depth shadows.
+- Why: User reported no visible gold perimeter after repeated ring-shadow passes and requested a clearly solid wrap comparable to the hero pill border.
+- Rollback: this branch/PR (`codex/ithelp-explicit-gold-stroke-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP solid gold wrap visibility pass
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -40,7 +40,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Standard text links (including phone/map links) should remain in-family with Schedule blue, only shifting brightness for contrast by theme.
 - Current blue target: DNS-aligned true blue (non-purple), with depth from shading rather than violet tint.
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
-- Prefer shadow-based edge treatment for IT/HELP lettering; avoid `-webkit-text-stroke` on logo glyphs because it can introduce Safari artifacts (notably on curved letters like `P`).
+- Prefer shadow-based edge treatment for IT/HELP lettering by default; if gold wrap remains imperceptible, use a controlled `-webkit-text-stroke` pass (roughly `0.8px`-`1.0px`) with solid fill and no glow-heavy stack.
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Current IT/HELP finish target: blue-dominant fill with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).
@@ -49,6 +49,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Keep perimeter ring weights top/bottom balanced to avoid rough edge artifacts on rounded glyph shoulders (especially `P`) on desktop Safari.
 - Prefer a drop-shadow perimeter ring for IT/HELP edge treatment when Safari shows curved-edge artifacts from dense directional text-shadow stacks.
 - When the ring reads too faint, match the glyph perimeter color to the hero pill gold stroke (`#D2B56F`) before increasing blur or glow.
+- If visibility is still insufficient after ring tuning, apply direct stroke using `--accent-gold-solid` so gold perimeter remains unmistakable across desktop/mobile.
 - Apply micro-kerning and optical offsets to IT/HELP consistently across desktop and mobile; avoid relying on one breakpoint tune.
 - Avoid silver/steel casts in IT/HELP lettering by keeping cool overlay alpha restrained.
 - Keep logo rendering Safari-stable: use solid indigo fill + shadow depth and avoid `background-clip:text` gradients on IT/HELP glyphs.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -190,23 +190,16 @@ html.switch .logo-constellation {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
+    -webkit-text-stroke: 0.92px var(--accent-gold-solid);
+    paint-order: stroke fill;
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 -0.16px 0 rgba(204, 230, 255, 0.30),
+        0 -0.16px 0 rgba(204, 230, 255, 0.28),
         0 0.95px 0 rgba(3, 14, 44, 0.84),
         0 3px 6px rgba(2, 8, 24, 0.26),
         0 8px 16px rgba(4, 12, 32, 0.28);
-    filter:
-        drop-shadow(-0.72px 0 0 rgba(210, 181, 111, 0.96))
-        drop-shadow(0.72px 0 0 rgba(210, 181, 111, 0.96))
-        drop-shadow(0 -0.72px 0 rgba(210, 181, 111, 0.94))
-        drop-shadow(0 0.72px 0 rgba(210, 181, 111, 0.88))
-        drop-shadow(-0.64px -0.64px 0 rgba(210, 181, 111, 0.92))
-        drop-shadow(0.64px -0.64px 0 rgba(210, 181, 111, 0.92))
-        drop-shadow(-0.64px 0.64px 0 rgba(210, 181, 111, 0.86))
-        drop-shadow(0.64px 0.64px 0 rgba(210, 181, 111, 0.86))
-        drop-shadow(0 0 1.2px rgba(210, 181, 111, 0.22));
+    filter: none;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -348,21 +341,14 @@ html.switch .logo-help {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
+    -webkit-text-stroke: 0.82px var(--accent-gold-solid);
+    paint-order: stroke fill;
     text-shadow:
         0 -0.14px 0 rgba(198, 226, 252, 0.24),
         0 0.8px 0 rgba(8, 24, 68, 0.50),
         0 1.6px 3.2px rgba(2, 8, 24, 0.14),
         0 4px 9px rgba(10, 26, 56, 0.08);
-    filter:
-        drop-shadow(-0.64px 0 0 rgba(210, 181, 111, 0.78))
-        drop-shadow(0.64px 0 0 rgba(210, 181, 111, 0.78))
-        drop-shadow(0 -0.64px 0 rgba(210, 181, 111, 0.76))
-        drop-shadow(0 0.64px 0 rgba(210, 181, 111, 0.68))
-        drop-shadow(-0.56px -0.56px 0 rgba(210, 181, 111, 0.72))
-        drop-shadow(0.56px -0.56px 0 rgba(210, 181, 111, 0.72))
-        drop-shadow(-0.56px 0.56px 0 rgba(210, 181, 111, 0.62))
-        drop-shadow(0.56px 0.56px 0 rgba(210, 181, 111, 0.62))
-        drop-shadow(0 0 1.0px rgba(210, 181, 111, 0.16));
+    filter: none;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
Summary:\n- switch IT/HELP perimeter from shadow ring model to direct gold text stroke for guaranteed visibility\n- keep blue letter fill and existing depth shadows\n- use pillbox gold token --accent-gold-solid for stroke match\n- apply matching stroke widths in dark and light logo variants\n- update style guide and evolution log\n\nValidation:\n- zola build