### PR TITLE
fix+copy: skip-link artifact + DNS Tool subdomain + homepage mission/La Jolla/multi-platform positioning

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -234,7 +234,7 @@ twitter_card        = "summary_large_image"
 </section>
 
 <p><a class="cta-button" href="https://schedule.it-help.tech/" target="_blank" rel="noopener noreferrer">Book an On‑Site Visit</a></p>
-<p><a class="cta-button cta-secondary" href="https://dns.it-help.tech" target="_blank" rel="noopener noreferrer">See Our Research</a></p>
+<p><a class="cta-button cta-secondary" href="https://dnstool.it-help.tech" target="_blank" rel="noopener noreferrer">See Our Research</a></p>
 
 ## What we do
 
@@ -255,7 +255,7 @@ We rescue email from spam folders by aligning SPF, DKIM, and DMARC against the a
 
 ## The Method
 
-We treat each engagement as a small research problem. Before we touch a config, we capture the evidence — packet traces, mail headers, DNS responses, system logs — and reason from there. The same instinct produced our public DNS research platform at <a href="https://dns.it-help.tech" class="gold-link" target="_blank" rel="noopener noreferrer">dns.it-help.tech</a>, where we publish what we learn from the wire. <a href="/blog/" class="gold-link">Read the field notes →</a>
+We treat each engagement as a small research problem. Before we touch a config, we capture the evidence — packet traces, mail headers, DNS responses, system logs — and reason from there. The same instinct produced our public DNS research platform at <a href="https://dnstool.it-help.tech" class="gold-link" target="_blank" rel="noopener noreferrer">dnstool.it-help.tech</a>, where we publish what we learn from the wire. <a href="/blog/" class="gold-link">Read the field notes →</a>
 
 ## Local credibility
 

--- a/content/services.md
+++ b/content/services.md
@@ -365,7 +365,7 @@ We resolve email deliverability and domain-security problems by going to the wir
 * **DNS edits and configuration** for MX, SPF, DKIM, DMARC, DNSSEC, and BIMI.
 * **DMARC enforcement** to `p=reject`, staged carefully through monitor and quarantine.
 * **Website and domain recovery** when access has been lost.
