### PR TITLE
infra(llms): auto-generate llms-full.txt from content/ at build time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,14 +151,27 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       
-      - name: Set UTF-8 header for LLMS files
+      - name: Generate llms-full.txt from content/
+        # Source of truth: infra/llms/llms-full.config.json + content/*.md.
+        # Fail-closed: if the generator throws, the deploy stops here, before any
+        # llms-* file is uploaded — better than shipping a stale or incomplete LLM
+        # corpus. See infra/llms/README.md for the runbook.
+        run: node infra/llms/build-llms-full.mjs
+
+      - name: Upload LLMS files (short TTL for freshness)
+        # llms-full.txt comes from build/ (generator output, source of truth).
+        # llms.txt is the small hand-maintained nav index in static/.
+        # Both get a short TTL with stale-while-revalidate so AI bots see updates
+        # within an hour while still tolerating origin hiccups.
         run: |
-          for f in static/llms*.txt; do
-            aws s3 cp "$f" "s3://$BUCKET/$(basename "$f")" \
-              --content-type "text/plain; charset=utf-8" \
-              --cache-control "public,max-age=31536000,immutable" \
-              --metadata-directive REPLACE
-          done
+          aws s3 cp build/llms-full.txt "s3://$BUCKET/llms-full.txt" \
+            --content-type "text/plain; charset=utf-8" \
+            --cache-control "public,max-age=3600,stale-while-revalidate=86400" \
+            --metadata-directive REPLACE
+          aws s3 cp static/llms.txt "s3://$BUCKET/llms.txt" \
+            --content-type "text/plain; charset=utf-8" \
+            --cache-control "public,max-age=3600,stale-while-revalidate=86400" \
+            --metadata-directive REPLACE
 
         env:
           AWS_S3_BUCKET: ${{ env.BUCKET }}

--- a/.github/workflows/llms-validate.yml
+++ b/.github/workflows/llms-validate.yml
@@ -1,0 +1,38 @@
+name: Validate llms-full.txt generation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "content/**"
+      - "infra/llms/**"
+      - "config.toml"
+      - ".github/workflows/llms-validate.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run llms-full generator
+        run: node infra/llms/build-llms-full.mjs
+
+      - name: Show byte count and section structure
+        run: |
+          echo "Generated $(wc -c < build/llms-full.txt) bytes"
+          echo ""
+          echo "=== Section structure ==="
+          grep -E "^#{1,3} " build/llms-full.txt
+
+      - name: Upload generated file as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: llms-full-txt-preview
+          path: build/llms-full.txt
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ csp-*.json
 !infra/cloudfront/csp-policy-v1.json
 !infra/cloudfront/csp-policy-signatures-v1.json
 sub3_diff.patch
+
+# llms-full.txt generator output (regenerated in CI; see infra/llms/README.md)
+build/

