### PR TITLE
Sub-4 (CSP Hardening): hash-free policy + COOP/CORP — target Observatory ≥145

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,21 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-04-17
+- Actor: AI (Sub-agent 4: CSP Hardening & CloudFront Policy)
+- Scope: Push Mozilla Observatory 130 → ≥145 by externalizing the last inline script + style and adding bonus security headers (per `.agent-transfer/plans/csp-tightening-plan.md`).
+- Files:
+  - `static/js/theme-init.js` (new — extracted theme-flash IIFE from `templates/partials/head.html`)
+  - `templates/partials/head.html` (replaced inline `<script>` with same-origin `<script src=... integrity=sha384-... crossorigin=anonymous>` blocking — must run pre-paint; replaced inline `<style>{{critical_css}}</style>` with `<link rel=stylesheet href=css/critical.min.css>`; removed obsolete `noscript` wrapper and the now-unused `load_data` import)
+  - `infra/cloudfront/generate_policy.py` (added `NON_EXECUTABLE_TYPE_RE` filter so `<script type="application/ld+json">`, `application/json`, `application/importmap`, and `speculationrules` blocks no longer consume `script-src` allowance — they are data per W3C CSP §6.6.4.2 and were inflating the policy with 15 unnecessary hashes)
+  - `infra/cloudfront/csp-policy-v1.json` (regenerated CSP collapses to `default-src 'none'; ...; style-src 'self'; script-src 'self'; ...` — zero hashes, 260 bytes vs ~2KB before; added `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Resource-Policy: same-origin` custom headers)
+  - `PROJECT_EVOLUTION_LOG.md` (this entry)
+- Change: Removed every CSP hash from the site policy by externalizing the two remaining inline blocks and teaching the policy generator to ignore non-executable `<script>` types. Added COOP+CORP for the documented +10 Observatory bonus.
+- Score delta target: Observatory 130 → ≥145 (+10 from "no inline executable scripts/styles, hash-free policy" + +10 from COOP/CORP). COEP `require-corp` deferred per the plan caveat (requires staging crawl validation of every cross-origin subresource before promotion).
+- Verification: `zola build` clean; `python3 infra/cloudfront/generate_policy.py --mode site` reports `0 inline script hashes, 0 inline style hashes, CSP length 260`; programmatic audit of `public/*.html` (excluding the signature page on its separate CloudFront behavior) confirms zero inline executable `<script>` and zero inline `<style>` blocks; live preview renders identically to pre-change.
+- Non-negotiables verified: `static/js/hero-logo.js` not modified; Sub-2 token system intact (parity gate passes); Sub-3 chrome unchanged.
+- Rollback: revert this branch's commits (`codex/sub4-csp`).
+
 ### 2026-02-15
 - Actor: AI (Sub-agent 2: Design Token Adoption)
 - Scope: Design token adoption (SOT) + token-parity CI gate + dark-theme baseline

--- a/infra/cloudfront/csp-policy-v1.json
+++ b/infra/cloudfront/csp-policy-v1.json
@@ -25,7 +25,7 @@
       "Override": true
     },
     "ContentSecurityPolicy": {
-      "ContentSecurityPolicy": "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'sha256-WbPiy3OjRckbGIupDmSBJeIJ/AmaLq1FV7ZR1gVglvY='; script-src 'self' 'sha256-18H+Mtcoe1hfGi22LXTOjAQ2sqMS/vP0Ed8d95mB2g8=' 'sha256-3b4JmXQaF6GkDrgL0EoOxEJ4iFIsz3PSzqSr6Chfw0M=' 'sha256-4Dn7XTpPWm3T5HQPqvTbw2gCiMJ9sTLL3V4v0XzKbj4=' 'sha256-4F7ijAyytj8FrP3r20Wu8yZL5X4w+w3DCCeNQXTbGU0=' 'sha256-62eYGTzqt1LOCthcenoELoQ0/n0IIWhJtDKtlfADr7o=' 'sha256-DwajN6QS0Kgw+iz84OkQUqyhrq4/8j6xmIecCJfvdtQ=' 'sha256-IlEXrdnue57XTKWawxDyUwZuhsU+KcjWIXnY6bbTbPM=' 'sha256-Iuq+Tka2Jurf9h1xqMsCbLpJjCYhsCysB6BsO84YOac=' 'sha256-JudjYpLT840u+tGTdud5VR1Rk9gqSbLp9hKXGY+zAP0=' 'sha256-O93iliQOWK6twBo5wy8DHpYYxVGZwc2N1CWBt/dGpB4=' 'sha256-P4uwpa/WqRYLcvG1BcW9X1ExSAJZV6nGSdiJeJfjGU8=' 'sha256-Pu4u0UyUl0b8jowt1remBNtKIy9xIR7t34Q9n7v80rQ=' 'sha256-XFu2l5lbdGA3i+pPMPznUsx1Efk3BHxdWemGGNUzhvU=' 'sha256-b1lDqSeq7cuHe4KHxBFpJFwlIetpTjKGG8ZbvRf9Ib4=' 'sha256-reKkcIkYH++92ITmpqySFyFnxgiNfJez+NUmlttCBrg=' 'sha256-wGTsbCVMwTR1c8txqyNeUJx44hjDPNTEQH5Ij7mX4Ug='; connect-src 'self'; media-src 'self'; manifest-src 'self'; upgrade-insecure-requests",
+      "ContentSecurityPolicy": "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self'; style-src 'self'; script-src 'self'; connect-src 'self'; media-src 'self'; manifest-src 'self'; upgrade-insecure-requests",
       "Override": true
     }
   },
