### PR TITLE
infra(llms): auto-generate llms-full.txt from content/ at build time (re-open of #563)

### DIFF
--- a/.github/workflows/llms-validate.yml
+++ b/.github/workflows/llms-validate.yml
@@ -9,14 +9,19 @@ on:
       - "config.toml"
       - ".github/workflows/llms-validate.yml"
 
+# Least-privilege token: this workflow only reads the repo and uploads an
+# artifact. Artifact upload uses the workflow run scope, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
 
@@ -31,7 +36,7 @@ jobs:
           grep -E "^#{1,3} " build/llms-full.txt
 
       - name: Upload generated file as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llms-full-txt-preview
           path: build/llms-full.txt

--- a/infra/llms/build-llms-full.mjs
+++ b/infra/llms/build-llms-full.mjs
@@ -11,7 +11,6 @@ import process from "node:process";
 
 const REPO_ROOT = process.cwd();
 const CONFIG_PATH = path.join(REPO_ROOT, "infra/llms/llms-full.config.json");
-const CONTENT_DIR = path.join(REPO_ROOT, "content");
 const SITE_CONFIG_PATH = path.join(REPO_ROOT, "config.toml");
 const OUTPUT_PATH = path.join(REPO_ROOT, "build/llms-full.txt");
 
@@ -24,6 +23,27 @@ function die(msg) {
 
 function warn(msg) {
   console.error(`[build-llms-full] WARN: ${msg}`);
+}
+
+// Apply a strip regex repeatedly until the string stops changing.
+// Defends against nested-tag bypasses like "<scr<script>ipt>" where a single
+// pass would leave residual "<scr" text. Used for tag/comment/svg stripping
+// since CodeQL flags single-pass replacements as incomplete sanitization.
+// Bounded to 10 iterations to prevent any pathological input from looping.
+function stripUntilStable(s, re) {
+  for (let i = 0; i < 10; i++) {
+    const next = s.replace(re, "");
+    if (next === s) return next;
+    s = next;
+  }
+  return s.replace(re, "");
+}
+
+// Single-pass HTML entity decode. Avoids cascading replacements that would
+// double-unescape inputs like "&amp;lt;" → "&lt;" → "<" (CodeQL flag).
+const ENTITY_MAP = { amp: "&", lt: "<", gt: ">", quot: '"', "#39": "'", nbsp: " " };
+function decodeEntities(s) {
+  return s.replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (_, e) => ENTITY_MAP[e]);
 }
 
 // --- Parse minimal site config (just title/description/base_url) ---
@@ -97,29 +117,47 @@ function parseFrontmatter(raw, filePath) {
 }
 
 // --- Body transform pipeline (deterministic, no markdown libs) ---
+// All tag/comment/svg strips run via stripUntilStable() to defeat nested-tag
+// bypasses (CodeQL "incomplete multi-character sanitization"). Entity decode
+// happens BEFORE tag-aware steps so reconstituted tags get caught by the
+// downstream strip passes. Entity decode is single-pass (decodeEntities) to
+// avoid the cascade-double-unescape bug ("&amp;lt;" → "&lt;" → "<").
 function transformBody(body, filePath) {
   let s = body;
 
-  // 1. Strip JSON-LD blocks.
-  s = s.replace(/<script\s+type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>/gi, "");
+  // Helper: strip a tag pair until stable, then strip any orphan opening or
+  // closing tokens of the same name. Defends against reassembly attacks like
+  // "<scr<script>alert()</script>ipt>" where pair-strip leaves a literal
+  // "<script>" by concatenating "<scr" + "ipt>". Two-stage cleanup gives
+  // CodeQL a complete sanitization signature it can recognize.
+  const stripTagPair = (input, tagName) => {
+    const pair = new RegExp(`<${tagName}\\b[^>]*>[\\s\\S]*?<\\/${tagName}>`, "gi");
+    const orphan = new RegExp(`<\\/?${tagName}\\b[^>]*>`, "gi");
+    let out = stripUntilStable(input, pair);
+    out = stripUntilStable(out, orphan);
+    return out;
+  };
 
-  // 1b. Strip HTML comments.
-  s = s.replace(/<!--[\s\S]*?-->/g, "");
+  // 1. Strip JSON-LD blocks first (most specific pattern), then all script tags.
+  s = stripUntilStable(s, /<script\s+type=["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>/gi);
+  s = stripTagPair(s, "script");
 
-  // 2. Strip <svg>...</svg> blocks.
-  s = s.replace(/<svg\b[\s\S]*?<\/svg>/gi, "");
+  // 1c. Strip HTML comments (loop until stable). Comments cannot legally nest,
+  //     and there is no "orphan comment" form, so a single pair-strip suffices.
+  s = stripUntilStable(s, /<!--[\s\S]*?-->/g);
 
-  // 2b. Decode common HTML entities EARLY, so any reconstituted tags
-  //     (e.g. "&lt;script&gt;..." → "<script>...") are caught by the
-  //     downstream tag-aware steps (anchor convert + conservative strip).
-  //     Per architect hardening note: decoding after tag-strip can leak
-  //     literal "<...>" text into the output.
-  s = s.replace(/&amp;/g, "&")
-       .replace(/&lt;/g, "<")
-       .replace(/&gt;/g, ">")
-       .replace(/&quot;/g, '"')
-       .replace(/&#39;/g, "'")
-       .replace(/&nbsp;/g, " ");
+  // 2. Strip <svg>...</svg> blocks plus any orphan svg tokens.
+  s = stripTagPair(s, "svg");
+
+  // 2b. Decode common HTML entities EARLY (single-pass, no cascade) so any
+  //     reconstituted tags get caught by the downstream tag-aware steps.
+  s = decodeEntities(s);
+
+  // 2c. Re-run dangerous-tag strips after entity decode in case the decoded
+  //     text now contains tag syntax that wasn't visible before.
+  s = stripTagPair(s, "script");
+  s = stripUntilStable(s, /<!--[\s\S]*?-->/g);
+  s = stripTagPair(s, "svg");
 
   // 3. Normalize <br> and </p> to line breaks.
   s = s.replace(/<br\s*\/?>/gi, "\n");
@@ -134,18 +172,18 @@ function transformBody(body, filePath) {
       return inner;
     }
     const href = hrefMatch[1];
-    const label = inner.replace(/<[^>]+>/g, "").trim();
+    const label = stripUntilStable(inner, /<[^>]+>/g).trim();
     if (!label) return `<${href}>`;
     return `[${label}](${href})`;
   });
 
   // 5. Strip remaining HTML tags conservatively (warn on anything substantive).
-  s = s.replace(/<\/?(?:span|div|section|article|header|footer|nav|aside|main|figure|figcaption|button|small|strong|em|i|b|u|s|mark|sup|sub|cite|abbr|kbd|code|pre|blockquote|hr|input|label|select|option|table|thead|tbody|tr|th|td|ul|ol|li|h[1-6])\b[^>]*>/gi, "");
-  // Remaining tags = unrecognized; warn and strip.
+  s = stripUntilStable(s, /<\/?(?:span|div|section|article|header|footer|nav|aside|main|figure|figcaption|button|small|strong|em|i|b|u|s|mark|sup|sub|cite|abbr|kbd|code|pre|blockquote|hr|input|label|select|option|table|thead|tbody|tr|th|td|ul|ol|li|h[1-6])\b[^>]*>/gi);
+  // Remaining tags = unrecognized; warn and strip until stable.
   const remaining = s.match(/<[a-z][^>]*>/gi);
   if (remaining) {
     warn(`${filePath}: stripped ${remaining.length} unrecognized HTML tag(s); first: ${remaining[0]}`);
-    s = s.replace(/<[^>]+>/g, "");
+    s = stripUntilStable(s, /<[^>]+>/g);
   }
 
   // 6. Strip Zola heading-anchor syntax {#anchor} from heading lines.


### PR DESCRIPTION
## Re-open of #563 with code-scanning findings already addressed

Original PR #563 was force-pushed to remove an unrelated platform auto-commit and to address all code-scanning findings, then accidentally closed during a state-sync workaround attempt and GitHub refused to reopen it. This PR is the same branch, same fixes, same scope — just a fresh PR object.

## Summary

Phase A of 3 — auto-generate `llms-full.txt` from `content/*.md` so it stops drifting from the live site. The hand-maintained `static/llms-full.txt` had drifted to 5 old service pillars when the live page has 7 new ones, and was missing 13+ vendor recommendations.

## Code-scanning findings from #563 — all addressed in this branch

| Tool | Finding | Fix |
|---|---|---|
| CodeQL | 6× `js/incomplete-multi-character-sanitization` on regex strips | Added `stripUntilStable()` + `stripTagPair()` helpers. Loops each strip until output stabilises; pair-strip then orphan-strip defeats reassembly attacks like `<scr<script>...</script>ipt>` |
| CodeQL | `js/double-escaping` on entity decode | Replaced cascading `.replace().replace()...` chain with single-pass `decodeEntities()` using one regex + lookup table. `&amp;lt;` now correctly stays `&lt;` instead of double-decoding to `<` |
| CodeQL | `actions/missing-workflow-permissions` | Added `permissions: contents: read` (least-privilege) |
| code-quality | Unused `CONTENT_DIR` constant | Removed |
| (Architect supply-chain hardening) | Floating action versions | Pinned `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` to commit SHAs matching deploy.yml's style |

## Verification before push

- Production output **byte-for-byte identical** (24,371 bytes both before and after fixes — no behavioral change)
- 7-test adversarial suite passes: nested-script reassembly, orphan opening/closing tags, nested svg, nested comments, double-escape preservation, normal entity decode

## What's in this PR

- `infra/llms/build-llms-full.mjs` — deterministic generator, zero deps beyond Node stdlib
- `infra/llms/llms-full.config.json` — canonical page order with validation (fails on missing files, missing titles, duplicate URLs/labels)
- `infra/llms/README.md` — design, runbook, rollout plan
- `.github/workflows/llms-validate.yml` — PR-validation workflow with least-privilege permissions and pinned action SHAs
- `.github/workflows/deploy.yml` — generator runs after `zola build`; cache-control downgraded from `max-age=31536000,immutable` to `max-age=3600,stale-while-revalidate=86400`; upload source changed from `static/` to `build/`
- `.gitignore` — `build/` ignored
- `static/llms-full.txt` intentionally retained as Phase A fallback (deletion is Phase C)

## Architect review

Two passes:
1. Implementation review of the original diff: PASS, with one hardening (entity decode reordering) applied before push.
2. Independent review of PR #563 as actually pushed: PASS, ship-ready with zero merge-blocking issues.

CodeQL findings from the first scan were addressed in the rebased commits below. CodeQL will re-run on this PR.

## Closes

Supersedes #563 (closed because GitHub refused reopen after force-push + state-toggle race).
