### PR TITLE
services: Apple Store softening + add Ubiquiti to recommendations

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -356,7 +356,7 @@ Seven service pillars, organized by the problem they solve. Across all seven, th
 
 ## Mac & Apple Ecosystem {#mac}
 
-Deep, system-level support for macOS and iOS. We diagnose what an Apple Store appointment cannot: kernel-level disk pressure, iCloud sync collisions, Spotlight index corruption, and the long tail of post-migration breakage. We are fluent on the command line and read system logs directly rather than guessing from symptoms.
+System-level support for macOS and iOS, focused on the diagnostics that require direct log access and command-line tooling: kernel-level disk pressure, iCloud sync collisions, Spotlight index corruption, and the long tail of post-migration breakage. We read system logs directly rather than guessing from symptoms.
 
 * **Mac performance & troubleshooting** — startup disk pressure, iCloud sync failures, application crashes, and post-update regressions.
 * **Apple Mail on macOS and iOS** — IMAP/SMTP setup, certificate issues, signing/encryption, and recovery of broken local mailboxes.


### PR DESCRIPTION
Two small content edits to `content/services.md`:

## 1. Drop Apple Store comparison from Mac & Apple Ecosystem intro

Owner flagged the **"We diagnose what an Apple Store appointment cannot"** framing as antagonistic toward an already-sensitive Apple relationship.

**Before:**
> Deep, system-level support for macOS and iOS. We diagnose what an Apple Store appointment cannot: kernel-level disk pressure, iCloud sync collisions, Spotlight index corruption, and the long tail of post-migration breakage. We are fluent on the command line and read system logs directly rather than guessing from symptoms.

**After:**
> System-level support for macOS and iOS, focused on the diagnostics that require direct log access and command-line tooling: kernel-level disk pressure, iCloud sync collisions, Spotlight index corruption, and the long tail of post-migration breakage. We read system logs directly rather than guessing from symptoms.

The technical-capability list (kernel disk pressure, iCloud collisions, Spotlight corruption, post-migration tail) is what actually establishes diagnostic depth — naming Apple as the foil was doing none of the work and all of the risk. Also tightens the prose by dropping the now-redundant "fluent on the command line" sentence since command-line tooling is established in the opening clause.

## 2. Add Ubiquiti (UniFi) to Our Recommendations

```
* **Ubiquiti (UniFi):** Enterprise-grade networking hardware — switches, access points, gateways, routers — sold direct to end users without reseller or distributor markup, with a unified management interface across the stack.
```

Framing intentionally emphasizes the substantive disruptor angle (direct-to-end-user sales channel, unified management) rather than editorial adjectives like "ethical" or "disruptor" — the factual description carries the same point more credibly and matches the terse, factual style of the surrounding list entries. Linked `ui.com` (canonical brand home) rather than the region-locked `store.ui.com/us/en` URL.

**Files**: `content/services.md` (one paragraph rewrite + one new list item).