### PR TITLE
Sub-4-bis: COEP require-corp + subresource CI gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,12 @@ jobs:
           cp -r static/images public/
           cp static/robots.txt static/ithelp-logo-sig-seablue.html static/ithelp-logo-sig-gold.html static/ithelp-anilogo.html static/red-plus.ico static/bimi-logo.svg public/
 
+      - name: Verify no external subresources (COEP require-corp gate)
+        # Fails the deploy if any built page loads a cross-origin script/style/image/iframe/etc.
+        # Required because csp-policy-v1.json sets Cross-Origin-Embedder-Policy: require-corp.
+        # See infra/cloudfront/csp-policy-v1.json and PROJECT_EVOLUTION_LOG.md (Sub-4-bis).
+        run: ./scripts/check-no-external-subresources.sh
+
       - name: Update CloudFront signature-pages security headers policy (CSP)
         run: |
           if [ -n "${POLICY_ID_SIGNATURES:-}" ]; then

--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,23 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-04-17 (Sub-4-bis · COEP promotion)
+- Actor: AI (CSP follow-up)
+- Scope: Promote `Cross-Origin-Embedder-Policy: require-corp` and add a CI gate that prevents future blog posts / template changes from silently breaking it. This is the follow-up the Sub-5 entry below documented as "safe to ship now."
+- Files:
+  - `infra/cloudfront/csp-policy-v1.json` — added COEP header, Quantity 3 → 4
+  - `scripts/check-no-external-subresources.sh` — new CI gate
+  - `.github/workflows/deploy.yml` — wired the gate in after the asset-copy step, before the CSP-update step
+  - `PROJECT_EVOLUTION_LOG.md` — this entry
+- Change:
+  1. Appended `Cross-Origin-Embedder-Policy: require-corp` to `csp-policy-v1.json`'s `CustomHeadersConfig.Items`. `require-corp` (not `same-origin`, which is not a valid COEP value — that confusion is with COOP) is the strict variant Mozilla Observatory awards bonus points for. Safe to ship because Sub-5's subresource crawl returned zero external loads.
+  2. New CI gate `scripts/check-no-external-subresources.sh` parses every built `*.html` (excluding signature pages on their separate CF behavior) and fails with a clear error if it finds any cross-origin `<script src>`, `<link rel=stylesheet|preload|modulepreload|icon|manifest|mask-icon|apple-touch-icon|prefetch href>`, `<img src>`, `<iframe src>`, `<video src>`, `<audio src>`, `<source src>`, `<embed src>`, or `<object data>`. Verified locally: exits 0 against current `public/`.
+  3. Wired into `deploy.yml` as a new step between "Copy images and root files" and the CSP-update steps. Fails closed: if a future change introduces an external embed, the deploy aborts BEFORE the CSP/headers policy is updated, so production stays serving the previous (working) policy.
+- Why: One more Observatory bonus (COEP `require-corp` is +5 in the standard scoring), and a permanent safety net so the COEP header can never silently break.
+- Confirmed safe by: `update_policy.sh → generate_policy.py` only mutates `SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy`. It never touches `CustomHeadersConfig`. The new COEP header therefore survives every future CSP regeneration without special handling.
+- Optional future improvement (not in this PR): add a separate workflow job that runs the gate on PR (the current deploy job is gated on `event_name == 'push'`, so PRs only catch this at merge time). The gate is fast (<100ms) so a PR-time run is cheap.
+- Rollback: revert this branch's commits, or remove the COEP item from `csp-policy-v1.json` and bump Quantity 4 → 3.
+
 ### 2026-04-17
 - Actor: AI (Sub-agent 5: Quality-Gate Verification)
 - Scope: Final QA gate for the design-transfer/v1 redesign per `.agent-transfer/plans/port-checklist.md` Sub-5. Bookend entry for the redesign work begun in Sub-1.

--- a/infra/cloudfront/csp-policy-v1.json
+++ b/infra/cloudfront/csp-policy-v1.json
@@ -45,8 +45,13 @@
         "Header": "Cross-Origin-Resource-Policy",
         "Value": "same-origin",
         "Override": true
+      },
+      {
+        "Header": "Cross-Origin-Embedder-Policy",
+        "Value": "require-corp",
+        "Override": true
       }
     ],
-    "Quantity": 3
+    "Quantity": 4
   }
 }

