### PR TITLE
services(recommendations): correct DEVONagent Express description

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -442,7 +442,7 @@ We believe in using best-in-class tools to achieve the best security and reliabi
 * **<a href="https://www.devontechnologies.com/apps/devonthink" target="_blank" rel="noopener noreferrer" class="gold-link">DEVONthink:</a>** Long-form document and research database for Mac.
 * **<a href="https://www.devontechnologies.com/apps/devonagent" target="_blank" rel="noopener noreferrer" class="gold-link">DEVONagent Pro:</a>** Focused web research agent for Mac.
 * **<a href="https://www.devontechnologies.com/apps/devonsphere" target="_blank" rel="noopener noreferrer" class="gold-link">DEVONsphere Express:</a>** Mac-wide content search and indexing.
-* **<a href="https://www.devontechnologies.com/apps/devonagent" target="_blank" rel="noopener noreferrer" class="gold-link">DEVONagent Express:</a>** Free DEVONagent build for ad-hoc research.
+* **<a href="https://www.devontechnologies.com/apps/devonagent" target="_blank" rel="noopener noreferrer" class="gold-link">DEVONagent Express:</a>** Lightweight DEVONagent build for ad-hoc research.
 
 Need expert Mac IT help to solve your tech challenges?
 <p><a class="cta-button" href="https://schedule.it-help.tech/" target="_blank" rel="noopener noreferrer">Book an on-site Appointment Now</a></p>


### PR DESCRIPTION
Owner caught that the **DEVONagent Express** entry described it as "Free" — it's actually \$4.95 on the Mac App Store. Verified against devontechnologies.com (lists Express \$4.95 alongside Pro \$49.95).

**Before:**
> DEVONagent Express: Free DEVONagent build for ad-hoc research.

**After:**
> DEVONagent Express: Lightweight DEVONagent build for ad-hoc research.

Reworded to **"Lightweight DEVONagent build"** rather than embedding a specific price in site copy — the linked product page carries the authoritative price, and prices change. The new wording accurately describes the relationship to DEVONagent Pro (\$49.95) without making any false claim either way.

**Files**: `content/services.md` (one word in one list entry).