### PR TITLE
Experiment: richer IT+HELP blue and thicker gold perimeter

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,16 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-10
 - Actor: AI+Developer
+- Scope: IT/HELP richer blue + thicker gold wrap experiment
+- Files:
+  - `static/css/late-overrides.css`
+  - `STYLE_GUIDE.md`
+- Change: Tuned the logo blue ramp to a richer mid-blue fill and increased IT/HELP gold perimeter stroke/closure intensity toward a pill-border-adjacent weight (dark + light variants), while retaining desktop per-glyph `P` carveout safeguards.
+- Why: User requested experimentation with stronger interior blue presence and a thicker gold wrap option versus the prior thin perimeter.
+- Rollback: this branch/PR (`codex/ithelp-blue-gold-balance-v1`).
+
+### 2026-02-10
+- Actor: AI+Developer
 - Scope: IT/HELP P top-spur subpixel cleanup (desktop)
 - Files:
   - `templates/partials/hero_logo.html`

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -10,9 +10,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
 - Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#7DAFE8` (`--logo-blue-top`)
-  - Mid: `#3D74BE` (`--logo-blue-mid`)
-  - Bottom: `#1E4F97` (`--logo-blue-bottom`)
+  - Top: `#86B9EF` (`--logo-blue-top`)
+  - Mid: `#4B83CB` (`--logo-blue-mid`)
+  - Bottom: `#24589F` (`--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)
@@ -47,6 +47,7 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 - Gold wrap continuity target: if perimeter looks broken, use a low-radius centered halo (`~0.2px`) plus a small positive-Y closure (`~0.4-0.6px`) before increasing stroke thickness further.
 - If a shoulder spur appears only on desktop, apply desktop-only reductions to stroke/halo first (`@media (min-width: 700px)`) and keep mobile values unchanged.
 - If a desktop-only glyph artifact persists, snap desktop logo size and optical offsets to integer-pixel geometry before adding more effect layers.
+- For a bolder headline-wrap experiment, raise gold perimeter stroke into the `~1.2px-1.3px` range and keep `P` as a controlled per-glyph carveout.
 - If curved-edge noise persists, prefer pure `-webkit-text-stroke` perimeter with no extra gold `filter` stack before increasing effect complexity.
 - Keep Apple rendering weight consistent: do not downshift IT/HELP glyphs to `800` in Safari-targeted overrides; keep the logo at its core heavyweight geometry.
 - Keep logo color strategy blue-led: gold should remain a restrained edge hint only, not a dominant fill impression.

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -26,9 +26,9 @@ html:not(.switch) h3 a,html:not(.switch) h3 a:visited{color:#fff!important}html:
     --schedule-blue-top: #6CAFEF;
     --schedule-blue-mid: #3F86D8;
     --schedule-blue-bottom: #2359A9;
-    --logo-blue-top: #7DAFE8;
-    --logo-blue-mid: #3D74BE;
-    --logo-blue-bottom: #1E4F97;
+    --logo-blue-top: #86B9EF;
+    --logo-blue-mid: #4B83CB;
+    --logo-blue-bottom: #24589F;
     --brand-blue-ink: #F7FBFF;
     --accent-gold: #C2A15A;
     --accent-gold-solid: #D2B56F;
@@ -190,13 +190,13 @@ html.switch .logo-constellation {
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.18px var(--accent-gold-solid);
+    -webkit-text-stroke: 1.3px var(--accent-gold-solid);
     paint-order: stroke fill;
     display: inline-block;
     letter-spacing: var(--logo-letter-spacing);
     text-shadow:
-        0 0 0.24px rgba(210, 181, 111, 0.64),
-        0 0.56px 0 rgba(210, 181, 111, 0.46),
+        0 0 0.28px rgba(210, 181, 111, 0.72),
+        0 0.66px 0 rgba(210, 181, 111, 0.54),
         0 0.90px 0 rgba(3, 14, 44, 0.74),
         0 2.4px 5px rgba(2, 8, 24, 0.22),
         0 7px 14px rgba(4, 12, 32, 0.24);
@@ -343,16 +343,16 @@ html.switch .logo-constellation {
 
 html.switch .logo-it,
 html.switch .logo-help {
-    color: #3466A8;
+    color: #3D72B1;
     background-image: none;
     -webkit-background-clip: border-box;
     background-clip: border-box;
     -webkit-text-fill-color: currentColor;
-    -webkit-text-stroke: 1.1px var(--accent-gold-solid);
+    -webkit-text-stroke: 1.22px var(--accent-gold-solid);
     paint-order: stroke fill;
     text-shadow:
-        0 0 0.2px rgba(210, 181, 111, 0.56),
-        0 0.42px 0 rgba(210, 181, 111, 0.38),
+        0 0 0.24px rgba(210, 181, 111, 0.62),
+        0 0.52px 0 rgba(210, 181, 111, 0.44),
         0 0.72px 0 rgba(8, 24, 68, 0.46),
         0 1.6px 3.2px rgba(2, 8, 24, 0.14),
         0 4px 9px rgba(10, 26, 56, 0.08);
@@ -372,10 +372,10 @@ html.switch .logo-help {
 
     .logo-it,
     .logo-help {
-        -webkit-text-stroke: 1.1px var(--accent-gold-solid);
+        -webkit-text-stroke: 1.22px var(--accent-gold-solid);
         text-shadow:
-            0 0 0.18px rgba(210, 181, 111, 0.56),
-            0 0.46px 0 rgba(210, 181, 111, 0.40),
+            0 0 0.24px rgba(210, 181, 111, 0.66),
+            0 0.60px 0 rgba(210, 181, 111, 0.48),
             0 0.90px 0 rgba(3, 14, 44, 0.74),
             0 2.4px 5px rgba(2, 8, 24, 0.22),
             0 7px 14px rgba(4, 12, 32, 0.24);
@@ -384,10 +384,10 @@ html.switch .logo-help {
     .logo-help-p {
         top: 0.005em;
         font-weight: 880;
-        -webkit-text-stroke: 0.94px var(--accent-gold-solid);
+        -webkit-text-stroke: 1.04px var(--accent-gold-solid);
         text-shadow:
-            0 0 0.11px rgba(210, 181, 111, 0.50),
-            0 0.28px 0 rgba(210, 181, 111, 0.34),
+            0 0 0.14px rgba(210, 181, 111, 0.56),
+            0 0.34px 0 rgba(210, 181, 111, 0.40),
             0 0.86px 0 rgba(3, 14, 44, 0.72),
             0 2.2px 4.6px rgba(2, 8, 24, 0.20),
             0 7px 14px rgba(4, 12, 32, 0.24);
@@ -395,10 +395,10 @@ html.switch .logo-help {
 
     html.switch .logo-it,
     html.switch .logo-help {
-        -webkit-text-stroke: 1.04px var(--accent-gold-solid);
+        -webkit-text-stroke: 1.16px var(--accent-gold-solid);
         text-shadow:
-            0 0 0.16px rgba(210, 181, 111, 0.48),
-            0 0.38px 0 rgba(210, 181, 111, 0.34),
+            0 0 0.2px rgba(210, 181, 111, 0.54),
+            0 0.46px 0 rgba(210, 181, 111, 0.40),
             0 0.72px 0 rgba(8, 24, 68, 0.46),
             0 1.6px 3.2px rgba(2, 8, 24, 0.14),
             0 4px 9px rgba(10, 26, 56, 0.08);
@@ -407,10 +407,10 @@ html.switch .logo-help {
     html.switch .logo-help-p {
         top: 0.004em;
         font-weight: 880;
-        -webkit-text-stroke: 0.9px var(--accent-gold-solid);
+        -webkit-text-stroke: 1px var(--accent-gold-solid);
         text-shadow:
-            0 0 0.09px rgba(210, 181, 111, 0.42),
-            0 0.24px 0 rgba(210, 181, 111, 0.28),
+            0 0 0.11px rgba(210, 181, 111, 0.48),
+            0 0.30px 0 rgba(210, 181, 111, 0.34),
             0 0.68px 0 rgba(8, 24, 68, 0.44),
             0 1.5px 3px rgba(2, 8, 24, 0.14),
             0 4px 9px rgba(10, 26, 56, 0.08);


### PR DESCRIPTION
## Summary\n- Runs a logo experiment with richer interior blue and a visibly thicker gold perimeter around IT+HELP\n- Keeps the desktop P carveout safeguards in place to avoid reintroducing the shoulder artifact\n- Tunes dark and light variant stroke/halo values consistently for the new thickness target\n\n## Files\n- static/css/late-overrides.css\n- STYLE_GUIDE.md\n- PROJECT_EVOLUTION_LOG.md\n\n## Validation\n- zola build