### PR TITLE
docs(security): finalize disclosure hardening refinements

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -15,6 +15,18 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ### 2026-02-14
 - Actor: AI
+- Scope: Security disclosure hardening + external-link safety refinement
+- Files:
+  - `content/security-policy.md`
+  - `static/.well-known/security.txt`
+  - `static/security.txt`
+  - `templates/base.html`
+- Change: Hardened disclosure operations by adding an authorized-assessment intake checklist, explicit urgent-report handling, and an acknowledgments section in `/security-policy`. Expanded `security.txt` metadata with a secondary policy URL contact and an RFC-compatible `Acknowledgments` field. Updated the Schedule external link rel attributes to `noopener noreferrer`.
+- Why: User requested additional cleanup and best-practice refinement from all angles after initial security-policy rollout.
+- Rollback: this branch/PR (`codex/security-policy-authorized-testing`, `#511`).
+
+### 2026-02-14
+- Actor: AI
 - Scope: Security disclosure publishing (`/security-policy` + RFC 9116 `security.txt`)
 - Files:
   - `content/security-policy.md`

--- a/content/security-policy.md
+++ b/content/security-policy.md
@@ -15,7 +15,8 @@ If you believe you found a security issue in systems operated by IT Help San Die
 ## Contact
 
 - Email: `security@it-help.tech`
-- Suggested subject: `Security Report - <brief summary>`
+- Suggested subject: `Security Report - [brief summary]`
+- If active exploitation is in progress, include `URGENT` in the subject line.
 
 If you need a different secure reporting channel, request one in your initial email.
 
@@ -50,6 +51,16 @@ Authorized testing may include:
 - Controlled active testing that is agreed in advance.
 
 For authorized engagements, follow the signed rules of engagement and designated escalation channels.
+
+## Authorized Assessment Intake
+
+For government, regulatory, or contracted testing, include:
+
+- Program or sponsor name.
+- Authorization reference (agreement/SOW/ROE identifier).
+- Assessment window (start/end in UTC).
+- Source IP ranges or infrastructure identifiers.
+- Primary operator contact for real-time coordination.
 
 ## Safe Harbor
 
@@ -87,6 +98,10 @@ Please do not publicly disclose vulnerabilities until remediation is complete or
 ## Bug Bounty
 
 IT Help San Diego Inc. does not currently operate a paid bug bounty program.
+
+## Acknowledgments
+
+We appreciate responsible reports that improve security outcomes. Public credit can be coordinated after remediation, based on reporter preference and operational constraints.
 
 ## security.txt
 

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,5 +1,7 @@
 Contact: mailto:security@it-help.tech
+Contact: https://www.it-help.tech/security-policy
 Expires: 2027-02-14T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://www.it-help.tech/.well-known/security.txt
 Policy: https://www.it-help.tech/security-policy
+Acknowledgments: https://www.it-help.tech/security-policy/#acknowledgments

--- a/static/security.txt
+++ b/static/security.txt
@@ -1,5 +1,7 @@
 Contact: mailto:security@it-help.tech
+Contact: https://www.it-help.tech/security-policy
 Expires: 2027-02-14T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://www.it-help.tech/.well-known/security.txt
 Policy: https://www.it-help.tech/security-policy
+Acknowledgments: https://www.it-help.tech/security-policy/#acknowledgments

--- a/templates/base.html
+++ b/templates/base.html
@@ -91,7 +91,7 @@
 
       <!-- schedule -->
       <li class="nav-schedule">
-        <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener" class="schedule-link">
+        <a href="https://schedule.it-help.tech/" target="_blank" rel="noopener noreferrer" class="schedule-link">
           Schedule
         </a>
       </li>


### PR DESCRIPTION
## Summary
- follow-up to #511 with remaining hardening commit
- add authorized assessment intake checklist to /security-policy
- add urgent-subject guidance for active exploitation reports
- add acknowledgments section in policy
- add RFC-compatible Acknowledgments field and policy URL contact in security.txt endpoints
- tighten external schedule link rel to noopener noreferrer

## Validation
- zola build