### PR TITLE
About page: ORCID iD disclosure + Engineering & Research links (corp GitHub)

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -29,7 +29,7 @@ toc = false
       "image": "https://www.it-help.tech/images/carey-256.avif",
       "sameAs": [
         "https://orcid.org/0009-0000-5237-9065",
-        "https://github.com/careyjames"
+        "https://github.com/IT-Help-San-Diego"
       ]
     },
     "address": {
@@ -71,5 +71,5 @@ For anyone who wants to verify the work underneath the practice — the deployed
 
 - <a href="https://dnstool.it-help.tech/" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — DNS &amp; Email Security Auditor</a> — the deployed web app.
 - <a href="https://dnstool.it-help.tech/about" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — Origin Story</a> — how it was built, and why.
-- <a href="https://github.com/careyjames/dns-tool" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — CLI source on GitHub</a> — open-source command-line version.
-- <a href="https://github.com/careyjames" target="_blank" rel="noopener noreferrer" class="gold-link">GitHub profile (@careyjames)</a>
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — CLI source on GitHub</a> — open-source command-line version.
+- <a href="https://github.com/IT-Help-San-Diego" target="_blank" rel="noopener noreferrer" class="gold-link">IT Help San Diego on GitHub</a> — the corporate organization.

--- a/content/about.md
+++ b/content/about.md
@@ -27,7 +27,10 @@ toc = false
       "jobTitle": "Founder",
       "description": "27+ years experience in IT support, specializing in Mac, iOS, DNS, email, and cybersecurity.",
       "image": "https://www.it-help.tech/images/carey-256.avif",
-      "sameAs": ["https://orcid.org/0009-0000-5237-9065"]
+      "sameAs": [
+        "https://orcid.org/0009-0000-5237-9065",
+        "https://github.com/careyjames"
+      ]
     },
     "address": {
       "@type": "PostalAddress",
@@ -54,10 +57,19 @@ Hi, I’m Carey Balboa.<br>
 
 I’ve been solving tech problems for 27 years. I love a challenge, solving technical problems, and helping people. I’m committed to mission success, and scientific discovery is my passion. Since 1999, I’ve assisted high-profile clients in the entertainment, medical, and legal sectors, as well as PhDs, with their technology challenges.
 
-*ORCID iD: [0009-0000-5237-9065](https://orcid.org/0009-0000-5237-9065)*
+<p class="orcid-line"><a href="https://orcid.org/0009-0000-5237-9065" target="_blank" rel="noopener noreferrer" aria-label="Carey Balboa's ORCID record (opens in new tab)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="16" height="16" aria-hidden="true" focusable="false"><path fill="#A6CE39" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/><path fill="#FFFFFF" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/><path fill="#FFFFFF" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/><path fill="#FFFFFF" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1C84.2,46.7,88.7,51.3,88.7,56.8z"/></svg>ORCID iD: 0009-0000-5237-9065</a></p>
 
 ## Business Ethics: Carey’s Promise
 
 As the Founder of IT Help San Diego Inc., I see my role as a problem solver, not a salesperson. My recommendations are based on transparent, verifiable data, not opinions or distributor deals. <strong class="ethics-statement">We don’t sell products, and we don’t accept commissions, affiliate fees, or kickbacks.</strong> If we recommend a solution, whether it's Route 53, SentinelOne, or 1Password, it's because we believe it's the best tool for the job. We'll show you the options, explain the *why*, and you'll purchase directly from the vendor. Our only revenue comes from our time and expertise dedicated to implementing these solutions effectively for you. My focus is always on your long-term reliability—truly listening so I can help you understand exactly what you want—and delivering real value.
 
 I’ve always stayed true to my ethics: no price gouging, no hidden fees, and no cutting corners on quality. That’s who I am, and that’s exactly how I’ll continue to operate.
+
+## Engineering & Research
+
+For anyone who wants to verify the work underneath the practice — the deployed tools, the source, and the story behind them:
+
+- <a href="https://dnstool.it-help.tech/" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — DNS &amp; Email Security Auditor</a> — the deployed web app.
+- <a href="https://dnstool.it-help.tech/about" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — Origin Story</a> — how it was built, and why.
+- <a href="https://github.com/careyjames/dns-tool" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — CLI source on GitHub</a> — open-source command-line version.
+- <a href="https://github.com/careyjames" target="_blank" rel="noopener noreferrer" class="gold-link">GitHub profile (@careyjames)</a>

--- a/content/about.md
+++ b/content/about.md
@@ -71,5 +71,5 @@ For anyone who wants to verify the work underneath the practice — the deployed
 
 - <a href="https://dnstool.it-help.tech/" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — DNS &amp; Email Security Auditor</a> — the deployed web app.
 - <a href="https://dnstool.it-help.tech/about" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — Origin Story</a> — how it was built, and why.
-- <a href="https://github.com/IT-Help-San-Diego/dns-tool" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — CLI source on GitHub</a> — open-source command-line version.
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool-intel" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — CLI source on GitHub</a> — open-source command-line version.
 - <a href="https://github.com/IT-Help-San-Diego" target="_blank" rel="noopener noreferrer" class="gold-link">IT Help San Diego on GitHub</a> — the corporate organization.

--- a/content/about.md
+++ b/content/about.md
@@ -26,7 +26,8 @@ toc = false
       "name": "Carey Balboa",
       "jobTitle": "Founder",
       "description": "27+ years experience in IT support, specializing in Mac, iOS, DNS, email, and cybersecurity.",
-      "image": "https://www.it-help.tech/images/carey-256.avif"
+      "image": "https://www.it-help.tech/images/carey-256.avif",
+      "sameAs": ["https://orcid.org/0009-0000-5237-9065"]
     },
     "address": {
       "@type": "PostalAddress",
@@ -52,6 +53,8 @@ Hi, I’m Carey Balboa.<br>
 *(Balboa: Like Balboa Park in San Diego)*
 
 I’ve been solving tech problems for 27 years. I love a challenge, solving technical problems, and helping people. I’m committed to mission success, and scientific discovery is my passion. Since 1999, I’ve assisted high-profile clients in the entertainment, medical, and legal sectors, as well as PhDs, with their technology challenges.
+
+*ORCID iD: [0009-0000-5237-9065](https://orcid.org/0009-0000-5237-9065)*
 
 ## Business Ethics: Carey’s Promise
 

--- a/content/dns-tool.md
+++ b/content/dns-tool.md
@@ -95,8 +95,8 @@ The report tells you _what_ is wrong, but if you need help fixing it, we have a 
 
 The CLI tool is open-source and maintained for those who want it:
 
-- <a href="https://github.com/IT-Help-San-Diego/dns-tool/" target="_blank" rel="noopener noreferrer" class="gold-link">GitHub (Source & Docs)</a>
-- <a href="https://github.com/IT-Help-San-Diego/dns-tool/releases" target="_blank" rel="noopener noreferrer" class="gold-link">CLI Releases</a>
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool-intel/" target="_blank" rel="noopener noreferrer" class="gold-link">GitHub (Source & Docs)</a>
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool-intel/releases" target="_blank" rel="noopener noreferrer" class="gold-link">CLI Releases</a>
 
 Think of it as a sharp pocket knife.
 

--- a/content/dns-tool.md
+++ b/content/dns-tool.md
@@ -95,8 +95,8 @@ The report tells you _what_ is wrong, but if you need help fixing it, we have a 
 
 The CLI tool is open-source and maintained for those who want it:
 
-- <a href="https://github.com/careyjames/dns-tool/" target="_blank" rel="noopener noreferrer" class="gold-link">GitHub (Source & Docs)</a>
-- <a href="https://github.com/careyjames/dns-tool/releases" target="_blank" rel="noopener noreferrer" class="gold-link">CLI Releases</a>
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool/" target="_blank" rel="noopener noreferrer" class="gold-link">GitHub (Source & Docs)</a>
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool/releases" target="_blank" rel="noopener noreferrer" class="gold-link">CLI Releases</a>
 
 Think of it as a sharp pocket knife.
 

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -606,3 +606,12 @@ textarea {
   min-height: 6rem;
   resize: vertical;
 }
+
+/* About page: ORCID iD line — official ORCID green mark inline with iD text.
+   Inline attribute styles would be CSP-blocked under style-src 'self' in prod,
+   so the SVG geometry tweaks live here. The iD text inherits the page link
+   color so dark/light theme handles itself. */
+.orcid-line svg {
+  vertical-align: -3px;
+  margin-right: 6px;
+}

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -225,8 +225,8 @@ It works interactively (with history!) or in batch mode. I use it daily to get a
 
 Want to try it out, see the code, or dive into the full details on installation and every command-line flag? It's all open-source and waiting for you on GitHub:
 
-* **[Main GitHub Repository (Code & Full README)](https://github.com/IT-Help-San-Diego/dns-tool/)**
-* **[Download Pre-compiled Binaries (Releases Page)](https://github.com/IT-Help-San-Diego/dns-tool/releases)**
+* **[Main GitHub Repository (Code & Full README)](https://github.com/IT-Help-San-Diego/dns-tool-intel/)**
+* **[Download Pre-compiled Binaries (Releases Page)](https://github.com/IT-Help-San-Diego/dns-tool-intel/releases)**
 
 ### Our Expertise
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -225,8 +225,8 @@ It works interactively (with history!) or in batch mode. I use it daily to get a
 
 Want to try it out, see the code, or dive into the full details on installation and every command-line flag? It's all open-source and waiting for you on GitHub:
 
-* **[Main GitHub Repository (Code & Full README)](https://github.com/careyjames/dns-tool/)**
-* **[Download Pre-compiled Binaries (Releases Page)](https://github.com/careyjames/dns-tool/releases)**
+* **[Main GitHub Repository (Code & Full README)](https://github.com/IT-Help-San-Diego/dns-tool/)**
+* **[Download Pre-compiled Binaries (Releases Page)](https://github.com/IT-Help-San-Diego/dns-tool/releases)**
 
 ### Our Expertise
 


### PR DESCRIPTION
Adds an appropriately-disclosed researcher identity + verifiable-work block to /about/, per owner direction across the session.

### What changes

**1. ORCID iD line** under the bio paragraph — official green ORCID mark (inline SVG, no external fetch, fits privacy-first ethos), followed by the literal iD `0009-0000-5237-9065` linking to the ORCID record. ORCID brand-toolkit display rules met.

**2. New `Engineering & Research` H2** at the bottom of /about/ with four bullets pointing IT-side visitors at the verifiable work:
- DNS Tool web app (dnstool.it-help.tech)
- DNS Tool Origin Story (dnstool.it-help.tech/about — the Memphis closet build / 27-years-of-evidence narrative the owner pointed me at)
- DNS Tool source on GitHub (`IT-Help-San-Diego/dns-tool-intel`)
- IT Help San Diego on GitHub (the corporate org)

**3. JSON-LD founder Person `sameAs`** extended to `[ORCID URL, github.com/IT-Help-San-Diego]` — canonical schema.org cross-linking pattern.

**4. Site-wide GitHub link cleanup** — `content/dns-tool.md` and `static/llms-full.txt` repointed from the personal `careyjames/dns-tool` repo to the corporate `IT-Help-San-Diego/dns-tool-intel` repo, per owner directive: "if you use GitHub links, don't use my personal one, push towards the corporate link."

### Tonal floor (owner constraints)

Owner is published but NOT peer-reviewed — explicit instruction: "I'm not a bragger, I want to be appropriately disclosed. I'm not claiming I'm some god scientist, just here's what we're doing." Therefore: no "Researcher" / "Scientist" descriptor preamble; no "Published Author" framing; bare iD only. The new H2 lead-in ("For anyone who wants to verify the work underneath the practice...") matches the calm-authority register from STYLE_GUIDE.md.

### Production-safety

- Architect-reviewed pre-push (round 1: bare-text version; round 2: logo + bottom block). Round-2 review caught a CSP issue (inline `style=""` on the SVG would be blocked by CloudFront's `style-src 'self'` policy) — the SVG geometry tweaks were moved to `sass/_extra.scss` as `.orcid-line svg` instead.
- All four corp GitHub URLs verified live (HTTP 200) before push.
- All four prior commits on `replit/working` were squashed/cleaned via reset-to-main + cherry-pick before opening this PR (per the standard reset-after-merge workflow that had been skipped after PR #553).

### Files

- `content/about.md` — JSON-LD `sameAs`, ORCID iD line, new `Engineering & Research` section
- `content/dns-tool.md` — corp-org GitHub links (CLI Releases / Source & Docs)
- `sass/_extra.scss` — `.orcid-line svg` styling block (CSP-safe replacement for inline styles)
- `static/llms-full.txt` — corp-org GitHub links in the LLM-readable site mirror

### Suggested merge mode

Squash and merge — preserves the four-commit history in the squashed message but keeps `main` linear.