### PR TITLE
Fix CodeQL: add explicit permissions block to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,14 @@ on:
     branches:
       - main
 
+# Least-privilege default for GITHUB_TOKEN. The deploy job authenticates to AWS
+# via repository secrets (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY), not via
+# GITHUB_TOKEN, so `contents: read` is sufficient. If a future job needs to
+# write back to the repo (e.g. comment on PRs, push tags), grant the extra
+# scope on that specific job rather than widening this default.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## What CodeQL flagged
`.github/workflows/deploy.yml:11` — workflow declared no `permissions` block, so `GITHUB_TOKEN` inherits whatever default the repo / org have configured (often `write-all`).

## Fix (CodeQL autofix)
Add a top-level least-privilege block:
```yaml
permissions:
  contents: read
```

## Why this is safe (no runtime change)
The deploy job authenticates to AWS via repo secrets (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `CF_DIST_ID_IT_HELP_TECH` / etc.), **not** via `GITHUB_TOKEN`. The only thing `GITHUB_TOKEN` is used for in this workflow is the implicit `actions/checkout` clone, which only needs `contents: read`.

If a future job needs to write back to the repo (comment on PRs, push tags, etc.), grant the extra scope on that specific job rather than widening this default.

## Merge order
Independent of #531, #532, #533. Any order.