### PR TITLE
fix(nav): single-line topbar at all widths + active-page indicator + glass surface

### DIFF
--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -943,20 +943,36 @@ html:not(.switch) h6 a.gold-link:active {
    (more reliably retained through the prod PurgeCSS pipeline). See that
    file for the full rule and the reasoning. */
 
-/* --- Top bar shell --- */
+/* --- Top bar shell ---
+   2026-04-17 (rev): Apple-style glass surface — sticky bar with backdrop
+   blur + saturate, token-driven translucent fill so the science layer
+   reads through subtly without the topbar going invisible. The
+   color-mix() variant gives both themes consistent translucency from a
+   single source token. Older WebKit gracefully ignores color-mix() and
+   falls back to the rgba() rule below. */
 .topbar {
     position: sticky;
     top: 0;
     z-index: 100;
-    background: rgba(13, 17, 23, 0.92);
-    -webkit-backdrop-filter: saturate(160%) blur(10px);
-    backdrop-filter: saturate(160%) blur(10px);
+    background: rgba(13, 17, 23, 0.82);
+    -webkit-backdrop-filter: saturate(160%) blur(14px);
+    backdrop-filter: saturate(160%) blur(14px);
     border-bottom: 1px solid rgba(48, 54, 61, 0.6);
+}
+@supports (background: color-mix(in oklab, red, blue)) {
+    .topbar {
+        background: color-mix(in oklab, var(--surface-charcoal) 82%, transparent);
+        border-bottom-color: color-mix(in oklab, var(--brand-gold-solid) 18%, transparent);
+    }
+    html.switch .topbar {
+        background: color-mix(in oklab, var(--neutral-white) 82%, transparent);
+        border-bottom-color: color-mix(in oklab, var(--ithelp-navy) 14%, transparent);
+    }
 }
 .topbar-inner {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 0.75rem;
     max-width: 1240px;
     margin: 0 auto;
     padding: 0.5rem 1rem;
@@ -1017,17 +1033,26 @@ html:not(.switch) h6 a.gold-link:active {
     outline-offset: 2px;
 }
 
-/* --- Nav list (desktop) --- */
+/* --- Nav list (desktop) ---
+   2026-04-17 (rev): Nav wrap fix — every label gets white-space: nowrap so
+   "Field Notes" and "(619) 853-5008" stay single-line. Gaps tightened
+   (nav 1.25→0.85rem, list 1→0.6rem, link padding 0.6→0.5rem) so the bar
+   fits a 5-link nav + CTA + phone + theme toggle without stealing the
+   hero's vertical real estate. Also added active-page indicator
+   (.topbar-nav-list a[aria-current=page]) — a 2px gold underline rather
+   than a bg fill, per Apple HIG: subtle, persistent, never competes with
+   the hover state. Hover layered on top reuses the gold tint at lower
+   alpha so active+hover remain distinguishable. */
 .topbar-nav {
     display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 0.85rem;
     margin-left: auto;
 }
 .topbar-nav-list {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 0.35rem;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -1036,8 +1061,10 @@ html:not(.switch) h6 a.gold-link:active {
     color: var(--text-primary);
     font-weight: 500;
     text-decoration: none;
-    padding: 0.4rem 0.6rem;
-    border-radius: 4px;
+    padding: 0.4rem 0.55rem;
+    border-radius: 6px;
+    white-space: nowrap;
+    position: relative;
     transition: color 0.15s ease, background 0.15s ease;
 }
 .topbar-nav-list a:hover,
@@ -1045,6 +1072,22 @@ html:not(.switch) h6 a.gold-link:active {
     color: var(--brand-gold-solid);
     background: rgba(210, 181, 111, 0.08);
     outline: none;
+}
+/* Active page indicator: thin gold underline anchored to the link's
+   baseline. Drawn with a pseudo-element so it animates independently of
+   the link's color/background transitions and never affects layout. */
+.topbar-nav-list a[aria-current="page"] {
+    color: var(--brand-gold-solid);
+}
+.topbar-nav-list a[aria-current="page"]::after {
+    content: "";
+    position: absolute;
+    left: 0.55rem;
+    right: 0.55rem;
+    bottom: 0.18rem;
+    height: 2px;
+    background: var(--brand-gold-solid);
+    border-radius: 2px;
 }
 .topbar-ext {
     display: inline-block;
@@ -1063,9 +1106,14 @@ html:not(.switch) h6 a.gold-link:active {
     border: 1px solid var(--schedule-cta-border);
     color: var(--ink-azure);
     font-weight: 700;
-    padding: 0.4rem 0.95rem;
+    padding: 0.4rem 0.85rem;
     border-radius: 6px;
+    white-space: nowrap;
 }
+/* CTA never gets the active-page underline (it's an external link, not a
+   site page) — explicit override so the rule above can't accidentally
+   stack a line under the gradient. */
+.topbar-nav-list .topbar-cta[aria-current="page"]::after { content: none; }
 .topbar-nav-list .topbar-cta:hover,
 .topbar-nav-list .topbar-cta:focus-visible {
     background-image: linear-gradient(180deg,
@@ -1080,12 +1128,14 @@ html:not(.switch) h6 a.gold-link:active {
 .topbar-phone {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.35rem;
     color: var(--text-secondary);
     text-decoration: none;
     font-variant-numeric: tabular-nums;
-    font-size: 0.92rem;
+    font-size: 0.9rem;
+    white-space: nowrap;
 }
+.topbar-phone-text { white-space: nowrap; }
 .topbar-phone:hover { color: var(--brand-gold-solid); }
 .topbar-phone svg { flex-shrink: 0; }
 
@@ -1101,9 +1151,25 @@ html:not(.switch) h6 a.gold-link:active {
 .topbar-mode:hover { color: var(--brand-gold-solid); }
 
 /* ============================================================================
-   Mobile (≤ 768px) — hamburger drawer
+   Compact + mobile (≤ 960px) — hamburger drawer
    ============================================================================ */
-@media (max-width: 768px) {
+/* Compact desktop (768–960px): hide the phone label so the phone reduces
+   to its tappable icon, freeing horizontal space without losing the
+   call-to-call entry point. The icon remains a 44×44 hit target via the
+   parent <a>'s padding + flex alignment. */
+@media (min-width: 769px) and (max-width: 960px) {
+    .topbar-phone-text { display: none; }
+    .topbar-phone { padding: 0.4rem; }
+}
+
+/* 2026-04-17 (rev): Hamburger threshold raised 768 → 960px. At common
+   laptop widths (≈900-1100px) the desktop nav was cramming the banner +
+   5 nav links + Schedule CTA + phone + theme toggle into a single line,
+   forcing "Field Notes" and the phone number to wrap onto two lines.
+   Switching to the drawer at 960px keeps the laptop layout single-line
+   and pushes the rich nav into the (already polished) hamburger drawer
+   on tablets, where it belongs. */
+@media (max-width: 960px) {
     .topbar-nav-toggle-label { display: inline-block; }
 
     .topbar-nav {

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,11 +68,21 @@
       </svg>
     </label>
 
+    {# 2026-04-17: Active-page indicator wired via aria-current="page". The
+       macro picks the link whose href is a prefix of the current page path
+       (current_path always starts with "/"); a literal === is too strict
+       because Zola pretty-URLs land on /services/ but the current_path on
+       a sub-route like /services/tag/ should still highlight Services. The
+       gold underline is rendered from a [aria-current=page]::after pseudo-
+       element in CSS — so this attribute drives both the visible state and
+       the screen-reader semantics in one shot. External links (DNS Tool,
+       Schedule) are skipped — they live on different domains. #}
     <nav class="topbar-nav" aria-label="Primary">
+      {%- set cp = current_path | default(value="/") -%}
       <ul class="topbar-nav-list">
-        <li><a href="/services/">Services</a></li>
-        <li><a href="/about/">About</a></li>
-        <li><a href="/blog/">Field Notes</a></li>
+        <li><a href="/services/"{% if cp is starting_with("/services") %} aria-current="page"{% endif %}>Services</a></li>
+        <li><a href="/about/"{% if cp is starting_with("/about") %} aria-current="page"{% endif %}>About</a></li>
+        <li><a href="/blog/"{% if cp is starting_with("/blog") %} aria-current="page"{% endif %}>Field Notes</a></li>
         <li>
           <a href="https://dns.it-help.tech" target="_blank" rel="noopener noreferrer">
             DNS Tool <span class="topbar-ext" aria-hidden="true">↗</span>


### PR DESCRIPTION
## What

Nav still inconsistent — `Field Notes` and `(619) 853-5008` were wrapping onto two lines at common laptop widths. Loaded the three design skills (`frontend-design`, `ui-ux-pro-max`, `web-design-guidelines`) and applied the relevant rule categories.

## Wrap fix (root cause)

- `white-space: nowrap` on every nav `<a>`, the CTA, the phone link, and the phone label
- Gaps tightened across the topbar (inner / nav / list / link padding / CTA / phone)
- Hamburger threshold raised **768 → 960px** — keeps the desktop nav from cramming on tablets/laptops
- New compact-desktop band (769–960px) hides the phone label so the icon stays as a tappable call-link without crowding

## Polish wins

- **Active-page indicator** (ui-ux-pro-max P9 `nav-state-active`): `aria-current="page"` wired via Tera prefix match in `templates/base.html`; CSS draws a 2px gold underline via `[aria-current=page]::after`. Schedule CTA gets `content: none` override so the gradient pill never doubles up.
- **Apple-style glass topbar** (frontend-design): `backdrop-filter: saturate(160%) blur(14px)` + token-driven translucent fill via `color-mix(in oklab, …)` for both themes. Wrapped in `@supports` so older WebKit gracefully falls back to the existing rgba() rule. Gold-tinted hairline replaces the gray bottom border.

## Verification

- `scripts/check-token-parity.sh`: PASS (no hex literals introduced — `color-mix()` wraps existing tokens)
- `zola build`: clean
- Compiled CSS: all new rules survive PurgeCSS
- Built HTML: `aria-current="page"` lands correctly on `/services/`, `/about/`, `/blog/`; home page correctly emits zero `aria-current`s

## Lighthouse / a11y posture preserved

- Zero new fonts, scripts, or CSS files
- `color-mix()` + `backdrop-filter` are GPU-accelerated, no layout impact
- `aria-current="page"` is the WCAG pattern for current-location announcement
- Touch targets remain ≥44px