### PR TITLE
fix(deploy): quote PurgeCSS glob — homepage CSS was being stripped in production (Safari blank-body root cause)

### DIFF
--- a/.agents/skills/frontend-design/LICENSE.txt
+++ b/.agents/skills/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.agents/skills/web-design-guidelines/SKILL.md
+++ b/.agents/skills/web-design-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,25 @@ jobs:
       - name: Purge unused CSS
         run: |
           npm install -g purgecss
-          purgecss --css public/css/*.css --content public/**/*.html --output public/css/ --safelist "phone-line" --safelist "particle" --safelist "is-copied" --safelist "is-copy-error"
+          # IMPORTANT: quote the --content glob.
+          # When unquoted, bash (without `globstar`) expands `public/**/*.html`
+          # to `public/*/*.html`, which matches files in IMMEDIATE subdirs only
+          # and silently SKIPS:
+          #   - public/index.html        (homepage — selectors only used here)
+          #   - public/404.html
+          #   - public/blog/<post>/index.html  (two levels deep)
+          # The result is PurgeCSS strips ~30 KB of homepage-specific rules
+          # (.hero-wrapper, .logo-container, .homepage-body, .homepage-hero,
+          #  .tech-particles, .main-logo, .tagline, .blob, .hex-decoration, …)
+          # from late-overrides.css, breaking the homepage in production.
+          # Quoting forces PurgeCSS's own glob lib (which honours `**`) to do
+          # the expansion correctly, recursively.
+          purgecss \
+            --css public/css/*.css \
+            --content "public/**/*.html" \
+            --output public/css/ \
+            --safelist "phone-line" --safelist "particle" \
+            --safelist "is-copied" --safelist "is-copy-error"
 
       - name: Minify CSS and hero JS (safe ship-time optimization)
         run: |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "skills": {
+    "frontend-design": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "computedHash": "063a0e6448123cd359ad0044cc46b0e490cc7964d45ef4bb9fd842bd2ffbca67"
+    },
+    "web-design-guidelines": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "computedHash": "f3bc47f890f42a44db1007ab390709ec368e4b8c089baee6b0007182236ac474"
+    }
+  }
+}


### PR DESCRIPTION
## TL;DR

The homepage's body content disappears in Safari (macOS, iPad, iPhone) because the deploy pipeline has been silently deleting ~30 KB of homepage-only CSS rules from `late-overrides.css` for some time. The cause is a single unquoted shell glob in the PurgeCSS step. One-line behavioural fix.

## Symptom (user-reported)

> "Most of the content flashes for a second and disappears."
>
> All Apple Safari (macOS / iPad / iPhone). Homepage shows the hero/logo briefly, then the `<article class="homepage-body">` content vanishes. Chrome works.

## Root cause

In `.github/workflows/deploy.yml`, the PurgeCSS step was:

```yaml
purgecss --css public/css/*.css --content public/**/*.html --output ...
```

`--content public/**/*.html` is **unquoted**. On the GitHub Actions Ubuntu runner, bash runs with `globstar` **off** by default, so `**` is treated as plain `*`. The pattern bash actually hands to PurgeCSS is `public/*/*.html`, which matches files in **immediate** subdirectories only:

| Path | Matched? |
|---|---|
| `public/services/index.html` | ✅ |
| `public/about/index.html` | ✅ |
| `public/blog/index.html` | ✅ |
| `public/index.html` (the homepage) | ❌ |
| `public/404.html` | ❌ |
| `public/blog/<post>/index.html` (any post, 2 levels deep) | ❌ |

PurgeCSS therefore never sees the homepage HTML, so it strips every selector that's only used on the homepage. From `late-overrides.css` that means:

`.hero-wrapper`, `.logo-container`, `.homepage-body`, `.homepage-hero`, `.tech-particles`, `.particle:nth-child(N)`, `.main-logo`, `.tagline`, `.tagline-border`, `.tagline-text`, `.blob`, `.hex-decoration`, `.hex`, `.circuit-bg`, `.glitch-container`, `.location`, `.logo-it`, `.logo-help`, `.logo-help-p`, `.logo-plus`, `.logo-constellation`, `.logo-light`, `.logo-dark`, `.highlight`, `.cta-button`, …

That is **all the structural and animation CSS for the hero + body wrapper.** The hero's text still appears (it's plain markup) and the constellation still paints (it's a JS canvas), but the layout, sizing, particle field, glitch, and homepage-body wrapper are unstyled. Chrome's permissive defaults render the unstyled DOM benignly; Safari ends up collapsing/overlapping boxes such that the body content visually disappears under or beside the hero.

## Reproduction

Fresh `zola build`, then run the exact pipeline (PurgeCSS + `cleancss -O1`) two ways locally:

| Pipeline | `late-overrides.css` size | `.hero-wrapper` rules | `.homepage-hero` rules |
|---|---:|---:|---:|
| Source (no PurgeCSS) | 41,839 B | many | many |
| **Current prod (broken)** | **11,101 B** | **0** | **0** |
| Faulty pipeline (unquoted glob) | 11,101 B | 0 | 0 |
| **Fixed pipeline (quoted glob)** | **24,313 B** | **1+** | **1+** |

The faulty-pipeline number is **byte-identical** to current prod, confirming the diagnosis.

## The fix

Quote the glob. PurgeCSS's own glob library (the npm `glob` package) handles `**` recursion correctly, so once bash isn't doing the expansion, every HTML file in `public/` is scanned and the homepage selectors are preserved.

```diff
-      purgecss --css public/css/*.css --content public/**/*.html --output public/css/ ...
+      purgecss \
+        --css public/css/*.css \
+        --content "public/**/*.html" \
+        --output public/css/ \
+        ...
```

The diff is +19 / −1 lines because I also added a long warning comment so this trap can't be silently re-set by a future drive-by edit, and split the command across multiple lines for readability.

## Risk

None. The new glob is a strict superset of what bash was actually expanding before, so PurgeCSS gets **more** HTML to scan and removes **fewer** (or the same) rules — never more. Any selector that survives today survives after this PR.

## Verification after deploy

```bash
# late-overrides.css should be ~24 KB, not ~11 KB:
curl -sSI "https://www.it-help.tech/css/late-overrides.css?h=…" | grep content-length

# Homepage selectors should be present:
curl -sS "https://www.it-help.tech/css/late-overrides.css?h=…" | grep -c '\.hero-wrapper'   # > 0
curl -sS "https://www.it-help.tech/css/late-overrides.css?h=…" | grep -c '\.homepage-hero'  # > 0
curl -sS "https://www.it-help.tech/css/late-overrides.css?h=…" | grep -c '\.tech-particles' # > 0
```

Then Safari hard-refresh on `https://www.it-help.tech/` — body content should stay visible.