### PR TITLE
copy(home): mission-based positioning + La Jolla emphasis + multi-platform truth

### DIFF
--- a/.replit
+++ b/.replit
@@ -42,3 +42,7 @@ externalPort = 80
 deploymentTarget = "static"
 build = ["zola", "build"]
 publicDir = "public"
+
+[postMerge]
+path = "scripts/post-merge.sh"
+timeoutMs = 60000

--- a/content/_index.md
+++ b/content/_index.md
@@ -198,7 +198,7 @@ twitter_card        = "summary_large_image"
       "@id": "https://www.it-help.tech/#webpage",
       "url": "https://www.it-help.tech/",
       "name": "Mac IT Support San Diego (La Jolla) | IT Help San Diego",
-      "description": "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla and San Diego. macOS and iOS first, with Unix, Linux, and Windows — a system is a system. 25 years across systems, networks, DNS, and email security (SPF · DKIM · DMARC). No hardware sales, no monthly retainers.",
+      "description": "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla and San Diego. macOS and iOS first, with Unix, Linux, and Windows — a system is a system. 27 years across systems, networks, DNS, and email security (SPF · DKIM · DMARC). No hardware sales, no monthly retainers.",
       "inLanguage": "en-US",
       "isPartOf": {
         "@id": "https://www.it-help.tech/#website"
@@ -252,7 +252,7 @@ macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientifi
 
 ## Trust signals
 
-- **25+ years** in the field, across macOS, networking, and DNS.
+- **27+ years** in the field, across macOS, Linux, Windows, network architecture, and DNS.
 - **High-profile clients** in entertainment, legal, restaurant, and medical sectors. Discretion comes standard; logos do not.
 - **Federal A+ DNS posture** on our own infrastructure — the same standards we apply to client domains.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -247,8 +247,8 @@ Bespoke wireless and wired networks for large homes, estates, and small offices.
 ### <a href="/services/#dns-email" class="gold-link">Email Deliverability &amp; DNS Forensics</a>
 We rescue email from spam folders by aligning SPF, DKIM, and DMARC against the actual sending surface — including SPF macro expansion checked against RFC 7208 §7.4. <a href="/services/#dns-email" class="gold-link">Learn more →</a>
 
-### <a href="/services/" class="gold-link">Cross-Platform Systems Engineering</a>
-macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. From shell scripts to file servers to mixed-OS environments, we engage the problem, not the logo. <a href="/services/" class="gold-link">Learn more →</a>
+### <a href="/services/#cross-platform" class="gold-link">Cross-Platform Systems Engineering</a>
+macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. From shell scripts to file servers to mixed-OS environments, we engage the problem, not the logo. <a href="/services/#cross-platform" class="gold-link">Learn more →</a>
 
 ## Trust signals
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,15 +1,15 @@
 +++
 title       = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-description = "Apple-centric IT support in San Diego for homes and SMBs: Mac, Wi‑Fi, DNS, and email security (SPF, DKIM, DMARC). No monthly retainers."
+description = "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no monthly retainers."
 
 [extra]
 seo_title       = "Mac IT Support San Diego"
 og_title        = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-og_description  = "Apple-centric IT support in San Diego for homes and SMBs: Mac, Wi‑Fi, DNS, and email security (SPF, DKIM, DMARC). No monthly retainers."
+og_description  = "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no monthly retainers."
 og_image        = "/images/og-home.png"
 
 twitter_title       = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-twitter_description = "Apple-centric IT support in San Diego for homes and SMBs: Mac, Wi‑Fi, DNS, and email security (SPF, DKIM, DMARC). No monthly retainers."
+twitter_description = "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no monthly retainers."
 twitter_image       = "/images/og-home.png"
 twitter_card        = "summary_large_image"
 +++
@@ -101,7 +101,7 @@ twitter_card        = "summary_large_image"
   "sameAs": [
     "https://www.linkedin.com/company/it-help-san-diego"
   ],
-  "description": "Apple‑centric tech help for homes & SMBs—no monthly retainers.",
+  "description": "Apple‑centric IT and deep-research diagnostics for La Jolla & San Diego — Mac first, with Unix, Linux, and Windows. No hardware sales, no monthly retainers.",
   "knowsAbout": [
     "macOS troubleshooting",
     "iOS troubleshooting",
@@ -198,7 +198,7 @@ twitter_card        = "summary_large_image"
       "@id": "https://www.it-help.tech/#webpage",
       "url": "https://www.it-help.tech/",
       "name": "Mac IT Support San Diego (La Jolla) | IT Help San Diego",
-      "description": "San Diego Apple-centric IT support for homes & SMBs: 25 yrs fixing Mac, Wi‑Fi, DNS & email (SPF · DKIM · DMARC). We solve tech problems—no monthly retainers.",
+      "description": "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla and San Diego. macOS and iOS first, with Unix, Linux, and Windows — a system is a system. 25 years across systems, networks, DNS, and email security (SPF · DKIM · DMARC). No hardware sales, no monthly retainers.",
       "inLanguage": "en-US",
       "isPartOf": {
         "@id": "https://www.it-help.tech/#website"
@@ -230,7 +230,7 @@ twitter_card        = "summary_large_image"
     <span class="hero-line-primary">We solve tech problems.</span>
     <span class="hero-line-secondary">No monthly retainers.</span>
   </h1>
-  <p class="hero-subtagline">Apple-centric IT, deep-research diagnostics, San Diego concierge.</p>
+  <p class="hero-subtagline">Apple-centric IT, deep-research diagnostics, systems &amp; networks — La Jolla concierge for greater San Diego.</p>
 </section>
 
 <p><a class="cta-button" href="https://schedule.it-help.tech/" target="_blank" rel="noopener noreferrer">Book an On‑Site Visit</a></p>
@@ -246,6 +246,9 @@ Bespoke wireless and wired networks for large homes, estates, and small offices.
 
 ### <a href="/services/#dns-email" class="gold-link">Email Deliverability &amp; DNS Forensics</a>
 We rescue email from spam folders by aligning SPF, DKIM, and DMARC against the actual sending surface — including SPF macro expansion checked against RFC 7208 §7.4. <a href="/services/#dns-email" class="gold-link">Learn more →</a>
+
+### <a href="/services/" class="gold-link">Cross-Platform Systems Engineering</a>
+macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. From shell scripts to file servers to mixed-OS environments, we engage the problem, not the logo. <a href="/services/" class="gold-link">Learn more →</a>
 
 ## Trust signals
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -258,7 +258,13 @@ macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientifi
 
 ## The Method
 
-We treat each engagement as a small research problem. Before we touch a config, we capture the evidence — packet traces, mail headers, DNS responses, system logs — and reason from there. The same instinct produced our public DNS research platform at <a href="https://dnstool.it-help.tech" class="gold-link" target="_blank" rel="noopener noreferrer">dnstool.it-help.tech</a>, where we publish what we learn from the wire. <a href="/blog/" class="gold-link">Read the field notes →</a>
+**Deep-research diagnostics** — the principle is simple: we measure before we fix. A doctor runs labs before prescribing; we read the evidence the system is already producing before we touch a config.
+
+Most IT support pattern-matches symptoms to the usual fix and hopes it sticks. We start one step earlier: capture the primary evidence — packet traces, mail headers, DNS responses, system logs, RF readings — and reason from there. The fix is whatever the evidence demands, not whatever the script says.
+
+A working example: when client mail goes to spam, the off-the-shelf answer is "buy a warmup tool." The evidence-led answer is to read the failed DMARC reports, find the one sending service that's misaligned, and fix the DNS so SPF, DKIM, and DMARC line up against the actual sending surface. Mail lands. No subscriptions added.
+
+The same instinct produced our public DNS research platform at <a href="https://dnstool.it-help.tech" class="gold-link" target="_blank" rel="noopener noreferrer">dnstool.it-help.tech</a>, where we publish what we learn from the wire. <a href="/blog/it-problem-solving-scientific-method/" class="gold-link">Read the field notes →</a>
 
 ## Local credibility
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,15 +1,15 @@
 +++
 title       = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-description = "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no monthly retainers."
+description = "Apple-centric IT, deep-research diagnostics for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no retainers."
 
 [extra]
 seo_title       = "Mac IT Support San Diego"
 og_title        = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-og_description  = "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no monthly retainers."
+og_description  = "Apple-centric IT, deep-research diagnostics for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no retainers."
 og_image        = "/images/og-home.png"
 
 twitter_title       = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-twitter_description = "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no monthly retainers."
+twitter_description = "Apple-centric IT, deep-research diagnostics for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no retainers."
 twitter_image       = "/images/og-home.png"
 twitter_card        = "summary_large_image"
 +++

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 +++
 title = "Our Expertise"
-description = "Learn about Carey Balboa, the founder of IT Help San Diego, with 25 years of experience providing expert, ethical IT support."
+description = "Learn about Carey Balboa, the founder of IT Help San Diego, with 27 years of experience providing expert, ethical IT support."
 path = "about"
 render = true
 template_macros = ["macros/images.html"]
@@ -25,7 +25,7 @@ toc = false
       "@type": "Person",
       "name": "Carey Balboa",
       "jobTitle": "Founder",
-      "description": "25+ years experience in IT support, specializing in Mac, iOS, DNS, email, and cybersecurity.",
+      "description": "27+ years experience in IT support, specializing in Mac, iOS, DNS, email, and cybersecurity.",
       "image": "https://www.it-help.tech/images/carey-256.avif"
     },
     "address": {
@@ -38,7 +38,7 @@ toc = false
     },
      "url": "https://www.it-help.tech"
   },
-  "description": "Learn about Carey Balboa, the founder of IT Help San Diego, with 25 years of experience providing expert, ethical IT support.",
+  "description": "Learn about Carey Balboa, the founder of IT Help San Diego, with 27 years of experience providing expert, ethical IT support.",
    "url": "https://www.it-help.tech{{ page.url }}"
 }
 </script>  
