### PR TITLE
about: correct DNS Tool repo description (web app source, not CLI)

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -71,5 +71,5 @@ For anyone who wants to verify the work underneath the practice — the deployed
 
 - <a href="https://dnstool.it-help.tech/" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — DNS &amp; Email Security Auditor</a> — the deployed web app.
 - <a href="https://dnstool.it-help.tech/about" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — Origin Story</a> — how it was built, and why.
-- <a href="https://github.com/IT-Help-San-Diego/dns-tool-intel" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — CLI source on GitHub</a> — open-source command-line version.
+- <a href="https://github.com/IT-Help-San-Diego/dns-tool-intel" target="_blank" rel="noopener noreferrer" class="gold-link">DNS Tool — source on GitHub</a> — source for the web app, including the scientifically published version.
 - <a href="https://github.com/IT-Help-San-Diego" target="_blank" rel="noopener noreferrer" class="gold-link">IT Help San Diego on GitHub</a> — the corporate organization.


### PR DESCRIPTION
Owner-directed factual correction on /about/.

The `Engineering & Research` bullet for the dns-tool-intel repo previously read:

> DNS Tool — CLI source on GitHub — open-source command-line version.

That is wrong: the linked repo is the source for the **web app** (and specifically the scientifically published version of it). A CLI build is a separate codebase (legacy CLI + planned future CLI per owner) and not what dns-tool-intel houses.

New bullet text:

> DNS Tool — source on GitHub — source for the web app, including the scientifically published version.

- Drops misleading `CLI` / `command-line` framing entirely.
- Echoes owner's exact phrase `scientifically published` (used verbatim in instruction). Stays factual, no elevation beyond what owner has already approved.
- No structural / styling / schema changes; just the link label + descriptor on a single line.

### Architect review

Skipped on this one because the change is owner-dictated (verbatim phrasing supplied) and is a factual correction rather than originated tone. If you want architect-in-the-loop even on these mechanical corrections, say the word and I'll add it to the protocol going forward.