@@ -35,8 +35,18 @@
         "Header": "Permissions-Policy",
         "Value": "interest-cohort=(), accelerometer=(), ambient-light-sensor=(), battery=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(), publickey-credentials-get=(), serial=(), storage-access=(), sync-xhr=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()",
         "Override": true
+      },
+      {
+        "Header": "Cross-Origin-Opener-Policy",
+        "Value": "same-origin",
+        "Override": true
+      },
+      {
+        "Header": "Cross-Origin-Resource-Policy",
+        "Value": "same-origin",
+        "Override": true
       }
     ],
-    "Quantity": 1
+    "Quantity": 3
   }
 }

--- a/infra/cloudfront/generate_policy.py
+++ b/infra/cloudfront/generate_policy.py
@@ -29,6 +29,18 @@ from typing import Callable, Iterable
 STYLE_TAG_RE = re.compile(r"<style\b([^>]*)>(.*?)</style>", re.IGNORECASE | re.DOTALL)
 SCRIPT_TAG_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.IGNORECASE | re.DOTALL)
 SRC_ATTR_RE = re.compile(r"\bsrc\s*=", re.IGNORECASE)
+# Per W3C CSP §6.6.4.2, scripts whose `type` is not a valid JS MIME type are
+# treated as DATA blocks (e.g. JSON-LD, importmap, speculationrules) and are
+# never executed by the parser. They MUST NOT consume a `script-src` allowance,
+# otherwise the policy bloats unnecessarily and tooling drifts every time a new
+# schema block is added to a page. See csp-tightening-plan.md (Sub-4).
+NON_EXECUTABLE_TYPE_RE = re.compile(
+    r"""\btype\s*=\s*['"]?\s*(?:
+        application/(?:ld\+json|json|importmap)
+      | speculationrules
+    )""",
+    re.IGNORECASE | re.VERBOSE,
+)
 
 SELF = "'self'"
 NONE = "'none'"
@@ -82,6 +94,11 @@ def _extract_inline_scripts(html: str, *, file: Path) -> Iterable[InlineScript]:
     for match in SCRIPT_TAG_RE.finditer(html):
         attrs = (match.group(1) or "").strip()
         if SRC_ATTR_RE.search(attrs):
+            continue
+        # Non-JS-typed <script> blocks (JSON-LD, importmap, speculationrules)
+        # are data — not subject to script-src — so they MUST NOT generate a
+        # CSP hash. See NON_EXECUTABLE_TYPE_RE for spec reference.
+        if NON_EXECUTABLE_TYPE_RE.search(attrs):
             continue
         body = match.group(2) or ""
         if body.strip() == "":

--- a/static/js/theme-init.js
+++ b/static/js/theme-init.js
@@ -1,0 +1,17 @@
+// Prevent a flash of the wrong theme before CSS loads.
+// Externalized for CSP hardening (Sub-4): with this script as a same-origin
+// blocking <script src=...> with SRI, the parser pauses here, applies the
+// stored preference, and only then continues — same UX as the old inline IIFE
+// but with no inline-script CSP hash required.
+(function () {
+  try {
+    if (localStorage.getItem('theme') === 'light') {
+      document.documentElement.classList.add('switch');
+    }
+  } catch (error) {
+    // localStorage can throw in privacy-restricted contexts; keep default theme.
+    if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+      console.debug('Theme preference storage unavailable:', error);
+    }
+  }
+})();

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -1,21 +1,15 @@
-{% set critical_css = load_data(path="static/css/critical.min.css") %}
 <meta charset="utf-8" />
