### PR TITLE
Fix CodeQL: use execFile in package_abridge.js

### DIFF
--- a/themes/abridge/package_abridge.js
+++ b/themes/abridge/package_abridge.js
@@ -4,9 +4,9 @@ const TOML = require('fast-toml');
 const UglifyJS = require('uglify-js');
 const jsonminify = require("jsonminify");
 const util = require("util");
-const { exec } = require("child_process");
+const { execFile } = require("child_process");
 const { exit } = require('process');
-const execPromise = util.promisify(exec);
+const execFilePromise = util.promisify(execFile);
 
 if (!(fs.existsSync('config.toml'))) {
   throw new Error('ERROR: cannot find config.toml!');
@@ -33,7 +33,7 @@ const pwa_IGNORE_FILES = data.extra.pwa_IGNORE_FILES;
 
 // This is used to pass arguments to zola via npm, for example:
 // npm run abridge -- "--base-url https://abridge.pages.dev"
-let args = process.argv[2] ? ' ' + process.argv[2] : '';
+let args = process.argv.slice(2);
 
 // check if abridge is used directly or as a theme.
 let bpath = '';
@@ -47,8 +47,8 @@ _rmRegex(path.join(__dirname, "static/js/"), /^pagefind-entry.*json$/);
 _rmRecursive(path.join(__dirname, "static/js/index"));
 _rmRecursive(path.join(__dirname, "static/js/fragment"));
 
-async function execWrapper(cmd) {
-  const { stdout, stderr } = await execPromise(cmd);
+async function execWrapper(cmd, cmdArgs = []) {
+  const { stdout, stderr } = await execFilePromise(cmd, cmdArgs);
   if (stdout) {
     console.log(stdout);
   }
@@ -71,7 +71,7 @@ async function setIndexFormat() {
     replaceInFileSync({ files: 'config.toml', from: /index_format.*=.*/g, to: `index_format = "${format}"` });
   }
   if (search_library === 'offline') {
-    args = args + ` -u "${__dirname}/public"`;
+    args.push('-u', path.join(__dirname, 'public'));
   }
 }
 
@@ -202,7 +202,7 @@ async function abridge() {
   await setIndexFormat();
 
   console.log('Zola Build to generate files for minification:');
-  await execWrapper('zola build' + args);
+  await execWrapper('zola', ['build', ...args]);
 
   ensureStaticJsDir();
 
@@ -240,7 +240,7 @@ async function abridge() {
   _rmRegex(path.join(__dirname, 'static/js/'), /^pagefind_search\.js$/);
 
   console.log('Zola Build to generate new integrity hashes for the previously minified files:');
-  await execWrapper('zola build' + args);
+  await execWrapper('zola', ['build', ...args]);
 }
 
 async function _headersWASM() {


### PR DESCRIPTION
## What CodeQL flagged
`themes/abridge/package_abridge.js:7` — `execWrapper` concatenated `process.argv[2]` and `__dirname` into a string passed to `child_process.exec`, which spawns a shell. Tagged as *Shell command built from environment values* / *uncontrolled absolute path*.

## Fix (CodeQL autofix, applied to both call sites)
- `exec` → `execFile` (no shell)
- `process.argv[2]` string concat → `process.argv.slice(2)` array
- `args + " -u \"${__dirname}/public\""` → `args.push("-u", path.join(__dirname, "public"))`
- `execWrapper("zola build" + args)` → `execWrapper("zola", ["build", ...args])`

The autofix diff in CodeQL only showed the first call site (line 205). I applied the same transform to the second one at line 243 — same string-concat pattern.

## Verified locally
- `node --check themes/abridge/package_abridge.js` parses cleanly
- No remaining `exec(`, `execPromise`, `"zola build"` concat, or `process.argv[N]` indexing in the file

## Scope note
This script is part of the vendored Abridge theme tooling and is **not invoked by our deploy pipeline** — `.github/workflows/deploy.yml` runs plain `zola build` directly. The fix is still worth applying so CodeQL stops flagging the repo and so anyone who later runs `node themes/abridge/package_abridge.js` does not get a shell-injection footgun.

## Merge order
Independent of #531 (COEP hotfix) and #532 (script-tag regex). Any order.