### PR TITLE
Suppress persistent desktop P spur in IT+HELP

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,17 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP P top-spur subpixel cleanup (desktop)
+- Files:
+  - `templates/partials/hero_logo.html`
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Isolated the `P` in `HELP` for per-glyph desktop tuning, then snapped desktop logo sizing/offsets to integer-pixel geometry and reduced `P`-only stroke/halo intensity to suppress the persistent top spur without weakening the mobile wrap.
+- Why: User-confirmed top-of-`P` artifact remained on desktop after global perimeter adjustments.
+- Rollback: this branch/PR (`codex/ithelp-p-subpixel-clean-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP desktop P shoulder spur cleanup
 - Files:
   - `static/css/late-overrides.css`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -46,6 +46,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - For cleaner curved tops (especially `P` shoulder), avoid negative-Y top highlight strokes; prefer a centered micro gold smoothing halo plus a downward closure pass.
 - Gold wrap continuity target: if perimeter looks broken, use a low-radius centered halo (`~0.2px`) plus a small positive-Y closure (`~0.4-0.6px`) before increasing stroke thickness further.
 - If a shoulder spur appears only on desktop, apply desktop-only reductions to stroke/halo first (`@media (min-width: 700px)`) and keep mobile values unchanged.
+- If a desktop-only glyph artifact persists, snap desktop logo size and optical offsets to integer-pixel geometry before adding more effect layers.
 - If curved-edge noise persists, prefer pure `-webkit-text-stroke` perimeter with no extra gold `filter` stack before increasing effect complexity.
 - Keep Apple rendering weight consistent: do not downshift IT/HELP glyphs to `800` in Safari-targeted overrides; keep the logo at its core heavyweight geometry.
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -216,6 +216,12 @@ html.switch .logo-constellation {
     left: var(--logo-help-shift);
 }
 
+.logo-help-p {
+    display: inline-block;
+    position: relative;
+    top: 0;
+}
+
 .logo-it::before,
 .logo-it::after,
 .logo-help::before,
@@ -358,6 +364,12 @@ html.switch .logo-help {
 
 /* Desktop optical cleanup: reduce top-shoulder spur on P while preserving mobile wrap strength. */
 @media (min-width: 700px) {
+    .main-logo {
+        font-size: 86px;           /* integer pixel size to reduce subpixel stroke artifacts */
+        --logo-it-shift: 0.093023em;   /* 8px at 86px */
+        --logo-help-shift: -0.023256em; /* -2px at 86px */
+    }
+
     .logo-it,
     .logo-help {
         -webkit-text-stroke: 1.1px var(--accent-gold-solid);
@@ -369,6 +381,18 @@ html.switch .logo-help {
             0 7px 14px rgba(4, 12, 32, 0.24);
     }
 
+    .logo-help-p {
+        top: 0.005em;
+        font-weight: 880;
+        -webkit-text-stroke: 0.94px var(--accent-gold-solid);
+        text-shadow:
+            0 0 0.11px rgba(210, 181, 111, 0.50),
+            0 0.28px 0 rgba(210, 181, 111, 0.34),
+            0 0.86px 0 rgba(3, 14, 44, 0.72),
+            0 2.2px 4.6px rgba(2, 8, 24, 0.20),
+            0 7px 14px rgba(4, 12, 32, 0.24);
+    }
+
     html.switch .logo-it,
     html.switch .logo-help {
         -webkit-text-stroke: 1.04px var(--accent-gold-solid);
@@ -377,6 +401,18 @@ html.switch .logo-help {
             0 0.38px 0 rgba(210, 181, 111, 0.34),
             0 0.72px 0 rgba(8, 24, 68, 0.46),
             0 1.6px 3.2px rgba(2, 8, 24, 0.14),
+            0 4px 9px rgba(10, 26, 56, 0.08);
+    }
+
+    html.switch .logo-help-p {
+        top: 0.004em;
+        font-weight: 880;
+        -webkit-text-stroke: 0.9px var(--accent-gold-solid);
+        text-shadow:
+            0 0 0.09px rgba(210, 181, 111, 0.42),
+            0 0.24px 0 rgba(210, 181, 111, 0.28),
+            0 0.68px 0 rgba(8, 24, 68, 0.44),
+            0 1.5px 3px rgba(2, 8, 24, 0.14),
             0 4px 9px rgba(10, 26, 56, 0.08);
     }
 }

--- a/templates/partials/hero_logo.html
+++ b/templates/partials/hero_logo.html
@@ -10,7 +10,7 @@
 
   <div class="glitch-container" aria-hidden="true">
     <div class="main-logo">
-      <span class="logo-it">IT</span><span class="logo-plus">+</span><span class="logo-help">HELP</span>
+      <span class="logo-it">IT</span><span class="logo-plus">+</span><span class="logo-help">HEL<span class="logo-help-p">P</span></span>
     </div>
     <div class="location">SAN DIEGO</div>
   </div>


### PR DESCRIPTION
Summary\n- Isolates the P glyph in HELP for desktop-only optical correction\n- Snaps desktop logo geometry to integer-pixel sizing/offsets to reduce subpixel stroke jag\n- Applies lighter P-only stroke/halo tuning so top shoulder artifact is suppressed without weakening mobile wrap\n\nFiles\n- templates/partials/hero_logo.html\n- static/css/late-overrides.css\n- STYLE_GUIDE.md\n- PROJECT_EVOLUTION_LOG.md\n\nValidation\n- zola build