### PR TITLE
Finalize IT+HELP perimeter closure and headline pop

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP perimeter closure + blue depth rebalance
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Switched IT/HELP stroke rendering to `paint-order: fill stroke` with near-1px gold strokes and a subtle downward gold micro-shadow so the perimeter reads as a complete wrap (including bottom edges). Also nudged logo blue ramp slightly darker for stronger headline presence.
+- Why: User feedback showed bottom outline segments were still weak and the interior blue read too light.
+- Rollback: this branch/PR (`codex/ithelp-gold-stroke-polish-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP gold stroke cleanup and solidity pass
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#90C7FA` (`--logo-blue-top`)
-  - Mid: `#4F8EDD` (`--logo-blue-mid`)
-  - Bottom: `#245EA9` (`--logo-blue-bottom`)
+  - Top: `#88BFF4` (`--logo-blue-top`)
+  - Mid: `#4684D2` (`--logo-blue-mid`)
+  - Bottom: `#215AA7` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)
@@ -42,6 +42,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering by default; if gold wrap remains imperceptible, use a controlled `-webkit-text-stroke` pass (roughly `0.8px`-`1.0px`) with solid fill and no glow-heavy stack.
 - For solid premium outlines, use near-integer stroke widths (`~1px`) with a tiny gold smoothing halo; avoid thin sub-pixel strokes that can look jagged.
+- If bottom edges look weak, render stroke on top (`paint-order: fill stroke`) and keep a subtle downward gold micro-shadow to preserve full perimeter closure.
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Current IT/HELP finish target: blue-dominant fill with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #90C7FA;
-    --logo-blue-mid: #4F8EDD;
-    --logo-blue-bottom: #245EA9;
+    --logo-blue-top: #88BFF4;
+    --logo-blue-mid: #4684D2;
+    --logo-blue-bottom: #215AA7;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-solid: #D2B56F;
@@ -190,17 +190,17 @@ html.switch .logo-constellation {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.08px var(--accent-gold-solid);
-    paint-order: stroke fill;
+    -webkit-text-stroke: 1.12px var(--accent-gold-solid);
+    paint-order: fill stroke;
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 0 0.60px rgba(210, 181, 111, 0.82),
-        0 0 1.10px rgba(210, 181, 111, 0.34),
-        0 -0.14px 0 rgba(204, 230, 255, 0.24),
-        0 0.95px 0 rgba(3, 14, 44, 0.84),
-        0 3px 6px rgba(2, 8, 24, 0.26),
-        0 8px 16px rgba(4, 12, 32, 0.28);
+        0 0 0.46px rgba(210, 181, 111, 0.76),
+        0 0.42px 0 rgba(210, 181, 111, 0.74),
+        0 -0.12px 0 rgba(204, 230, 255, 0.22),
+        0 0.76px 0 rgba(3, 14, 44, 0.72),
+        0 2.4px 5px rgba(2, 8, 24, 0.22),
+        0 7px 14px rgba(4, 12, 32, 0.24);
     filter: none;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
@@ -338,18 +338,18 @@ html.switch .logo-constellation {
 
 html.switch .logo-it,
 html.switch .logo-help {
-    color: #3F78C1;
+    color: #3B74BC;
     background-image: none;
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 0.98px var(--accent-gold-solid);
-    paint-order: stroke fill;
+    -webkit-text-stroke: 1.02px var(--accent-gold-solid);
+    paint-order: fill stroke;
     text-shadow:
-        0 0 0.48px rgba(210, 181, 111, 0.72),
-        0 0 0.90px rgba(210, 181, 111, 0.26),
-        0 -0.14px 0 rgba(198, 226, 252, 0.24),
-        0 0.8px 0 rgba(8, 24, 68, 0.50),
+        0 0 0.40px rgba(210, 181, 111, 0.66),
+        0 0.36px 0 rgba(210, 181, 111, 0.64),
+        0 -0.12px 0 rgba(198, 226, 252, 0.20),
+        0 0.72px 0 rgba(8, 24, 68, 0.46),
         0 1.6px 3.2px rgba(2, 8, 24, 0.14),
         0 4px 9px rgba(10, 26, 56, 0.08);
     filter: none;


### PR DESCRIPTION
Summary:\n- ensure gold perimeter reads fully closed (including bottom edges) by switching to paint-order fill stroke and tuning stroke widths\n- slightly darken logo blue ramp for stronger headline presence while staying in-family\n- refine gold micro-shadow support for cleaner edge continuity\n- update style guide and evolution log\n\nValidation:\n- zola build