### PR TITLE
style(tagline): match white text weight to gold highlight (700)

### DIFF
--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -469,6 +469,12 @@ html.switch .location {
     white-space: nowrap;
     margin: 0;
     color: var(--neutral-white);
+    /* Match the highlight weight (700) so "IT research" reads with the
+       same visual presence as "in motion" — owner noted the white words
+       looked thin next to the bolded gold phrase. Same weight on both
+       segments produces a unified line, with the gold accent doing the
+       emphasis work via color, not weight. */
+    font-weight: 700;
     padding: 0;
     background-color: transparent;
     background-image: none;


### PR DESCRIPTION
Owner: *"the words IT and research that are in white, can they be bolded somehow? The research just looks a little thin."*

Root: `.highlight` (gold `in motion`) was already `font-weight: 700`, but `.tagline-text` (white `IT research`) had no font-weight set so it inherited regular (~400). Visual mismatch was real.

Fix: `.tagline-text { font-weight: 700; }` — both segments now share weight, gold does the emphasis via color.

Files: `static/css/late-overrides.css`

Verified: zola build clean, token-parity PASS, visual confirms unified weight.