### PR TITLE
Fix CodeQL: SCRIPT_TAG_RE matches malformed end tags

### DIFF
--- a/infra/cloudfront/generate_policy.py
+++ b/infra/cloudfront/generate_policy.py
@@ -27,7 +27,7 @@ from typing import Callable, Iterable
 
 
 STYLE_TAG_RE = re.compile(r"<style\b([^>]*)>(.*?)</style>", re.IGNORECASE | re.DOTALL)
-SCRIPT_TAG_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.IGNORECASE | re.DOTALL)
+SCRIPT_TAG_RE = re.compile(r"<script\b([^>]*)>(.*?)</script\b[^>]*>", re.IGNORECASE | re.DOTALL)
 SRC_ATTR_RE = re.compile(r"\bsrc\s*=", re.IGNORECASE)
 # Per W3C CSP §6.6.4.2, scripts whose `type` is not a valid JS MIME type are
 # treated as DATA blocks (e.g. JSON-LD, importmap, speculationrules) and are


### PR DESCRIPTION
## What CodeQL flagged
`infra/cloudfront/generate_policy.py:30` — `SCRIPT_TAG_RE` used `</script>` as the closing anchor, which does not match end tags with trailing whitespace or attributes (`</script >`, `</script\n>`, `</script bar=baz>`). An attacker authoring blog-post HTML could slip past the script extractor used during CSP hash generation by inserting whitespace before the closing `>`.

## Fix (CodeQL autofix)
Replace `</script>` with `</script\b[^>]*>`:
- `\b` keeps `</scriptfoo>` from matching
- `[^>]*` accepts any whitespace/attributes before `>`

## Verified locally
| Input | Match? | Expected |
|---|---|---|
| `<script>alert(1)</script>` | yes | yes |
| `<script type="application/ld+json">{}</script>` | yes | yes |
| `<script>x</script >` | yes | yes |
| `<script>x</script\n>` | yes | yes |
| `<script>x</scriptfoo>` | no | no |
| `<script>x</script bar=baz>` | yes | yes |

No behavior change for any real script tag in the repo. Hash generation output is byte-identical to before.

## Merge order
Independent of PR #531 (the COEP hotfix). Either order is fine.