### PR TITLE
perf(hero): reduce mobile TBT from constellation animation load

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,15 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-13
 - Actor: AI
+- Scope: Mobile Lighthouse TBT recovery (hero animation workload reduction)
+- Files:
+  - `static/js/hero-logo.js`
+- Change: Deferred constellation startup to idle-time, added touch-device frame throttling, reduced touch-node density, replaced per-call crypto random sampling with pooled random values, and removed per-frame array allocations in link drawing/neighbor selection paths.
+- Why: User requested a symbiotic remediation pass to improve mobile Lighthouse performance while keeping Ahrefs/SEO crawl hygiene and preserving the established visual system.
+- Rollback: this branch/PR (`codex/mobile-tbt-recovery-v1`).
+
+### 2026-02-13
+- Actor: AI
 - Scope: Ahrefs crawl follow-up (internal redirect-noise reduction)
 - Files:
   - `templates/base.html`


### PR DESCRIPTION
## Summary
- optimize hero constellation runtime to reduce mobile main-thread pressure and TBT without changing brand styling
- defer constellation initialization to idle-time after DOM load
- throttle touch-device constellation rendering cadence
- reduce touch-device node density and remove per-frame allocation hot paths
- keep deterministic secure randomness by pooling `crypto.getRandomValues` calls
- document change in `PROJECT_EVOLUTION_LOG.md`

## Why
Recent mobile PageSpeed report showed a Lighthouse performance dip (93) with TBT as the main contributor. Long tasks were primarily attributed to `static/js/hero-logo.js` animation work. This PR targets that hotspot while preserving look and feel.

## Validation completed
- `zola build` passes
- no template/CSP/tracker changes
- no palette/typography/layout changes

## Post-merge validation plan (symbiotic gates)
1. Lighthouse (mobile + desktop) for `https://www.it-help.tech/`
2. Ahrefs recrawl check for redirect/noise regressions
3. Mozilla Observatory confirmation (target remains A+ / >=120)

## Files changed
- `static/js/hero-logo.js`
- `PROJECT_EVOLUTION_LOG.md`
