### PR TITLE
Fix IT+HELP P horseshoe artifact and tune blue depth

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP horseshoe artifact cleanup + blue pop tune
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Switched wordmark stroke rendering back to `paint-order: stroke fill` to remove inner `P` horseshoe artifacts, added a downward-only gold micro-shadow for lower-edge closure, and nudged the logo blue ramp darker for stronger headline pop.
+- Why: User feedback confirmed the prior pass reintroduced a `P` horseshoe artifact and still needed richer blue emphasis.
+- Rollback: this branch/PR (`codex/ithelp-p-horseshoe-fix-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP perimeter closure + blue depth rebalance
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#88BFF4` (`--logo-blue-top`)
-  - Mid: `#4684D2` (`--logo-blue-mid`)
-  - Bottom: `#215AA7` (`--logo-blue-bottom`)
+  - Top: `#82B8EE` (`--logo-blue-top`)
+  - Mid: `#3F79C6` (`--logo-blue-mid`)
+  - Bottom: `#1F539E` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)
@@ -42,7 +42,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Render IT/HELP letters as a single text layer; avoid duplicated pseudo-text overlays that can create ghosting on retina and screenshot captures.
 - Prefer shadow-based edge treatment for IT/HELP lettering by default; if gold wrap remains imperceptible, use a controlled `-webkit-text-stroke` pass (roughly `0.8px`-`1.0px`) with solid fill and no glow-heavy stack.
 - For solid premium outlines, use near-integer stroke widths (`~1px`) with a tiny gold smoothing halo; avoid thin sub-pixel strokes that can look jagged.
-- If bottom edges look weak, render stroke on top (`paint-order: fill stroke`) and keep a subtle downward gold micro-shadow to preserve full perimeter closure.
+- To avoid inner horseshoe artifacts on curved glyphs (notably `P`), prefer `paint-order: stroke fill`; if bottom edges read weak, add only a subtle downward gold micro-shadow.
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.
 - IT/HELP lettering should favor stable depth (tonal fill + restrained edge) over attention-grabbing glow.
 - Current IT/HELP finish target: blue-dominant fill with strong silhouette presence (slightly larger wordmark, restrained gloss, crisp contour).

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #88BFF4;
-    --logo-blue-mid: #4684D2;
-    --logo-blue-bottom: #215AA7;
+    --logo-blue-top: #82B8EE;
+    --logo-blue-mid: #3F79C6;
+    --logo-blue-bottom: #1F539E;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-solid: #D2B56F;
@@ -190,18 +190,16 @@ html.switch .logo-constellation {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.12px var(--accent-gold-solid);
-    paint-order: fill stroke;
+    -webkit-text-stroke: 1.16px var(--accent-gold-solid);
+    paint-order: stroke fill;
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 0 0.46px rgba(210, 181, 111, 0.76),
-        0 0.42px 0 rgba(210, 181, 111, 0.74),
-        0 -0.12px 0 rgba(204, 230, 255, 0.22),
-        0 0.76px 0 rgba(3, 14, 44, 0.72),
+        0 -0.10px 0 rgba(204, 230, 255, 0.18),
+        0 0.82px 0 rgba(3, 14, 44, 0.74),
         0 2.4px 5px rgba(2, 8, 24, 0.22),
         0 7px 14px rgba(4, 12, 32, 0.24);
-    filter: none;
+    filter: drop-shadow(0 0.52px 0 rgba(210, 181, 111, 0.62));
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;
@@ -338,21 +336,19 @@ html.switch .logo-constellation {
 
 html.switch .logo-it,
 html.switch .logo-help {
-    color: #3B74BC;
+    color: #366CB2;
     background-image: none;
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.02px var(--accent-gold-solid);
-    paint-order: fill stroke;
+    -webkit-text-stroke: 1.06px var(--accent-gold-solid);
+    paint-order: stroke fill;
     text-shadow:
-        0 0 0.40px rgba(210, 181, 111, 0.66),
-        0 0.36px 0 rgba(210, 181, 111, 0.64),
-        0 -0.12px 0 rgba(198, 226, 252, 0.20),
+        0 -0.10px 0 rgba(198, 226, 252, 0.18),
         0 0.72px 0 rgba(8, 24, 68, 0.46),
         0 1.6px 3.2px rgba(2, 8, 24, 0.14),
         0 4px 9px rgba(10, 26, 56, 0.08);
-    filter: none;
+    filter: drop-shadow(0 0.42px 0 rgba(210, 181, 111, 0.52));
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     animation: none;


### PR DESCRIPTION
Summary:\n- remove inner P horseshoe artifacts by switching stroke rendering back to paint-order: stroke fill\n- preserve full wrap feel with a subtle downward-only gold micro-shadow\n- nudge logo blue ramp slightly darker for stronger headline presence\n- update style guide and evolution log\n\nValidation:\n- zola build