-* **Public research platform:** [dns.it-help.tech](https://dns.it-help.tech) — the same diagnostic depth we apply to client domains, available for anyone to use.
+* **Public research platform:** [dnstool.it-help.tech](https://dnstool.it-help.tech) — the same diagnostic depth we apply to client domains, available for anyone to use.
 
 ## Cybersecurity & Ethical Screen Sharing {#cybersecurity}
 

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -480,9 +480,19 @@ section h2 {
    — zero hex literals (intentional: hex values discussed only in prose
    above are kept token-named, not literal).
    ========================================================================== */
+/* Skip link uses transform: translateY(-100%) instead of a hardcoded
+   negative top. The previous `top: -40px` was a pixel guess — at the
+   actual rendered link height (~44px with bold + padding + line-height
+   at 16px base) it leaked roughly 4px of pale-blue into the top-left
+   of every page. transform: translateY(-100%) hides the element by
+   exactly its own rendered height regardless of font size, padding,
+   user zoom, or future copy changes — the standards-compliant pattern
+   used by github.com, apple.com, gov.uk, and the WAI-ARIA Authoring
+   Practices reference implementation. left:0/top:0 anchor the visible
+   focused state to the corner; the transform handles hide/reveal. */
 a.skip-link {
   position: absolute;
-  top: -40px;
+  top: 0;
   left: 0;
   padding: 8px 14px;
   background: var(--brand-blue);
@@ -491,11 +501,12 @@ a.skip-link {
   text-decoration: none;
   border-radius: 0 0 6px 0;
   z-index: 9999;
-  transition: top 0.18s ease;
+  transform: translateY(-100%);
+  transition: transform 0.18s ease;
 }
 a.skip-link:focus,
 a.skip-link:focus-visible {
-  top: 0;
+  transform: translateY(0);
   color: var(--neutral-black);
   background: var(--brand-blue);
   outline: 2px solid var(--brand-gold-solid);

--- a/templates/base.html
+++ b/templates/base.html
@@ -93,7 +93,7 @@
           {%- elif cp is starting_with("/blog/") %} aria-current="true"
           {%- endif %}>Field Notes</a></li>
         <li>
-          <a href="https://dns.it-help.tech" target="_blank" rel="noopener noreferrer">
+          <a href="https://dnstool.it-help.tech" target="_blank" rel="noopener noreferrer">
             DNS Tool <span class="topbar-ext" aria-hidden="true">↗</span>
           </a>
         </li>

--- a/templates/partials/_footer-org.html
+++ b/templates/partials/_footer-org.html
@@ -69,7 +69,7 @@
             </div>
             <div class="ftr-org-dept-right">
                 <div class="ftr-org-dept-arm"></div>
-                <a href="https://dns.it-help.tech" target="_blank" rel="noopener" class="ftr-node">
+                <a href="https://dnstool.it-help.tech" target="_blank" rel="noopener" class="ftr-node">
                     <svg class="ftr-icon" aria-hidden="true"><use href="#i-brain"/></svg>
                     DNS Tool (Research Platform)
                 </a>
@@ -102,14 +102,14 @@
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-microchip"/></svg> Expertise</span>
             <a href="/about" class="ftr-link">25+ Years Experience</a>
             <a href="/about#clients" class="ftr-link">High-Profile Clients</a>
-            <a href="https://dns.it-help.tech" target="_blank" rel="noopener" class="ftr-link">Research Platform</a>
+            <a href="https://dnstool.it-help.tech" target="_blank" rel="noopener" class="ftr-link">Research Platform</a>
             <a href="/blog" class="ftr-link">Field Notes</a>
         </div>
         <div class="ftr-cell">
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-shield"/></svg> Trust</span>
             <a href="/security-policy" class="ftr-link">Security Policy</a>
             <a href="/billing" class="ftr-link">Billing &amp; Pricing</a>
-            <a href="https://dns.it-help.tech/privacy" target="_blank" rel="noopener" class="ftr-link">Privacy</a>
+            <a href="https://dnstool.it-help.tech/privacy" target="_blank" rel="noopener" class="ftr-link">Privacy</a>
             <a href="/brand-colors" class="ftr-link">Brand Colors</a>
         </div>
         <div class="ftr-cell">


### PR DESCRIPTION
## Root cause (finally)

Owner reported a thin pale-blue horizontal bar at the top-left of every page on live production, visible across iPad/iPhone simulators and desktop screenshots. After three wrong attempts at the topbar (PRs #547/#548/#550 — last one closed unmerged), I diffed the homepage HTML vs the DNS tool HTML and confirmed the topbar markup and CSS are byte-identical between pages, so the artifact could not be in .topbar.

The first element in body on every page is the skip link, positioned `top: -40px` with background var(--brand-blue) and padding 8px 14px / font-weight 700.

The link's actual rendered height (bold text + 16px vertical padding + line-height at 16px base) is ~44px, not 40. The -40px offset leaves ~4px of pale blue protruding into the viewport at the top-left. Exactly the artifact in every screenshot, every page.

## Fix
Replace the pixel offset with `transform: translateY(-100%)`, which hides the element by its own rendered height regardless of font size, padding, user zoom, future copy changes, or translation. WAI-ARIA Authoring Practices reference pattern; also used by github.com, apple.com, gov.uk.

## Preserved
- WCAG 2.4.1 Bypass Blocks (skip link still functional)
- Slide-in animation on focus (transition swapped from top to transform)
- Gold WCAG focus outline (PR #545)
- Color contrast ~9:1 AAA

## Cleanup
PR #550 closed unmerged (any-pointer/any-hover topbar change based on wrong hypothesis). Production back to exactly post-PR-#549 state, no orphan changes.