### PR TITLE
fix(crawl): reduce internal redirect noise from nav section links

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-02-13
+- Actor: AI
+- Scope: Ahrefs crawl follow-up (internal redirect-noise reduction)
+- Files:
+  - `templates/base.html`
+- Change: Updated primary nav internal links to explicit trailing-slash URLs (`/services/`, `/billing/`, `/about/`, `/blog/`, `/dns-tool/`) so crawlers hit canonical section URLs directly instead of slashless variants that can produce 3xx hops.
+- Why: Post-report remediation pass for the "redirect/HTTP redirect" issue set, focusing on safe, non-visual crawl hygiene improvements.
+- Rollback: this branch/PR (`codex/ahrefs-report-followup-20260213`).
+
 ### 2026-02-11
 - Actor: AI+Developer
 - Scope: GitHub Actions supply-chain hardening (full SHA pinning)

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,7 +59,7 @@
     <ul class="nav-pill-list">
       <!-- home icon -->
       <li class="nav-home">
-        <a href="{{ get_url(path='/') }}" aria-label="Home" class="home-icon">
+        <a href="{{ get_url(path='/', trailing_slash=true) }}" aria-label="Home" class="home-icon">
           <svg xmlns="http://www.w3.org/2000/svg"
                viewBox="0 0 24 24"
                fill="none"
@@ -80,11 +80,11 @@
         <details>
           <summary class="dropdown-toggle">More</summary>
           <ul class="dropdown-content">
-            <li><a href="{{ get_url(path='/services/') }}">Services</a></li>
-            <li><a href="{{ get_url(path='/billing/')  }}">Pricing</a></li>
-            <li><a href="{{ get_url(path='/about/')    }}">Our Expertise</a></li>
-            <li><a href="{{ get_url(path='/blog/')     }}">Blog</a></li>
-            <li><a href="{{ get_url(path='/dns-tool/') }}">DNS Tool</a></li>
+            <li><a href="/services/">Services</a></li>
+            <li><a href="/billing/">Pricing</a></li>
+            <li><a href="/about/">Our Expertise</a></li>
+            <li><a href="/blog/">Blog</a></li>
+            <li><a href="/dns-tool/">DNS Tool</a></li>
           </ul>
         </details>
       </li>


### PR DESCRIPTION
## Summary
- switch primary nav section links to explicit trailing-slash URLs (`/services/`, `/billing/`, `/about/`, `/blog/`, `/dns-tool/`)
- keep behavior and look/feel unchanged while improving crawl canonicality
- record the remediation in `PROJECT_EVOLUTION_LOG.md`

## Why
Latest Ahrefs report (`All issues - It-help.pdf`, 2026-02-13 09:09 PST) flagged redirect-related crawl noise. This change removes a predictable internal source (slashless section URLs).

## Validation
- `zola build` passes
- rendered nav links now resolve to canonical trailing-slash URLs in generated HTML
- no non-slash canonical section links remain in `public/**/*.html` for services/billing/about/blog/dns-tool

## Notes on report deltas
- Report indicates `Actual: 7`, `New: 2`, `All tracked: 172` (compared to yesterday).
- The two newly flagged items are informational (`No. of URLs in sitemap decreased`, `Pages to submit to IndexNow`) and align with intentional sitemap/indexability cleanup.