-<script>
-  // Prevent a flash of the wrong theme before CSS loads.
-  (function () {
-    try {
-      if (localStorage.getItem('theme') === 'light') {
-        document.documentElement.classList.add('switch');
-      }
-    } catch (error) {
-      // localStorage can throw in privacy-restricted contexts; keep default theme.
-      if (typeof console !== 'undefined' && typeof console.debug === 'function') {
-        console.debug('Theme preference storage unavailable:', error);
-      }
-    }
-  })();
-</script>
-<style>{{- critical_css | safe -}}</style>
+{# --- Theme-flash guard (externalized for CSP — Sub-4). Blocking on purpose:
+       must run before paint to apply the stored light/dark preference. --- #}
+<script src="{{ get_url(path='js/theme-init.js', trailing_slash=false, cachebust=true) | safe }}"
+        integrity="sha384-{{ get_hash(path='js/theme-init.js', sha_type=384, base64=true) | safe }}"
+        crossorigin="anonymous"></script>
+
+{# --- Critical above-the-fold CSS (externalized for CSP — Sub-4).
+       Tiny (~850B), same-origin, edge-cached: render-blocking cost is negligible
+       and the inline-style CSP hash is no longer required. --- #}
+<link rel="stylesheet"
+      href="{{ get_url(path='css/critical.min.css', trailing_slash=false, cachebust=true) | safe }}">
 
 {#
   Preload the page's main portrait image only when it exists. This
@@ -56,13 +50,6 @@
 {%- if config.extra.search_library and config.extra.search_library == "offline" %}
   {% set integrity = false %}
 {%- endif %}
-
-<noscript>
-  <link rel="stylesheet" href="{{ get_url(path='critical-inline.css') | safe }}">
-</noscript>
-
-{# --- Critical hero styling uses CSP nonce --- #}
-
 
 {# --- Style Sheets --- #}
 {%- set stylesheets = config.extra.stylesheets | default(value=[ "css/abridge.css" ]) -%}


### PR DESCRIPTION
## Sub-agent 4 of design-transfer/v1

Pushes Mozilla Observatory **130 → ≥145** per `.agent-transfer/plans/csp-tightening-plan.md`.

### Strategy
Three compounding wins:
1. **Externalize the last inline executable script** — the theme-flash IIFE in `head.html` becomes `static/js/theme-init.js`, loaded same-origin with SRI. Blocking on purpose so it runs pre-paint and prevents FOUT.
2. **Externalize the last inline `<style>`** — critical CSS now loads via `<link rel=stylesheet href=css/critical.min.css>` instead of `<style>{{critical_css}}</style>`. Same payload, no inline hash needed.
3. **Stop hashing JSON-LD** — `generate_policy.py` now skips `type="application/ld+json"` (and `application/json`, `application/importmap`, `speculationrules`) per W3C CSP §6.6.4.2 — they are data, not script, and were inflating the policy with 15 unnecessary hashes per build.

Result: CSP collapses from ~2KB / 17 hashes to **260 bytes / zero hashes**:
```
default-src none; base-uri self; object-src none; frame-ancestors none; form-action self; img-src self data:; font-src self; style-src self; script-src self; connect-src self; media-src self; manifest-src self; upgrade-insecure-requests
```

Plus **+10 Observatory bonus** from adding:
- `Cross-Origin-Opener-Policy: same-origin`
- `Cross-Origin-Resource-Policy: same-origin`

### Files
- `static/js/theme-init.js` *(new)* — extracted theme-flash IIFE verbatim
- `templates/partials/head.html` — externalized script + style; removed obsolete `noscript` wrapper and unused `load_data` import
- `infra/cloudfront/generate_policy.py` — added `NON_EXECUTABLE_TYPE_RE` filter
- `infra/cloudfront/csp-policy-v1.json` — regenerated CSP, added COOP+CORP (Quantity 1→3)
- `PROJECT_EVOLUTION_LOG.md` — score-delta entry

### Verification
- ✅ `zola build` clean
- ✅ `python3 infra/cloudfront/generate_policy.py --mode site` reports `0 inline script hashes, 0 inline style hashes, CSP length 260`
- ✅ Programmatic audit of `public/*.html` (excluding signature page on its separate behavior): **0 inline executable scripts, 0 inline `<style>` blocks**
- ✅ Live preview renders identically to pre-change
- ✅ Token-parity gate still passes (Sub-2 system intact)
- ✅ Architect code review: zero CRITICAL/HIGH issues

### What is NOT in this PR
- **COEP `require-corp`** — deferred per the plan caveat; requires deploy-to-staging + full subresource crawl validation before promotion. COOP+CORP alone net +10 score with zero compatibility risk on a same-origin-only site. Re-evaluate in a follow-up PR after staging validation.
- **`require-trusted-types-for script`** — defer-until-post-redesign per the plan.
- **`report-to`** — requires a CSP-reporting endpoint; out of scope.

### Depends On
- #525 (Sub-1, IA & Content) — merged ✓
- #526 (Sub-2, Design Tokens) — merged ✓
- #527 (Sub-3, Templates) — merged ✓

### Next
- Sub-5: QA gate (Lighthouse, Observatory rescan, axe-core a11y, cross-browser smoke)

### Off-limits files (untouched)
- `static/js/hero-logo.js`
- `.github/workflows/deploy.yml`