@@ -51,7 +51,7 @@ Hi, I’m Carey Balboa.<br>
 *(Carey: Like the Hawksbill Sea Turtle (Eretmochelys imbricata) Common Name: Carey)*<br>
 *(Balboa: Like Balboa Park in San Diego)*
 
-I’ve been solving tech problems for 25 years. I love a challenge, solving technical problems, and helping people. I’m committed to mission success, and scientific discovery is my passion. Since 1999, I’ve assisted high-profile clients in the entertainment, medical, and legal sectors, as well as PhDs, with their technology challenges.
+I’ve been solving tech problems for 27 years. I love a challenge, solving technical problems, and helping people. I’m committed to mission success, and scientific discovery is my passion. Since 1999, I’ve assisted high-profile clients in the entertainment, medical, and legal sectors, as well as PhDs, with their technology challenges.
 
 ## Business Ethics: Carey’s Promise
 

--- a/content/billing.md
+++ b/content/billing.md
@@ -60,7 +60,7 @@ We do not bill recurring fees, retainers, or unattended time.
 ## Privacy, Security & Ethics
 
 * All client data is encrypted and never shared or sold.
-* We have served high-profile and security-sensitive clients for over 25 years.
+* We have served high-profile and security-sensitive clients for over 27 years.
 * We have never had a data leak and never speak with media or third parties.
 
 ### Business Ethics — Carey’s Promise