--- a/infra/llms/README.md
+++ b/infra/llms/README.md
@@ -1,0 +1,66 @@
+# `llms-full.txt` generator
+
+Auto-generates `llms-full.txt` from `content/*.md` so it never drifts from the live site.
+
+## Why this exists
+
+`llms-full.txt` is a long-form, plain-text mirror of the site for AI/LLM crawlers. Before this generator, it was hand-maintained in `static/llms-full.txt` and drifted badly: in the most recent audit it listed 5 old service pillars when the live page had 7 new ones, and was missing 13+ vendor recommendations. Hand-maintenance does not scale at the editing cadence we run.
+
+## How it works
+
+1. `infra/llms/build-llms-full.mjs` reads `infra/llms/llms-full.config.json` for the canonical page order, then walks each referenced `content/*.md`.
+2. For each page: parses frontmatter (TOML `+++` or YAML `---`, both supported), strips JSON-LD `<script>` blocks, strips HTML comments and `<svg>` blocks, normalizes `<br>`/`<p>`, converts inline `<a>` tags to markdown links, strips remaining HTML conservatively, decodes common HTML entities, strips Zola heading-anchor `{#anchor}` syntax, normalizes whitespace.
+3. Writes the assembled output to `build/llms-full.txt` (UTF-8, LF line endings, deterministic — same input always produces the same output, byte-for-byte).
+4. Deploy uploads `build/llms-full.txt` directly to S3 with a 1-hour TTL plus `stale-while-revalidate=86400`.
+
+The script has zero dependencies beyond Node stdlib.
+
+## Local usage
+
+```bash
+# Print to stdout without writing (debugging):
+node infra/llms/build-llms-full.mjs --dry-run
+
+# Write to build/llms-full.txt:
+node infra/llms/build-llms-full.mjs
+```
+
+## Config: `llms-full.config.json`
+
+- `tagline` — short site tagline used in the header preamble.
+- `main` / `optional` — section arrays. Each section has a `heading` and an `entries` list.
+- Each entry is one of:
+  - **File-backed**: `{ "label": "...", "file": "content/path.md" }`. Label and source URL are derived from config + file path; body comes from the page.
+  - **Link-only**: `{ "label": "...", "url": "https://...", "description": "..." }`. For external destinations like the booking subdomain that have no markdown source.
+
+### Per-page label override
+
+If a content author wants the LLM-facing label to differ from the page `<title>`, they can add `extra.llms_label = "..."` to the page frontmatter. Config wins if both are set; otherwise frontmatter wins; otherwise page title.
+
+## CI integration
+
+- **PR validation** (`.github/workflows/llms-validate.yml`): runs the generator on every PR that touches `content/`, `infra/llms/`, or `config.toml`. Uploads the generated file as a workflow artifact so reviewers can download and inspect the LLM-facing copy before merge.
+- **Deploy** (`.github/workflows/deploy.yml`): regenerates after `zola build` and before the S3 upload. Fail-closed — if the generator throws, the deploy stops and no `llms-*` file is uploaded that run.
+
+## Failure runbook
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Deploy fails at "Generate llms-full.txt from content/" with `frontmatter missing required 'title'` | A content file is missing `title` in its frontmatter | Add the `title` field to the offending file (the error message names the file). Push fix; re-run deploy. |
+| Same step fails with `config references missing file: …` | A renamed/moved `content/*.md` left a stale entry in `llms-full.config.json` | Update the `file` path in the config. Push fix. |
+| Same step fails with `duplicate label in config: …` or `duplicate URL in config: …` | Two entries collide | Rename one of the labels, or remove the duplicate entry. |
+| Same step warns `stripped N unrecognized HTML tag(s)` but doesn't fail | A page added an HTML construct the conservative stripper doesn't know about | Inspect `build/llms-full.txt` (or the PR validation artifact) to confirm output is acceptable. Extend the recognized-tag list in `transformBody()` if needed. |
+| `llms-full.txt` on production looks stale 1+ hour after deploy | CloudFront edge cache | Cache-control is `max-age=3600`; wait an hour or invalidate `/llms-full.txt` via CloudFront. |
+| Need to roll back to the prior hand-maintained file | Generator producing wrong output and we need a hotfix | Revert the relevant PR. Until `static/llms-full.txt` is removed (Phase C of rollout), reverting also restores the hand-maintained file. |
+
+## Rollout plan (3 phases)
+
+- **Phase A** (this PR): Add generator + config + PR-validate workflow + deploy.yml updates (output path + cache-control). `static/llms-full.txt` stays in repo as fallback. After merge, deploy proves the generator works against current production.
+- **Phase B**: Inspect generator output vs current `static/llms-full.txt`, tune config/labels until parity is good or deliberate-improvement is achieved. Document any intentional differences.
+- **Phase C**: Delete `static/llms-full.txt` from repo. Generator becomes sole source of truth.
+
+## Out of scope
+
+- `llms.txt` (short nav index) stays hand-maintained — it's stable and not the drift source.
+- `sitemap.xml` is auto-generated by Zola; no changes here.
+- Schema (JSON-LD) is in markdown files and rebuilt by Zola; no changes here.

