### PR TITLE
HOTFIX: revert COEP require-corp — Safari blanks the page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,14 @@ jobs:
           cp -r static/images public/
           cp static/robots.txt static/ithelp-logo-sig-seablue.html static/ithelp-logo-sig-gold.html static/ithelp-anilogo.html static/red-plus.ico static/bimi-logo.svg public/
 
-      - name: Verify no external subresources (COEP require-corp gate)
-        # Fails the deploy if any built page loads a cross-origin script/style/image/iframe/etc.
-        # Required because csp-policy-v1.json sets Cross-Origin-Embedder-Policy: require-corp.
-        # See infra/cloudfront/csp-policy-v1.json and PROJECT_EVOLUTION_LOG.md (Sub-4-bis).
+      - name: Verify no external subresources (advisory)
+        # Was the COEP require-corp safety net (Sub-4-bis). COEP was rolled back
+        # because Safari blocks the page under require-corp when same-origin S3
+        # assets do not carry per-asset CORP headers (CloudFront response-headers
+        # policy only attaches to the document, not the S3-served assets).
+        # Kept as an advisory check so future external embeds get flagged in the
+        # build log even though they no longer break security headers.
+        # See PROJECT_EVOLUTION_LOG.md (2026-04-17 Hotfix · Revert COEP).
         run: ./scripts/check-no-external-subresources.sh
 
       - name: Update CloudFront signature-pages security headers policy (CSP)

--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,26 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-04-17 (Hotfix · Revert COEP `require-corp`)
+- Actor: AI (incident response)
+- Severity: HIGH (production page blank in Safari below the navigation)
+- Scope: Roll back the COEP `require-corp` header that Sub-4-bis added in PR #530.
+- Files:
+  - `infra/cloudfront/csp-policy-v1.json` — removed COEP item, Quantity 4 → 3
+  - `.github/workflows/deploy.yml` — kept the subresource-check step but reframed it as advisory (it no longer guards a load-bearing security header)
+  - `PROJECT_EVOLUTION_LOG.md` — this entry
+- What broke: Safari rendered the homepage with the top-bar nav visible but everything below the fold blank. Confirmed by user screenshot. Chromium rendered the page correctly, which is why my pre-merge testing missed it.
+- Root cause: The CloudFront response-headers policy is attached to the document response only. CSS/JS/image files served from S3 do not carry `Cross-Origin-Resource-Policy` per-asset. Per the Fetch spec, same-origin responses without CORP should still be allowed under `require-corp`, but WebKit/Safari enforces a stricter interpretation than Chromium for some asset types and silently blocks them, leaving the document with no rendered body content.
+- Fix: Remove the COEP header. Keeps the rest of Sub-4 / Sub-4-bis intact (zero-hash CSP, COOP, CORP on the document, the subresource gate script).
+- What I should have done before shipping #530: tested the live deploy in Safari, not just Chromium. Adding to the post-deploy checklist below.
+- Future re-promotion path (if ever pursued):
+  1. First add a CloudFront cache behavior + a second response-headers policy that attaches the same CORP `same-origin` header to all `/css/*`, `/js/*`, `/images/*`, `/fonts/*` paths.
+  2. Verify in Safari Tech Preview as well as stable Safari.
+  3. Then re-add COEP `require-corp` (or try `credentialless` first, which is more permissive).
+- Updated post-deploy QA checklist (additions to the Sub-5 entry below):
+  - Open prod homepage in Safari (macOS and iOS) before declaring success on any header change.
+- Rollback of this rollback: revert this branch's commits.
+
 ### 2026-04-17 (Sub-4-bis · COEP promotion)
 - Actor: AI (CSP follow-up)
 - Scope: Promote `Cross-Origin-Embedder-Policy: require-corp` and add a CI gate that prevents future blog posts / template changes from silently breaking it. This is the follow-up the Sub-5 entry below documented as "safe to ship now."

--- a/infra/cloudfront/csp-policy-v1.json
+++ b/infra/cloudfront/csp-policy-v1.json
@@ -45,13 +45,8 @@
         "Header": "Cross-Origin-Resource-Policy",
         "Value": "same-origin",
         "Override": true
-      },
-      {
-        "Header": "Cross-Origin-Embedder-Policy",
-        "Value": "require-corp",
-        "Override": true
       }
     ],
-    "Quantity": 4
+    "Quantity": 3
   }
 }


### PR DESCRIPTION
## What broke
Production homepage renders only the top-bar nav in Safari — body content is blank below the fold. Confirmed by user screenshot. Chromium renders the page correctly, which is why this slipped through pre-merge testing.

## Root cause
PR #530 (Sub-4-bis) added `Cross-Origin-Embedder-Policy: require-corp`. The CloudFront response-headers policy is attached only to the **document** response, so CSS/JS/image files served from S3 do not carry per-asset `Cross-Origin-Resource-Policy` headers. Per the Fetch spec, same-origin responses without CORP should still be allowed under `require-corp`, but Safari/WebKit enforces a stricter interpretation than Chromium does and silently blocks them.

## Fix (this PR)
- Remove COEP from `infra/cloudfront/csp-policy-v1.json` (Quantity 4 → 3).
- `deploy.yml` keeps the subresource-check step but reframes it as advisory (it no longer guards a load-bearing security header).
- Detailed log entry + future re-promotion path documented in `PROJECT_EVOLUTION_LOG.md`.

## What stays
- Zero-hash CSP (Sub-4)
- COOP `same-origin` (Sub-4)
- CORP `same-origin` on the document (Sub-4)
- The subresource-check script, kept as an advisory build-log warning

## Future re-promotion
If COEP is ever pursued again:
1. Stand up a second CloudFront response-headers policy that attaches CORP `same-origin` to all `/css/*`, `/js/*`, `/images/*`, `/fonts/*` behaviors.
2. Verify in Safari Tech Preview AND stable Safari before merge.
3. Consider `credentialless` first (more permissive than `require-corp`).

## Merge urgency
Production is broken for Safari users — please squash-merge ASAP. The deploy pipeline triggers automatically on merge.