--- a/content/services.md
+++ b/content/services.md
@@ -213,6 +213,16 @@ extra:
         "description": "Extraction of iPhone text messages for legal professionals, creating court-admissible reports.",
         "provider": { "@id": "https://www.it-help.tech/#business" }
       }
+    },
+    {
+      "@type": "ListItem",
+      "position": 14,
+      "item": {
+        "@type": "Service",
+        "name": "Cross-Platform & Systems Work",
+        "description": "Unix, Linux, and Windows systems work alongside macOS — shell scripting, file servers, mixed-OS networks, and server diagnostics.",
+        "provider": { "@id": "https://www.it-help.tech/#business" }
+      }
     }
   ]
 }
@@ -323,6 +333,14 @@ extra:
     },
     {
       "@type": "Service",
+      "name": "Cross-Platform & Systems Work",
+      "serviceType": "Systems Engineering",
+      "provider": { "@id": "https://www.it-help.tech/#business" },
+      "description": "Unix, Linux, and Windows systems work alongside macOS — shell scripting, file servers, mixed-OS networks, and server diagnostics. A system is a system.",
+      "url": "https://www.it-help.tech/services/#cross-platform"
+    },
+    {
+      "@type": "Service",
       "name": "Managed Agent (Opt-In, $50/Device)",
       "serviceType": "Managed Endpoint Service",
       "provider": { "@id": "https://www.it-help.tech/#business" },
@@ -334,7 +352,7 @@ extra:
 </script>
 
 
-Six service pillars, organized by the problem they solve. No retainers, no lock-in, no padded hours — just clear billing for actual work performed.
+Seven service pillars, organized by the problem they solve. No retainers, no lock-in, no padded hours — just clear billing for actual work performed.
 
 ## Mac & Apple Ecosystem {#mac}
 
@@ -379,6 +397,16 @@ Endpoint defense, mobile device security, and remote support that respects clien
 ## Forensic Data Extraction {#data-extraction}
 
 For law firms and legal professionals: structured extraction of email and iPhone iMessages into court-admissible, timestamped PDF reports suitable for litigation and eDiscovery. The work is done **on-site, on your equipment, so the data never leaves your office.** After the first engagement we document the process so your team can repeat it without us.
+
+## Cross-Platform & Systems Work {#cross-platform}
+
+macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. We engage the problem, not the logo. The same instinct for reading logs, tracing packets, and reasoning from evidence applies whether the prompt is `$`, `#`, or `C:\>`.
+
+* **Shell scripting and automation** — Bash, Zsh, and PowerShell for repeatable, auditable operations instead of click-by-click drift.
+* **File servers and shared storage** — SMB and NFS that hold up across macOS, Windows, and Linux clients without permissions roulette.
+* **Mixed-OS networks** — identity, DNS, printing, and file sharing that behave the same on every desk, regardless of operating system.
+* **Server diagnostics** — Linux and Windows server troubleshooting from the logs up: systemd, journalctl, Event Viewer, and the boring fundamentals that vendor dashboards skip.
+* **Cross-platform migrations** — moving users, data, and workflows between macOS, Windows, and Linux without losing fidelity along the way.
 
 ## Managed Agent (Opt-In, $50 per Device) {#managed-agent}
 

--- a/scripts/post-merge.sh
+++ b/scripts/post-merge.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Post-merge setup for IT Help San Diego corp site.
+#
+# This is a static Zola site — no DB migrations, no package manager state to
+# reconcile (zola comes from Nix, pinned in .replit). The only useful local
+# post-merge check is to confirm the merged tree still builds cleanly, so a
+# bad shortcode/template/anchor surfaces in Replit immediately rather than
+# only in CI.
+#
+# Idempotent. Non-interactive. Fail-fast.
+
+set -euo pipefail
+
+echo "post-merge: verifying zola build…"
+zola build
+echo "post-merge: build OK"

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -10,13 +10,13 @@ Source: [https://www.it-help.tech](https://www.it-help.tech)
 
 # Expert Mac IT Support
 
-La Jolla and San Diego’s Apple‑centric IT and deep-research diagnostics shop. 25+ years across systems, networks, DNS, and email security. Mac and iOS first, with Unix, Linux, and Windows — a system is a system. We fix macOS/iOS issues, eliminate Wi‑Fi dead zones, boost security, and ensure email delivery (SPF/DKIM/DMARC) — on‑site, in‑home, or at our La Jolla office by appointment. No hardware sales, no monthly retainers. Clear answers & discreet service. [(619) 853‑5008](tel:16198535008)
+La Jolla and San Diego’s Apple‑centric IT and deep-research diagnostics shop. 27+ years across systems, networks, DNS, and email security. Mac and iOS first, with Unix, Linux, and Windows — a system is a system. We fix macOS/iOS issues, eliminate Wi‑Fi dead zones, boost security, and ensure email delivery (SPF/DKIM/DMARC) — on‑site, in‑home, or at our La Jolla office by appointment. No hardware sales, no monthly retainers. Clear answers & discreet service. [(619) 853‑5008](tel:16198535008)
 
 [Read Verified Reviews](https://8750b1ff89054a2b8a27550322e2ed7c.elf.site)
 
 ## Custom Solutions That Work for You
 
-Our premium, concierge-level on-site service is designed for individuals, executives, business owners, and anyone who values precision, discretion, and results. With over 25 years of experience supporting high-profile clients in the entertainment, legal, restaurant, and medical fields, we bring the technical depth and professionalism to solve your problem correctly the first time. We listen closely and implement solutions that are proven to work effectively, tailored to your specific needs.
+Our premium, concierge-level on-site service is designed for individuals, executives, business owners, and anyone who values precision, discretion, and results. With over 27 years of experience supporting high-profile clients in the entertainment, legal, restaurant, and medical fields, we bring the technical depth and professionalism to solve your problem correctly the first time. We listen closely and implement solutions that are proven to work effectively, tailored to your specific needs.
 
 ## Core Expertise
 
@@ -110,7 +110,7 @@ This policy covers real operational costs and ensures continued reliability.
 ## Privacy & Security
 
 * All client data (login credentials, network configurations, etc.) is encrypted and is NEVER shared or sold.
-* We have served high-profile, sensitive security and entertainment businesses for 25 years.
+* We have served high-profile, sensitive security and entertainment businesses for 27 years.
 * We have never had a data leak or spoken with paparazzi/journalists. Your trust is paramount.
 
 ## Final Notes
@@ -239,7 +239,7 @@ Hi, I’m Carey Balboa.
 _(Carey: Like the Hawksbill Sea Turtle (Eretmochelys imbricata) Common Name: Carey)_  
 _(Balboa: Like Balboa Park in San Diego)_
 
-I’ve been solving tech problems for 25 years. I love a challenge, solving technical problems, and helping people. I’m committed to mission success, and scientific discovery is my passion. Since 1999, I’ve assisted high-profile clients in the entertainment, medical, and legal sectors, as well as PhDs, with their technology challenges.
+I’ve been solving tech problems for 27 years. I love a challenge, solving technical problems, and helping people. I’m committed to mission success, and scientific discovery is my passion. Since 1999, I’ve assisted high-profile clients in the entertainment, medical, and legal sectors, as well as PhDs, with their technology challenges.
 
 ## Business Ethics: Carey’s Promise
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -10,7 +10,7 @@ Source: [https://www.it-help.tech](https://www.it-help.tech)
 
 # Expert Mac IT Support
 
-San Diego’s Apple‑centric IT support for homes & SMBs. 25+ years fixing Mac, Wi‑Fi, DNS & Email issues. We fix macOS/iOS glitches, eliminate Wi‑Fi dead zones, boost security, and ensure Email delivery (SPF/DKIM/DMARC)—on‑site, in‑home or meet at our office (by appointment) in La Jolla. Clear answers & discreet service. [(619) 853‑5008](tel:16198535008)
+La Jolla and San Diego’s Apple‑centric IT and deep-research diagnostics shop. 25+ years across systems, networks, DNS, and email security. Mac and iOS first, with Unix, Linux, and Windows — a system is a system. We fix macOS/iOS issues, eliminate Wi‑Fi dead zones, boost security, and ensure email delivery (SPF/DKIM/DMARC) — on‑site, in‑home, or at our La Jolla office by appointment. No hardware sales, no monthly retainers. Clear answers & discreet service. [(619) 853‑5008](tel:16198535008)
 
 [Read Verified Reviews](https://8750b1ff89054a2b8a27550322e2ed7c.elf.site)
 


### PR DESCRIPTION
## What

Rewrites the homepage positioning per owner direction:

- **Mission-based** instead of service-list-based ("give us a problem and we solve it")
- **Apple-centric SEO weight preserved** (Mac is the primary client base — title, H1, meta all still lead with Mac/Apple)
- **Multi-platform truth signaled** so existing PC clients and the homeless-shelter Linux client aren't scared away ("macOS first; Unix, Linux, Windows too — a system is a system")
- **La Jolla emphasized** (science capital, primary client geography) without dropping greater San Diego from the service-area framing
- **"No hardware sales"** explicit (we're software/systems only)

## Files (2)

- `content/_index.md` — meta/og/twitter description (synced, 141 chars to clear Google SERP truncation), LocalBusiness JSON-LD description, WebPage JSON-LD description, hero subtagline, **new "What we do" card #4: Cross-Platform Systems Engineering** (placed last so Mac stays first visually)
- `static/llms-full.txt` — intro paragraph rewritten in same voice for LLM crawlers

## Verification

- `zola build` clean
- Visual verified via screenshot: hero reads on a single line on desktop, no topbar artifact regression, gold "in motion" pill + owl crest layout intact
- Meta description count: 141 chars (Google truncates ~155-160 — "No hardware sales" stays visible)

## Architect review notes

- HIGH (link target for new card to `/services/` vs a specific anchor) deferred — would require fabricating a new services-page subsection. Filed as follow-up.
- MEDIUM (meta description length) addressed in 8536e25.
- LOW (LocalBusiness should mention "No hardware sales") was already accurate in d22398a.