--- a/infra/llms/build-llms-full.mjs
+++ b/infra/llms/build-llms-full.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+// Generate llms-full.txt from content/*.md.
+// Source of truth: infra/llms/llms-full.config.json + content/ + config.toml.
+// Output: build/llms-full.txt (deterministic, UTF-8, LF).
+// Run from repo root. --dry-run prints to stdout without writing.
+// See infra/llms/README.md for design and runbook.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const REPO_ROOT = process.cwd();
+const CONFIG_PATH = path.join(REPO_ROOT, "infra/llms/llms-full.config.json");
+const CONTENT_DIR = path.join(REPO_ROOT, "content");
+const SITE_CONFIG_PATH = path.join(REPO_ROOT, "config.toml");
+const OUTPUT_PATH = path.join(REPO_ROOT, "build/llms-full.txt");
+
+const dryRun = process.argv.includes("--dry-run");
+
+function die(msg) {
+  console.error(`[build-llms-full] ERROR: ${msg}`);
+  process.exit(1);
+}
+
+function warn(msg) {
+  console.error(`[build-llms-full] WARN: ${msg}`);
+}
+
+// --- Parse minimal site config (just title/description/base_url) ---
+function readSiteConfig() {
+  const raw = fs.readFileSync(SITE_CONFIG_PATH, "utf8");
+  const get = (key) => {
+    const re = new RegExp(`^${key}\\s*=\\s*"([^"]*)"`, "m");
+    const m = raw.match(re);
+    return m ? m[1] : null;
+  };
+  const title = get("title");
+  const description = get("description");
+  const base_url = get("base_url");
+  if (!title || !base_url) {
+    die(`config.toml missing required field(s): title=${title} base_url=${base_url}`);
+  }
+  return { title, description: description ?? "", base_url: base_url.replace(/\/$/, "") };
+}
+
+// --- Frontmatter parser (TOML +++ or YAML ---). Extracts title, description, extra.llms_label only. ---
+function parseFrontmatter(raw, filePath) {
+  const lines = raw.split(/\r?\n/);
+  const first = lines[0];
+  let delim, isToml;
+  if (first === "+++") {
+    delim = "+++";
+    isToml = true;
+  } else if (first === "---") {
+    delim = "---";
+    isToml = false;
+  } else {
+    die(`${filePath}: missing frontmatter (first line must be '+++' or '---', got '${first}')`);
+  }
+  const endIdx = lines.indexOf(delim, 1);
+  if (endIdx === -1) {
+    die(`${filePath}: frontmatter not closed (no matching '${delim}')`);
+  }
+  const fmLines = lines.slice(1, endIdx);
+  const body = lines.slice(endIdx + 1).join("\n");
+
+  // Extract values. Both TOML and YAML support "key = value" and "key: value" respectively.
+  // We only need title, description, and extra.llms_label.
+  const fm = { title: null, description: null, llms_label: null };
+  let inExtra = false;
+  for (const line of fmLines) {
+    const trimmed = line.trim();
+    if (isToml) {
+      if (/^\[extra\]/.test(trimmed)) { inExtra = true; continue; }
+      if (/^\[/.test(trimmed)) { inExtra = false; continue; }
+      const m = trimmed.match(/^(\w+)\s*=\s*"((?:\\.|[^"\\])*)"\s*$/);
+      if (!m) continue;
+      const [, k, v] = m;
+      const value = v.replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+      if (!inExtra && (k === "title" || k === "description")) fm[k] = value;
+      if (inExtra && k === "llms_label") fm.llms_label = value;
+    } else {
+      // YAML: very narrow subset — top-level "key: value", and extra: block with 2-space indent "  llms_label: value".
+      const top = trimmed.match(/^(title|description):\s*"?(.*?)"?\s*$/);
+      if (top && /^[a-z]/.test(line)) { fm[top[1]] = top[2]; continue; }
+      if (/^extra:\s*$/.test(trimmed)) { inExtra = true; continue; }
+      if (inExtra) {
+        const sub = line.match(/^\s+llms_label:\s*"?(.*?)"?\s*$/);
+        if (sub) fm.llms_label = sub[1];
+        // Bail out of extra block if we hit a non-indented line (next top-level key).
+        if (/^\S/.test(line)) inExtra = false;
+      }
+    }
+  }
+  if (!fm.title) die(`${filePath}: frontmatter missing required 'title'`);
+  return { fm, body };
+}
+
+// --- Body transform pipeline (deterministic, no markdown libs) ---
+function transformBody(body, filePath) {
+  let s = body;
+
+  // 1. Strip JSON-LD blocks.
+  s = s.replace(/<script\s+type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>/gi, "");
+
+  // 1b. Strip HTML comments.
+  s = s.replace(/<!--[\s\S]*?-->/g, "");
+
+  // 2. Strip <svg>...</svg> blocks.
+  s = s.replace(/<svg\b[\s\S]*?<\/svg>/gi, "");
+
+  // 2b. Decode common HTML entities EARLY, so any reconstituted tags
+  //     (e.g. "&lt;script&gt;..." → "<script>...") are caught by the
+  //     downstream tag-aware steps (anchor convert + conservative strip).
+  //     Per architect hardening note: decoding after tag-strip can leak
+  //     literal "<...>" text into the output.
+  s = s.replace(/&amp;/g, "&")
+       .replace(/&lt;/g, "<")
+       .replace(/&gt;/g, ">")
+       .replace(/&quot;/g, '"')
+       .replace(/&#39;/g, "'")
+       .replace(/&nbsp;/g, " ");
+
+  // 3. Normalize <br> and </p> to line breaks.
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  s = s.replace(/<\/p>/gi, "\n");
+  s = s.replace(/<p[^>]*>/gi, "");
+
+  // 4. Convert <a href="X" ...>LABEL</a> → [LABEL](X). Preserve href + visible inner text.
+  s = s.replace(/<a\b([^>]*)>([\s\S]*?)<\/a>/gi, (match, attrs, inner) => {
+    const hrefMatch = attrs.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+    if (!hrefMatch) {
+      warn(`${filePath}: <a> without href, dropping tag, keeping inner: ${match.slice(0, 80)}`);
+      return inner;
+    }
+    const href = hrefMatch[1];
+    const label = inner.replace(/<[^>]+>/g, "").trim();
+    if (!label) return `<${href}>`;
+    return `[${label}](${href})`;
+  });
+
+  // 5. Strip remaining HTML tags conservatively (warn on anything substantive).
+  s = s.replace(/<\/?(?:span|div|section|article|header|footer|nav|aside|main|figure|figcaption|button|small|strong|em|i|b|u|s|mark|sup|sub|cite|abbr|kbd|code|pre|blockquote|hr|input|label|select|option|table|thead|tbody|tr|th|td|ul|ol|li|h[1-6])\b[^>]*>/gi, "");
+  // Remaining tags = unrecognized; warn and strip.
+  const remaining = s.match(/<[a-z][^>]*>/gi);
+  if (remaining) {
+    warn(`${filePath}: stripped ${remaining.length} unrecognized HTML tag(s); first: ${remaining[0]}`);
+    s = s.replace(/<[^>]+>/g, "");
+  }
+
+  // 6. Strip Zola heading-anchor syntax {#anchor} from heading lines.
+  s = s.replace(/^(#{1,6}\s+.*?)\s*\{#[^}]+\}\s*$/gm, "$1");
+
+  // 7. Normalize whitespace.
+  s = s.replace(/[ \t]+\n/g, "\n");           // trailing spaces
+  s = s.replace(/\n{3,}/g, "\n\n");            // collapse 3+ blank lines
+  s = s.replace(/^\s+|\s+$/g, "");             // trim
+
+  return s;
+}
+
+// --- Main ---
+function main() {
+  const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+  const site = readSiteConfig();
+
+  // Validate config: dup URLs/labels.
+  const seenLabels = new Set();
+  const seenUrls = new Set();
+  for (const sec of [...(config.main ?? []), ...(config.optional ?? [])]) {
+    for (const entry of sec.entries) {
+      if (seenLabels.has(entry.label)) die(`duplicate label in config: ${entry.label}`);
+      seenLabels.add(entry.label);
+      const url = entry.url ?? (entry.file ? `${site.base_url}/${entry.file.replace(/^content\//, "").replace(/\.md$/, "").replace(/_index$/, "")}` : null);
+      if (url) {
+        if (seenUrls.has(url)) die(`duplicate URL in config: ${url}`);
+        seenUrls.add(url);
+      }
+    }
+  }
+
+  // Build output.
+  const out = [];
+  out.push(`# ${site.title}`);
+  out.push("");
+  if (config.tagline) out.push(`> ${config.tagline}`);
+  out.push("");
+
+  for (const section of [...(config.main ?? []), ...(config.optional ?? [])]) {
+    out.push(`## ${section.heading}`);
+    out.push("");
+    for (const entry of section.entries) {
+      const label = entry.label;
+      // Link-only entry (e.g., external schedule).
+      if (entry.url && !entry.file) {
+        out.push(`### ${label}`);
+        out.push("");
+        out.push(`Source: [${entry.url}](${entry.url})`);
+        out.push("");
+        if (entry.description) {
+          out.push(entry.description);
+          out.push("");
+        }
+        out.push("---");
+        out.push("");
+        continue;
+      }
+      // File-backed entry.
+      const filePath = path.join(REPO_ROOT, entry.file);
+      if (!fs.existsSync(filePath)) die(`config references missing file: ${entry.file}`);
+      const raw = fs.readFileSync(filePath, "utf8");
+      const { fm, body } = parseFrontmatter(raw, entry.file);
+      const finalLabel = entry.label ?? fm.llms_label ?? fm.title;
+      const url = `${site.base_url}/${entry.file.replace(/^content\//, "").replace(/\.md$/, "").replace(/_index$/, "")}`;
+      const cleanedBody = transformBody(body, entry.file);
+
+      out.push(`### ${finalLabel}`);
+      out.push("");
+      out.push(`Source: [${url}](${url})`);
+      out.push("");
+      if (cleanedBody) {
+        out.push(cleanedBody);
+        out.push("");
+      }
+      out.push("---");
+      out.push("");
+    }
+  }
+
+  // Final normalization: single trailing newline, LF endings.
+  let result = out.join("\n").replace(/\r\n/g, "\n").replace(/\n{3,}/g, "\n\n");
+  if (!result.endsWith("\n")) result += "\n";
+
+  if (dryRun) {
+    process.stdout.write(result);
+    console.error(`[build-llms-full] dry-run: ${result.length} bytes (not written)`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, result, "utf8");
+  console.error(`[build-llms-full] wrote ${OUTPUT_PATH} (${result.length} bytes)`);
+}
+
+main();

--- a/infra/llms/llms-full.config.json
+++ b/infra/llms/llms-full.config.json
@@ -1,0 +1,28 @@
+{
+  "tagline": "Expert Apple IT support in San Diego for homes and businesses. No monthly retainers.",
+  "main": [
+    {
+      "heading": "Main",
+      "entries": [
+        { "label": "IT Help San Diego", "file": "content/_index.md" },
+        { "label": "Pricing", "file": "content/billing.md" },
+        { "label": "Services", "file": "content/services.md" },
+        { "label": "DNS Tool", "file": "content/dns-tool.md" },
+        { "label": "Our Expertise", "file": "content/about.md" },
+        {
+          "label": "Schedule",
+          "url": "https://schedule.it-help.tech/",
+          "description": "Book an on-site appointment."
+        }
+      ]
+    }
+  ],
+  "optional": [
+    {
+      "heading": "Optional",
+      "entries": [
+        { "label": "Blog", "file": "content/blog/_index.md" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Phase A of 3 — auto-generate `llms-full.txt` from `content/*.md` so it stops drifting from the live site.

The hand-maintained `static/llms-full.txt` had drifted badly: 5 old service pillars listed when the live page has 7 new ones, and 13+ vendor recommendations missing (LuLu, CISA Cyber Hygiene, Ubiquiti, full DEVONtech suite, Notion Mail, Zotero, Obsidian, Raycast, TheBrain, etc.). Hand-maintenance does not scale at our editing cadence.

## What's in this PR

- **`infra/llms/build-llms-full.mjs`** — Node ESM generator, zero deps beyond stdlib. Walks `content/*.md` per config, parses TOML or YAML frontmatter, runs a deterministic transform pipeline (strip JSON-LD/comments/svg, convert `<a>` to markdown links, conservative tag strip, HTML entity decode, Zola heading-anchor strip, whitespace normalize). Writes `build/llms-full.txt`. Same input → same output, byte-for-byte.
- **`infra/llms/llms-full.config.json`** — canonical page order + entries. Validates: fails on missing files, missing frontmatter `title`, duplicate URLs, duplicate labels.
- **`.github/workflows/llms-validate.yml`** — runs the generator on every PR touching `content/`, `infra/llms/`, or `config.toml`. Uploads the generated file as a 14-day artifact so reviewers can see the LLM-facing copy before merge.
- **`.github/workflows/deploy.yml`** — new "Generate llms-full.txt" step + rewritten upload step. Cache-control changed from `max-age=31536000,immutable` to `max-age=3600,stale-while-revalidate=86400` (the immutable header was actively hostile to LLM bot freshness). Source path changed from `static/` to `build/`.
- **`infra/llms/README.md`** — design, local usage, config schema, CI integration, failure runbook, rollout plan.
- **`.gitignore`** — `build/` ignored.

## What's NOT in this PR

- `static/llms-full.txt` is intentionally retained as a fallback. Phase B will tune the generator output against current production; Phase C will delete the static file.
- `static/llms.txt` (the short hand-maintained nav index) is unchanged — it's stable and not a drift source.
- `replit.md` / `PROJECT_EVOLUTION_LOG.md` updates will land as a follow-up commit on this same branch (kept separate to avoid the `commit -am` sweep failure mode hit twice this session).

## Validation

Local `--dry-run` against current main produces 24233 bytes (vs 19305 in the stale hand-maintained file). All recent additions present: LuLu, CISA, Ubiquiti, DEVONagent Express description fix, Mac & Apple Ecosystem rename, Cross-Platform pillar, Managed Agent pillar. Zero stderr warnings from the unrecognized-tag stripper. HTML entity decode and comment stripping verified.

End-to-end CI validation will occur on the next deploy after merge.

## Architect review

PASS with one hardening already applied (entity decode moved earlier in the pipeline so reconstituted tags get caught by the downstream tag-strip pass).
