### PR TITLE
Improve IT+HELP gold perimeter continuity

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP gold perimeter continuity pass
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Kept direct text-stroke rendering but strengthened perimeter continuity with a tiny centered gold smoothing halo and a subtle downward gold closure shadow (dark + light variants), while avoiding filter-based ring effects.
+- Why: User feedback indicated the gold wrap around IT/HELP still looked incomplete/uneven and needed a cleaner, more continuous edge read.
+- Rollback: this branch/PR (`codex/ithelp-gold-wrap-clean-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP P contour cleanup (Apple weight + stroke simplification)
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -44,6 +44,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - For solid premium outlines, use near-integer stroke widths (`~1px`) with a tiny gold smoothing halo; avoid thin sub-pixel strokes that can look jagged.
 - To avoid inner horseshoe artifacts on curved glyphs (notably `P`), prefer `paint-order: stroke fill`; if bottom edges read weak, add only a subtle downward gold micro-shadow.
 - For cleaner curved tops (especially `P` shoulder), avoid negative-Y top highlight strokes; prefer a centered micro gold smoothing halo plus a downward closure pass.
+- Gold wrap continuity target: if perimeter looks broken, use a low-radius centered halo (`~0.2px`) plus a small positive-Y closure (`~0.4-0.6px`) before increasing stroke thickness further.
 - If curved-edge noise persists, prefer pure `-webkit-text-stroke` perimeter with no extra gold `filter` stack before increasing effect complexity.
 - Keep Apple rendering weight consistent: do not downshift IT/HELP glyphs to `800` in Safari-targeted overrides; keep the logo at its core heavyweight geometry.
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -190,12 +190,14 @@ html.switch .logo-constellation {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.1px var(--accent-gold-solid);
+    -webkit-text-stroke: 1.18px var(--accent-gold-solid);
     paint-order: stroke fill;
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 0.90px 0 rgba(3, 14, 44, 0.76),
+        0 0 0.24px rgba(210, 181, 111, 0.64),
+        0 0.56px 0 rgba(210, 181, 111, 0.46),
+        0 0.90px 0 rgba(3, 14, 44, 0.74),
         0 2.4px 5px rgba(2, 8, 24, 0.22),
         0 7px 14px rgba(4, 12, 32, 0.24);
     filter: none;
@@ -340,9 +342,11 @@ html.switch .logo-help {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.02px var(--accent-gold-solid);
+    -webkit-text-stroke: 1.1px var(--accent-gold-solid);
     paint-order: stroke fill;
     text-shadow:
+        0 0 0.2px rgba(210, 181, 111, 0.56),
+        0 0.42px 0 rgba(210, 181, 111, 0.38),
         0 0.72px 0 rgba(8, 24, 68, 0.46),
         0 1.6px 3.2px rgba(2, 8, 24, 0.14),
         0 4px 9px rgba(10, 26, 56, 0.08);


### PR DESCRIPTION
## Summary\n- Keeps IT/HELP on direct text-stroke rendering and avoids filter-ring artifacts\n- Strengthens gold perimeter continuity with a tiny centered halo and subtle downward closure shadow\n- Tunes dark/light stroke widths to keep wrap visible and consistent across desktop/mobile\n\n## Files\n- static/css/late-overrides.css\n- STYLE_GUIDE.md\n- PROJECT_EVOLUTION_LOG.md\n\n## Validation\n- zola build