--- a/scripts/check-no-external-subresources.sh
+++ b/scripts/check-no-external-subresources.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# CI gate: fail the build if any built page loads a cross-origin subresource.
+#
+# This is the safety net for the COEP `require-corp` header (Sub-4-bis).
+# COEP requires every subresource to either be same-origin or carry an
+# explicit CORP / CORS opt-in from the cross-origin server. The site has
+# zero external subresources today; this gate prevents a future blog post
+# (or template change) from silently breaking the COEP-protected pages.
+#
+# Excludes the signature page (`ithelp-anilogo.html`) which is served by a
+# separate CloudFront behavior with its own response-headers policy.
+#
+# Usage: run from repo root after `zola build`.
+#   scripts/check-no-external-subresources.sh
+#
+# Exit codes:
+#   0 — no external subresources found
+#   1 — at least one external subresource found (blocks deploy)
+#   2 — build output missing (run `zola build` first)
+set -euo pipefail
+
+PUBLIC_DIR="${PUBLIC_DIR:-public}"
+
+if [ ! -d "$PUBLIC_DIR" ]; then
+  echo "error: $PUBLIC_DIR not found — run 'zola build' first" >&2
+  exit 2
+fi
+
+python3 - "$PUBLIC_DIR" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+public = Path(sys.argv[1])
+SITE_ORIGINS = ("it-help.tech",)  # any apex/subdomain treated as same-site
+
+# Subresource attributes that COEP cares about.
+# - <script src>, <img src>, <iframe src>, <video src>, <audio src>, <source src>, <embed src>, <object data>
+# - <link rel=stylesheet|preload|modulepreload|icon|manifest|mask-icon|apple-touch-icon|prefetch href>
+# - srcset / imagesrcset (responsive images) — comma-separated URL+descriptor list
+# - <video poster=...>
+SUBRESOURCE_RE = re.compile(
+    r'<(?:script|img|iframe|video|audio|source|embed)[^>]+\bsrc\s*=\s*["\']([^"\']+)|'
+    r'<object[^>]+\bdata\s*=\s*["\']([^"\']+)|'
+    r'<link[^>]+\brel\s*=\s*["\'](?:stylesheet|preload|modulepreload|icon|manifest|mask-icon|apple-touch-icon|prefetch)["\'][^>]*\bhref\s*=\s*["\']([^"\']+)|'
+    r'<link[^>]+\bhref\s*=\s*["\']([^"\']+)["\'][^>]*\brel\s*=\s*["\'](?:stylesheet|preload|modulepreload|icon|manifest|mask-icon|apple-touch-icon|prefetch)|'
+    r'<video[^>]+\bposter\s*=\s*["\']([^"\']+)',
+    re.IGNORECASE,
+)
+# srcset attributes can hold N comma-separated URLs; handle separately.
+SRCSET_RE = re.compile(
+    r'\b(?:imagesrcset|srcset)\s*=\s*["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+
+def is_external(url: str) -> bool:
+    if not url.startswith(("http://", "https://", "//")):
+        return False
+    return not any(o in url for o in SITE_ORIGINS)
+
+def iter_srcset_urls(value: str):
+    # `srcset` is "URL [descriptor], URL [descriptor], ..." per HTML spec.
+    for candidate in value.split(","):
+        url = candidate.strip().split()[0] if candidate.strip() else ""
+        if url:
+            yield url
+
+violations = []
+for html_file in sorted(public.rglob("*.html")):
+    # Signature pages are served by a separate CloudFront behavior with their own policy.
+    if html_file.name == "ithelp-anilogo.html":
+        continue
+    if html_file.name.startswith("ithelp-logo-sig-"):
+        continue
+    text = html_file.read_text(encoding="utf-8")
+    for match in SUBRESOURCE_RE.finditer(text):
+        url = next((g for g in match.groups() if g), None)
+        if url and is_external(url):
+            violations.append((html_file.relative_to(public), url))
+    for match in SRCSET_RE.finditer(text):
+        for url in iter_srcset_urls(match.group(1)):
+            if is_external(url):
+                violations.append((html_file.relative_to(public), url))
+
+if violations:
+    print(f"FAIL: {len(violations)} external subresource(s) found.", file=sys.stderr)
+    print("COEP require-corp requires every subresource to be same-origin or carry CORP/CORS opt-in.", file=sys.stderr)
+    print("Either remove the embed, host the asset locally, or relax COEP in csp-policy-v1.json.", file=sys.stderr)
+    print("", file=sys.stderr)
+    for page, url in violations:
+        print(f"  {page}: {url}", file=sys.stderr)
+    sys.exit(1)
+
+print("OK: 0 external subresources across all site pages — COEP require-corp is safe.")
+PY


### PR DESCRIPTION
Follow-up to PR #528 (Sub-4) and PR #529 (Sub-5). Promotes COEP and installs the safety net the Sub-5 entry recommended.

## What this PR does
1. **COEP `require-corp`** added to `infra/cloudfront/csp-policy-v1.json` (Quantity 3 → 4). Standard Mozilla Observatory bonus. Safe to ship because Sub-5 verified zero external subresources across the built site.
2. **New CI gate `scripts/check-no-external-subresources.sh`** — parses every built `*.html` (excluding signature pages on their separate CF behavior) and fails if any cross-origin subresource is found. Covers `<script src>`, `<img src>` + `srcset`, `<link rel=stylesheet|preload|modulepreload|icon|manifest|mask-icon|apple-touch-icon|prefetch href>`, `<iframe src>`, `<video src>` + `poster`, `<audio src>`, `<source src>`, `<embed src>`, `<object data>`, and `imagesrcset`.
3. **Wired into `.github/workflows/deploy.yml`** as a new step between asset-copy and the CSP-update steps. Fails closed: if a future change introduces an external embed, the deploy aborts BEFORE the CSP/headers policy is updated, so production keeps serving the previous (working) policy.

## Verified locally
- `zola build` clean.
- Gate exits **0** against current `public/` (matches Sub-5 finding).
- Negative test against a synthetic page with planted external `srcset`, `<link rel=preload>`, and `<video poster>` URLs: gate exits **1** with all three URLs reported by name.
- `update_policy.sh` → `generate_policy.py` only mutates `SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy` and never touches `CustomHeadersConfig`, so the new COEP header is stable across all future CSP regenerations.

## Architect review
APPROVED. Zero CRITICAL/HIGH/MEDIUM issues. Sole LOW nit (initial regex missed `srcset` / `imagesrcset` / `poster`) was addressed in the same commit before pushing.

## Optional future improvement (not in this PR)
The deploy job is gated on `event_name == push`, so PRs only catch violations at merge time. Adding a separate workflow job that runs the gate on PR would shift the failure left. The gate runs in <100ms so it is cheap to add.

## Stacking note
Independent of PR #529 (docs-only). Either order of merge works.