### PR TITLE
docs: stub replit.md; promote AGENTS.md to sole governance + add CI guard

### DIFF
--- a/.github/workflows/replit-md-guard.yml
+++ b/.github/workflows/replit-md-guard.yml
@@ -1,0 +1,64 @@
+name: Guard replit.md against auto-expansion
+
+# Replit's checkpoint subsystem auto-rewrites replit.md on every "Loop ended"
+# event, so durable governance lives in AGENTS.md / STYLE_GUIDE.md /
+# PROJECT_EVOLUTION_LOG.md instead. This workflow enforces that replit.md
+# stays a small stub at PR time, blocking any future re-expansion (whether
+# from the platform auto-summarizer or from accidental manual edits).
+#
+# See PROJECT_EVOLUTION_LOG.md 2026-04-18 entry for the full investigation.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "replit.md"
+      - ".github/workflows/replit-md-guard.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Enforce stub policy
+        run: |
+          set -euo pipefail
+          MAX_LINES=30
+          ACTUAL=$(wc -l < replit.md)
+          echo "replit.md line count: $ACTUAL (max allowed: $MAX_LINES)"
+
+          if [ "$ACTUAL" -gt "$MAX_LINES" ]; then
+            echo "::error file=replit.md::replit.md has grown to $ACTUAL lines (max $MAX_LINES)."
+            echo ""
+            echo "This file is intentionally a stub."
+            echo "Replit's checkpoint subsystem auto-rewrites replit.md on every"
+            echo "'Loop ended' event, so durable governance must live in:"
+            echo "  - AGENTS.md (primary)"
+            echo "  - STYLE_GUIDE.md"
+            echo "  - PROJECT_EVOLUTION_LOG.md"
+            echo ""
+            echo "See PROJECT_EVOLUTION_LOG.md 2026-04-18 doc-hierarchy entry."
+            exit 1
+          fi
+
+          if ! grep -qF "AGENTS.md" replit.md; then
+            echo "::error file=replit.md::replit.md no longer references AGENTS.md as the canonical source."
+            echo "The stub must keep the canonical-sources pointer block intact."
+            exit 1
+          fi
+
+          if ! grep -qF "STYLE_GUIDE.md" replit.md; then
+            echo "::error file=replit.md::replit.md no longer references STYLE_GUIDE.md."
+            exit 1
+          fi
+
+          if ! grep -qF "PROJECT_EVOLUTION_LOG.md" replit.md; then
+            echo "::error file=replit.md::replit.md no longer references PROJECT_EVOLUTION_LOG.md."
+            exit 1
+          fi
+
+          echo "Stub policy: OK"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,21 @@
 # AGENTS.md
 
+This is the canonical, durable source of truth for all AI agents and human
+contributors working on this repository. `replit.md` is intentionally a stub
+(see `PROJECT_EVOLUTION_LOG.md` 2026-04-18 entry); do not rely on it for
+governance.
+
 ## Mandatory Read (All AI Agents)
 
-If you are an AI coding or automation agent (Codex, Replit Agent, Claude Code, Cursor, Copilot, Anti-Gravity, or similar), read these files before making any edits:
+If you are an AI coding or automation agent (Codex, Replit Agent, Claude Code,
+Cursor, Copilot, Anti-Gravity, or similar), read these files before making any
+edits, in this order:
 
-1. `STYLE_GUIDE.md`
-2. `PROJECT_EVOLUTION_LOG.md`
-3. `replit.md` (for build/deploy pipeline constraints)
+1. `AGENTS.md` (this file) — primary governance
+2. `STYLE_GUIDE.md` — visual system and tokens
+3. `PROJECT_EVOLUTION_LOG.md` — recent change rationale and rollback hooks
 
-Do not make style or UX edits until those files are read.
+Do not make style, UX, infrastructure, or copy edits until those files are read.
 
 ## Engineering Philosophy (Hard Quality Bar)
 
@@ -43,6 +50,37 @@ If a gate cannot be met, document the reason and rollback path in both PR notes 
   - IT/HELP edge outline stays, but should be tuned for clarity without harsh glow.
 - Avoid duplicate CSS selectors and dead override blocks; Sonar must stay clean.
 - Do not introduce new palette colors ad hoc. Use existing tokens first.
+- **Never use Replit's "Publish" button.** It deploys to a `*.replit.app` host that creates an SEO collision with the production site (`https://www.it-help.tech/`). All deploys go through the GitHub Actions pipeline below.
+
+## Development Workflow
+
+- Work on `replit/working` (or a topic branch named `replit/<scope>` for isolated changes).
+- Push to GitHub and open a PR against `main`.
+- Merge to `main` via **squash and merge** only.
+- After every squash-merge, reset the working branch locally so the next PR doesn't carry duplicate commits:
+  ```bash
+  git fetch origin
+  git checkout replit/working
+  git reset --hard origin/main
+  git push --force origin replit/working
+  ```
+  Then click "Pull" in Replit to sync.
+- Topic branches (`replit/<scope>`) can be deleted after merge.
+
+## Deploy & Build Pipeline
+
+Automatic on merge to `main` via `.github/workflows/deploy.yml`:
+
+1. **Zola build** → outputs to `public/` (or `build/` after the llms generator runs).
+2. **PurgeCSS** removes unused styles.
+3. **KaTeX assets** removed if unused.
+4. **CSP hashes auto-regenerated** via `infra/cloudfront/update_policy.sh` (signature pages use `infra/cloudfront/update_policy_signatures.sh` when `POLICY_ID_SIGNATURES` is set).
+5. **`infra/llms/build-llms-full.mjs`** auto-generates `build/llms-full.txt` from `content/*.md` so it never drifts from the live site.
+6. **S3 sync** with proper cache headers (`max-age=3600, stale-while-revalidate=86400` for `llms*.txt`; long-cache for fingerprinted assets).
+7. **CloudFront invalidation**.
+8. **Post-deploy audit gate** — `infra/audit/run-lighthouse.mjs` runs Lighthouse mobile/desktop and Mozilla Observatory against URLs in `infra/audit/audit.config.json`. Median-of-3 sampling per (url, formFactor); fails if any per-category median drops below thresholds (currently 98 for Performance/Accessibility/Best Practices/SEO; A+/120 for Observatory). Single-sample dips that pass the median surface as warnings, not failures.
+
+Local build: `zola build` → `public/`. Local preview: `zola serve --interface 0.0.0.0 --port 5000`.
 
 ## Required Update Process For Visual Changes
 
@@ -58,6 +96,39 @@ When changing palette, hero/logo styling, nav/CTA styling, or readability treatm
    - rollback reference (commit/PR)
 4. Run `zola build` before opening or updating a PR.
 
+## Project Architecture (At-a-Glance)
+
+**Stack:** Zola static site generator + Abridge theme (customized). SASS for styles, PurgeCSS for optimization. No client-side frameworks. No trackers, no cookies, no third-party JS frameworks.
+
+**Layout:**
+
+- `content/` — Markdown pages, blog posts, and embedded JSON-LD schema
+- `templates/` — Zola HTML templates and macros (`base.html`, `page.html`, `blog.html`)
+- `themes/abridge/` — Abridge theme; SEO macros at `themes/abridge/templates/macros/seo.html`
+- `sass/` — SASS sources (`_extra.scss` holds component/interaction tokens; `css/abridge.scss` holds theme/link tokens)
+- `static/` — assets, `robots.txt`, `llms.txt`; `static/css/late-overrides.css` is the canonical visual-system file
+- `infra/` — `audit/` (Lighthouse + Observatory gate), `llms/` (build-time `llms-full.txt` generator), `cloudfront/` (CSP policy regen)
+- `public/` — Zola build output (gitignored)
+- `build/` — generator output staged for S3 (gitignored)
+
+**Content pages and schema types:**
+
+| Page | File | Schema Types |
+|------|------|--------------|
+| Home | `content/_index.md` | FAQPage, LocalBusiness+ProfessionalService, WebSite, WebPage |
+| Services | `content/services.md` | WebSite, WebPage, LocalBusiness, ItemList, Offer, FAQPage, Service graph |
+| Billing | `content/billing.md` | Offer, FAQPage |
+| About | `content/about.md` | AboutPage with Organization |
+| DNS Tool | `content/dns-tool.md` | SoftwareApplication |
+| Blog Index | `content/blog/_index.md` | ItemList |
+| Blog Posts | `content/blog/*.md` | Article (via `templates/page.html`) |
+
+**SEO architecture:** Theme SEO macros handle base meta, OG, Twitter. Per-page overrides via content frontmatter (`extra.og_title`, `extra.twitter_description`, etc.). JSON-LD schema lives in content Markdown files, not templates. `templates/blog.html` adds Blog schema for the index.
+
+**CSS load order (do not reorder):** `critical.min.css` (inlined) → `cls-fixes.css` → `abridge.css` → `override.min.css` → `late-overrides.css`.
+
+**LLM/bot files:** `static/robots.txt` enumerates AI bot permissions. `static/llms.txt` is the short LLM-friendly summary. `build/llms-full.txt` (auto-generated at deploy time from `content/*.md`) is the full content snapshot; the legacy `static/llms-full.txt` is retained as a Phase A fallback and will be deleted in a future PR.
+
 ## Canonical Files
 
 - Visual system: `static/css/late-overrides.css`
@@ -65,3 +136,20 @@ When changing palette, hero/logo styling, nav/CTA styling, or readability treatm
 - Component/interaction tokens: `sass/_extra.scss`
 - Project style rules: `STYLE_GUIDE.md`
 - Change history: `PROJECT_EVOLUTION_LOG.md`
+- Site config: `config.toml`
+- Layout shell + footer NAP: `templates/base.html`
+- Audit gate config + thresholds: `infra/audit/audit.config.json`
+- llms-full generator + page order: `infra/llms/build-llms-full.mjs`, `infra/llms/llms-full.config.json`
+
+## Why `replit.md` Is a Stub
+
+Replit's checkpoint subsystem auto-rewrites `replit.md` on every "Loop ended"
+event (commit author `careybalboa <...@users.noreply.replit.com>`, trailer
+`Replit-Commit-Checkpoint-Type: full_checkpoint`). Manually curated sections do
+not survive. There is no documented `.replit` flag to disable this. We
+therefore deny the auto-summarizer anything meaningful to manage by keeping
+`replit.md` short, and we enforce the stub policy with a CI guard
+(`.github/workflows/replit-md-guard.yml`). All real governance lives here,
+in `STYLE_GUIDE.md`, and in `PROJECT_EVOLUTION_LOG.md`. See
+`PROJECT_EVOLUTION_LOG.md` 2026-04-18 doc-hierarchy entry for the full
+investigation.

--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,19 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-04-18 (Docs · `replit.md` reduced to platform-owned stub; AGENTS.md becomes sole governance source)
+- Actor: AI (Replit Agent + architect subagent)
+- Severity: MEDIUM (changes the documented source-of-truth hierarchy for all AI agents on this repo)
+- Trigger: Replit's checkpoint subsystem was repeatedly stripping `replit.md` on every "Loop ended" event. Three strips observed in a single session (137 → 46 → 78 → 45 lines), each commit titled "Restore..." but actually deleting 90+ lines. Author trailer `careybalboa <43527839-careybalboa@users.noreply.replit.com>` and commit headers `Replit-Commit-Checkpoint-Type: full_checkpoint` + `Replit-Helium-Checkpoint-Created: true` confirmed platform automation as the source. No documented `.replit` flag disables the behavior. Owner directive: "find out how to prevent this error."
+- Files:
+  - `replit.md` — reduced from 137 lines to ~12-line stub: title, one paragraph explaining the stub policy, canonical-sources block pointing to `AGENTS.md`, `STYLE_GUIDE.md`, `PROJECT_EVOLUTION_LOG.md`
+  - `AGENTS.md` — folded in Development Workflow, Deploy & Build Pipeline, Project Architecture (At-a-Glance), and "Why replit.md Is a Stub" sections. Mandatory Read list updated to drop `replit.md` and elevate `AGENTS.md` itself as primary
+  - `.github/workflows/replit-md-guard.yml` — new CI guard fails any PR where `replit.md` exceeds 30 lines or drops the canonical-sources pointers (`AGENTS.md`, `STYLE_GUIDE.md`, `PROJECT_EVOLUTION_LOG.md`)
+  - `PROJECT_EVOLUTION_LOG.md` — this entry
+- Change: AGENTS.md is now the sole canonical source for engineering governance, dev workflow, deploy pipeline, and project architecture pointers. `replit.md` is intentionally disposable; the platform may rewrite it freely without affecting governance. CI guard at PR boundary blocks any future re-expansion (whether from the platform auto-summarizer or from accidental human edits).
+- Why: Architect-validated root cause — the Replit checkpoint subsystem treats `replit.md` as an auto-summary file it owns, derived from a project metadata pass that fires after the agent loop ends. Fighting it inside the loop is futile (autocommit lands after the agent's last action). Architect ranked five mitigation options; the durable fix is option (a): deny the auto-summarizer anything meaningful to summarize, and let CI catch any drift at PR time. Options (b) `.gitignore`, (c) author/line-delta pre-commit hook, and (d) `.replit` config flag were rejected (no supported flag; hooks may not run for platform commits; ignoring breaks fresh-clone bootstrap). The 137-line `replit.md` we kept restoring was itself a prior platform summary, not the owner's original — confirming the file has not been durably owner-controlled for some time.
+- Rollback: revert this PR. Note: reverting reintroduces the strip-cycle on every checkpoint and re-orphans governance content into a file the platform overwrites unpredictably.
+
 ### 2026-04-18 (Audit gate · jitter elimination via median-of-3 with leading-indicator warnings)
 - Actor: AI (Replit Agent + architect subagent)
 - Severity: MEDIUM (CI infrastructure; affects every deploy going forward; engineering bar preserved exactly)

--- a/replit.md
+++ b/replit.md
@@ -1,137 +1,46 @@
 # IT Help San Diego Inc. Site
 
-## AI Agent Mandatory Context (Read First)
-- Source of truth for all AI agents: `AGENTS.md`
-- Required pre-read before edits:
-  - `STYLE_GUIDE.md`
-  - `PROJECT_EVOLUTION_LOG.md`
-  - `replit.md`
-- If you change visual system, tokens, or hero/logo treatment:
-  - Update `STYLE_GUIDE.md`
-  - Add an entry to `PROJECT_EVOLUTION_LOG.md`
-  - Run `zola build`
-
-## Engineering Bar (No-Compromise)
-- Aim for Lighthouse perfection on meaningful pages; do not accept regressions casually.
-- Maintain Observatory A+ posture with target score >=120.
-- Maintain strict security/privacy posture: no trackers, no cookies, no unnecessary frameworks.
-- Build cleanly from the start; avoid "ship now, fix later" practices.
-- Prioritize readable, maintainable foundations over flashy shortcuts.
-- Treat best practices as symbiotic: security, speed, accessibility, UX psychology, and maintainability must all reinforce each other.
-- Do not optimize one axis while degrading another and call it "done."
-
 ## Overview
-A static website for IT Help San Diego Inc., built with Zola static site generator and the Abridge theme. Privacy-first, no-tracking, no-cookies design. Production site: https://www.it-help.tech/
+This project is a privacy-first, no-tracking, no-cookies static website for IT Help San Diego Inc., built using the Zola static site generator and the Abridge theme. Its main purpose is to provide a professional online presence, showcasing services, transparent pricing, and company information. The site aims for technical excellence with high Lighthouse scores and a strong security posture, reflecting a business vision of professional confidence without aggressive sales tactics. The production site is accessible at https://www.it-help.tech/.
 
-## Project Structure
-- `content/` - Markdown content files (pages, blog posts, and JSON-LD schema)
-- `templates/` - Zola HTML templates and macros
-- `themes/abridge/` - Abridge theme (SEO macros, partials)
-- `sass/` - SASS stylesheets
-- `static/` - Static assets (images, CSS, JS, robots.txt, llms.txt)
-- `config.toml` - Zola configuration
-- `public/` - Generated build output (gitignored)
+## User Preferences
+- **Engineering Bar (No-Compromise)**: Aim for Lighthouse perfection on meaningful pages; do not accept regressions casually. Maintain Observatory A+ posture with target score >=120. Maintain strict security/privacy posture: no trackers, no cookies, no unnecessary frameworks. Build cleanly from the start; avoid "ship now, fix later" practices. Prioritize readable, maintainable foundations over flashy shortcuts. Treat best practices as symbiotic: security, speed, accessibility, UX psychology, and maintainability must all reinforce each other. Do not optimize one axis while degrading another and call it "done."
+- **Site Philosophy**: No tracking, no cookies, no frameworks. Professional confidence without salesy/desperate elements. Link to verified Google Reviews (not embedded testimonials). Transparent pricing, no retainers, no kickbacks. `base_url` stays as production URL (Replit preview quirks are acceptable).
+- **Development Workflow**: Work on `replit/working` branch, push to GitHub, create PRs, and merge to `main` via squash and merge. After every PR merge, run the specified `git fetch`, `git checkout`, `git reset --hard`, and `git push --force` commands to reset the working branch.
+- **Deployment Restrictions**: NEVER use Replit's "Publish" button as it causes SEO collision with the production site.
+- **Visual System Changes**: If changes are made to the visual system, tokens, or hero/logo treatment, `STYLE_GUIDE.md` must be updated, an entry added to `PROJECT_EVOLUTION_LOG.md`, and `zola build` run.
 
-## Content Pages
-| Page | File | Schema Types |
-|------|------|--------------|
-| Home | `content/_index.md` | FAQPage, LocalBusiness+ProfessionalService, WebSite, WebPage |
-| Services | `content/services.md` | WebSite, WebPage, LocalBusiness, ItemList (13 services), Offer, FAQPage, Service graph |
-| Billing | `content/billing.md` | Offer, FAQPage |
-| About | `content/about.md` | AboutPage with Organization |
-| DNS Tool | `content/dns-tool.md` | SoftwareApplication |
-| Blog Index | `content/blog/_index.md` | ItemList (blog posts) |
-| Blog Posts | `content/blog/*.md` | Article (via page.html template) |
+## System Architecture
+The site is structured with `content/` for Markdown files (pages, blog posts, JSON-LD schema), `templates/` for Zola HTML, `themes/abridge/` for the Abridge theme (SEO macros, partials), `sass/`, and `static/` for assets. `config.toml` manages Zola configuration.
 
-## SEO Architecture
-- **Theme SEO macros**: `themes/abridge/templates/macros/seo.html` handles base meta, OG, Twitter
-- **Per-page overrides**: Content frontmatter with `extra.og_title`, `extra.twitter_description`, etc.
-- **JSON-LD schema**: Embedded in content markdown files (not templates)
-- **Blog template**: `templates/blog.html` adds Blog schema for the index
+**UI/UX Decisions:**
+- **Design Principles**: Privacy-first, no-tracking, no-cookies. Emphasis on professional confidence.
+- **Navigation**: Single-line navigation with `white-space: nowrap` for items. Hamburger menu threshold at 960px. Compact-desktop band (769–960px) hides phone label.
+- **Topbar**: Apple-style glass topbar with `backdrop-filter` and `color-mix()`. WCAG-correct nav polish with `aria-current` for active pages/sections and enhanced focus-visible states. Stratified topbar for consistent background and adaptive styles based on media queries (desktop, touch). Decorative elements (`.circuit-bg`, `.logo-constellation`) use `mask-image` for smooth transitions.
+- **Accessibility**: `prefers-reduced-motion` applied to decorative elements. `aria-current="page"` for exact matches, `aria-current="true"` for section ancestors. Topbar bottom-border alpha adjusted to 38% for WCAG 1.4.11 contrast.
+- **Typography**: `@media print` stylesheet with letterhead and paper typography.
+- **Hero Section**: Hero tagline rewritten for concise brand messaging, with `in motion` highlighted in gold.
 
-## Key Files
-- `config.toml` - Site config, base_url, menu, theme settings
-- `templates/base.html` - Main layout, nav dropdown, footer with NAP
-- `templates/page.html` - Standard page template with Article schema for blog posts
-- `templates/blog.html` - Blog index with Blog schema
-- `static/robots.txt` - AI bot permissions explicitly listed
-- `static/llms.txt` - LLM-friendly site summary
-- `static/llms-full.txt` - Full content for LLM context
+**Technical Implementations:**
+- **Static Site Generation**: Zola is used for building the site.
+- **SEO Architecture**: Theme SEO macros (`themes/abridge/templates/macros/seo.html`) handle base meta, OG, Twitter. Per-page overrides are managed via content frontmatter. JSON-LD schema is embedded directly in Markdown content files. Blog index (`templates/blog.html`) adds Blog schema.
+- **Build Process**: `zola build` outputs to `public/`.
+- **Deployment Pipeline (GitHub Actions)**:
+    - Zola build.
+    - PurgeCSS for unused styles.
+    - KaTeX assets removed if unused.
+    - CSP hashes auto-regenerated via `infra/cloudfront/update_policy.sh`.
+    - S3 sync with proper cache headers.
+    - CloudFront invalidation.
+    - **Post-deploy audit gate**: Runs Lighthouse mobile/desktop and Mozilla Observatory checks against URLs defined in `infra/audit/audit.config.json`. Fails if Performance, Accessibility, Best Practices, or SEO drop below 98, or Observatory below A+/score 120 (median of N samples). `infra/audit/run-lighthouse.mjs` implements median-of-N sampling for robustness against single-sample jitter.
+- **CSS Architecture**: Specific load order for stylesheets: `critical.min.css` (inlined), `cls-fixes.css`, `abridge.css`, `override.min.css`, `late-overrides.css`.
+- **Content Pages**: Defined content pages include Home, Services, Billing, About, DNS Tool, Blog Index, and Blog Posts, each with specific Schema Types for SEO.
+- **LLM Integration**: `static/robots.txt` explicitly lists AI bot permissions, `static/llms.txt` provides an LLM-friendly site summary, and `static/llms-full.txt` contains full content for LLM context.
 
-## Development
-```bash
-zola serve --interface 0.0.0.0 --port 5000
-```
-
-## Build & Deploy
-- Build: `zola build` → outputs to `public/`
-- Deploy: GitHub Actions workflow (`.github/workflows/deploy.yml`)
-- **NEVER use Replit's "Publish" button** (causes SEO collision with production)
-
-### Deploy Pipeline (Automatic on merge to main)
-1. Zola build
-2. PurgeCSS removes unused styles
-3. KaTeX assets removed if unused
-4. **CSP hashes auto-regenerated** via `infra/cloudfront/update_policy.sh` (signature pages use `infra/cloudfront/update_policy_signatures.sh` when `POLICY_ID_SIGNATURES` is set)
-5. S3 sync with proper cache headers
-6. CloudFront invalidation
-7. **Post-deploy audit gate** (`audit` job) — runs Lighthouse mobile + desktop against every URL in `infra/audit/audit.config.json` and re-checks Mozilla Observatory. Fails the workflow if any of Performance / Accessibility / Best Practices / SEO drops below 98 on either form factor, or if Observatory regresses below A+ / score 120.
-
-### Audit gate — how to update
-- All thresholds and the audited URL list live in **`infra/audit/audit.config.json`**. Add a page to `lighthouse.urls` (e.g. `https://www.it-help.tech/services/`) or change a number; no workflow edit needed.
-- The two scripts (`infra/audit/run-lighthouse.mjs`, `infra/audit/run-observatory.mjs`) can be run locally with `lighthouse` + a Chromium binary on PATH to reproduce a CI failure.
-
-**Local/Replit note:** `update_policy_signatures.sh` requires AWS credentials + `POLICY_ID_SIGNATURES`. If those secrets aren't available, the signature CSP update will fail or be skipped—this is expected outside CI.
-
-### CSS Architecture (load order matters!)
-1. `critical.min.css` - inlined in head
-2. `cls-fixes.css` - prevents layout shift
-3. `abridge.css` - theme base styles
-4. `override.min.css` - homepage/nav/mobile overrides (complex, don't merge)
-5. `late-overrides.css` - hero animation + gold links (combined from hero-logo.css + gold-override.css)
-
-## Branching Workflow
-- Work on `replit/working` branch
-- Push to GitHub and create PRs
-- Merge to main via squash and merge
-
-### IMPORTANT: After Every PR Merge
-Run these commands locally after each squash-merge to reset the working branch:
-```bash
-git fetch origin
-git checkout replit/working
-git reset --hard origin/main
-git push --force origin replit/working
-```
-Then click "Pull" in Replit to sync. This prevents duplicate commits in future PRs.
-
-## Site Philosophy
-- No tracking, no cookies, no frameworks
-- Professional confidence without salesy/desperate elements
-- Link to verified Google Reviews (not embedded testimonials)
-- Transparent pricing, no retainers, no kickbacks
-- base_url stays as production URL (Replit preview quirks are acceptable)
-
-## Lighthouse Scores
-Site maintains 98-100 scores. All changes must preserve these.
-
-## Engineering Bar / Audit gate
-The post-deploy audit gate is configured by `infra/audit/audit.config.json` and run by `infra/audit/run-lighthouse.mjs` from `.github/workflows/deploy.yml`. The config enumerates the production URLs Lighthouse-verified after each deploy on both `formFactors` (mobile + desktop), with the engineering-bar threshold of ≥98 for Performance / Accessibility / Best Practices / SEO, plus a Mozilla Observatory floor of A+ / score ≥120. **The runner samples each (url, formFactor) pair `samplesPerAudit` times (default 3) and fails the deploy only if the per-category MEDIAN drops below threshold** — single-sample TBT jitter from CloudFront edge cold-start no longer false-fails CI, and a real intermittent regression (manifests on ≥2 of 3 samples) still surfaces. A non-failing **warning** is also emitted whenever any single sample dipped below threshold but the median still passed (leading indicator of thinning margin). **Currently audited URLs:** `/`, `/services/`, `/billing/`, `/about/`. To extend coverage, add a fully-qualified URL to `lighthouse.urls` and verify it clears 98+ median on both form factors in production before merging — flaky pages must be fixed or the deviation documented here, not silently demoted. Setting `samplesPerAudit: 1` reverts to the original single-sample behavior.
-
-## Recent Changes
-- 2026-04-18: Audit gate jitter fix — `infra/audit/run-lighthouse.mjs` rewritten to median-of-N (default N=3) per (url, formFactor), with per-category-independent median aggregation and sub-threshold-but-median-passing single-sample warnings. Background: PR #554 mobile P=96 and PR #557 mobile P=95 both false-failed CI on the homepage despite the page genuinely scoring 99–100; root cause documented (CloudFront edge cold-start + headless-Chromium TBT scheduling noise). Architect-vetted plan rejected best-of-N (masks intermittent regressions) and Lighthouse-CI migration (fights existing JSON config schema) in favor of straight median-of-3 with the leading-indicator warning. Median-of-3 keeps the engineering bar honest — a real regression that triggers in ≥2 of 3 samples still fails the gate — while a single jittery sample no longer false-fails. Cost: Lighthouse phase grows from ~96s to ~5min per deploy (24 audits × ~12s); Observatory phase unchanged. `samplesPerAudit` is configurable in `audit.config.json` and defaults to 3; setting it to 1 reverts to the original single-sample behavior.
-- 2026-04-17: Audit gate scope expansion (round 2) — `/about/` added to `infra/audit/audit.config.json` `lighthouse.urls`. Production verification: `/about/` desktop perfect 100/100/100/100; `/about/` mobile A100 BP100 SEO100 with Performance jitter band 95–100 across a 7-run sample (99, 97, 98, 100, 98, 95, 96; mean ≈97.6, median 98). The page is a static markdown page with one JSON-LD block — same shape as `/billing/`, and the variance has the same root cause (CloudFront edge cold-start + headless-Chromium TBT measurement noise on a single sample). It clears the 98 floor as often as it doesn't, so a CI re-run policy is acceptable. **`/dns-tool/` was intentionally NOT added** despite being in scope: production mobile verification across 5 runs returned 95, 95, 96, 95, 95 (consistent, not jitter; TBT 213–235ms). Lighthouse opportunities point to `/img/brand/wordmark-banner.png` (38 KiB PNG, ~28 KiB savings if responsive-sized, ~31 KiB if served as AVIF/WebP) plus `css/tokens.css` render-blocking ~150ms — both are *site-wide* assets, but `/dns-tool/` is the longest content page on the site and the only one where the cumulative effect drops mobile P below 98. Adding it now would guarantee a CI failure on every deploy. Remediation path before re-adding: convert `wordmark-banner.png` to responsive WebP/AVIF and inline `tokens.css` (or fold it into `critical.min.css`); re-run mobile, expect P to climb to ≥98 with the same jitter band as `/about/`.
-- 2026-04-17: Audit gate scope expansion — `infra/audit/audit.config.json` `lighthouse.urls` extended from `/` only to `/`, `/services/`, `/billing/`. Production verification on both form factors: `/services/` mobile P98 A100 BP100 SEO100, desktop all 100; `/billing/` mobile P98–99 (3-run sample: 99/99/98) A100 BP100 SEO100, desktop all 100. Note on `/billing/` mobile variance: an initial cold run hit P89 with TBT ≈280ms — three follow-up runs settled to 98/99/99 (TBT 27–151ms). The page is static HTML with two JSON-LD blocks and no extra script; the variance is jitter in CloudFront/edge cold-start + headless-Chromium TBT measurement, not a content regression. The 98 floor is met but the margin is thin enough that any future addition of script/3p to `/billing/` must be re-audited; the runner only takes a single sample per `(url, formFactor)`, so a flaky failure in CI is possible — re-run on infra noise. Other pages considered (`/about/`, `/dns-tool/`, `/security-policy/`) intentionally deferred — task scope is `/services/` and `/billing/`.
-- 2026-04-17: Post-PR #551 verification — production audit of https://www.it-help.tech/ confirms the homepage rewrite (skip-link transform fix, DNS subdomain correction, mission-based copy rewrite, new "What we do" card) preserves the engineering bar. Lighthouse mobile: Performance 100, Accessibility 100, Best Practices 100, SEO 100. Lighthouse desktop: Performance 100, Accessibility 100, Best Practices 100, SEO 100. Mozilla Observatory: A+, score 140 (10/10 tests passed, algorithm v5). All ≥98 invariants intact; no regressions. Tooling used (reproducible): `chromium` was added as a system Nix dep (auto-written to `replit.nix` alongside `zola` declared in `.replit`'s `[nix].packages` — two-source split is the platform-prescribed pattern; both binaries resolve). Lighthouse CLI installed ad-hoc into `/tmp/lh` (not committed). Commands run: `lighthouse https://www.it-help.tech/ --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage" --only-categories=performance,accessibility,best-practices,seo` (mobile) and the same plus `--preset=desktop`. Observatory pulled via `POST https://observatory-api.mdn.mozilla.net/api/v2/scan?host=www.it-help.tech` with empty JSON body. See follow-up #5 for wiring this gate into CI.
-- 2026-04-17: PR #548 — Architect-validated DEFINITIVE topbar seam fix. Root cause: surface discontinuity, not a border. Topbar now stratified — BASE: `background: var(--c1)` (matches body exactly, no blur, no border, no shadow); DESKTOP `@media (min-width: 961px) and (hover: hover) and (pointer: fine)`: re-enables Apple glass + 38% gold WCAG 1.4.11 hairline mixed from --c1 (not --surface-charcoal); TOUCH `@media (hover: none), (pointer: coarse)`: forces solid for iPad landscape + touch laptops. Decorative `.circuit-bg` + `.logo-constellation` got 56px top-fade `mask-image` so grid/dots fade in below the topbar instead of clipping. STYLE_GUIDE codified the never-tint-with-non-c1 invariant.
-- 2026-04-17: PR #546 — Hero tagline rewritten from `We solve tech problems. / No monthly retainers.` (which duplicated the H1 verbatim) to `IT research in motion.` (single line, `in motion` as gold highlight). The H1 retains the literal proposition for SEO; the pill carries the brand promise. Mobile topbar gold hairline dropped (`@media (max-width: 960px) { .topbar { border-bottom-color: transparent } }`) — desktop hairline preserved per PR #545's WCAG 1.4.11 contrast win. STYLE_GUIDE + PROJECT_EVOLUTION_LOG updated.
-- 2026-04-17: PR #545 — WCAG-correct nav polish. `aria-current="page"` reserved for exact match; section ancestors emit `aria-current="true"` (CSS attr selector widened to `[aria-current]` so underline shows for both). Topbar bottom-border alpha 18% → 38% for WCAG 1.4.11. Distinct focus-visible state restored (2px gold outline, no longer collapsed into hover). Compositing hint added to topbar (`translateZ(0)` + narrow `will-change: backdrop-filter`). External-link arrow underline trim via `:has(.topbar-ext)`.
-- 2026-04-17: PR #544 — single-line nav fix. `white-space: nowrap` on every nav item (links, CTA, phone, phone label). Hamburger threshold raised 768 → 960px. New compact-desktop band (769–960px) hides phone label so icon stays as a tappable call link without crowding. Apple-style glass topbar via `backdrop-filter: saturate(160%) blur(14px)` + `color-mix()` translucent fill (with `@supports` fallback). Active-page indicator wired in `templates/base.html` via Tera prefix match.
-- 2026-04-17: Polish Phase 1 — `prefers-reduced-motion` extended to decorative-only elements (`.blob`, `.circuit-bg`, `.hex-decoration`); new `@media print` "leave-behind" stylesheet with letterhead + paper typography; tokenized form-control baseline ready for first contact form
-- 2026-02-04: Fixed CSP pipeline to prevent hash accumulation (removed --merge-hashes-from-stdin)
-- 2026-02-04: Created og-home.png (1200x630px, 498KB) with tagline for OG/Twitter sharing
-- 2026-02-04: Combined hero-logo.css + gold-override.css into late-overrides.css (5→4 CSS requests)
-- 2026-02-04: Optimized hero-logo.js to cache dimensions, eliminating forced reflows
-- 2026-02-04: Cleaned up unused files, created WebP image alternatives, fixed git workflow
-- 2026-02-04: Reordered nav dropdown: Services, Pricing, Our Expertise, Blog, DNS Tool
-- 2026-02-03: Configured for Replit environment with Zola static site generator
+## External Dependencies
+- **Static Site Generator**: Zola
+- **Theme**: Abridge (Zola theme)
+- **Deployment/Hosting**: GitHub Actions, Amazon S3, Amazon CloudFront
+- **Performance/Security Auditing**: Google Lighthouse, Mozilla Observatory
+- **CSS Processing**: PurgeCSS
+- **Mathematical Typesetting**: KaTeX (if used)

--- a/replit.md
+++ b/replit.md
@@ -1,46 +1,15 @@
 # IT Help San Diego Inc. Site
 
-## Overview
-This project is a privacy-first, no-tracking, no-cookies static website for IT Help San Diego Inc., built using the Zola static site generator and the Abridge theme. Its main purpose is to provide a professional online presence, showcasing services, transparent pricing, and company information. The site aims for technical excellence with high Lighthouse scores and a strong security posture, reflecting a business vision of professional confidence without aggressive sales tactics. The production site is accessible at https://www.it-help.tech/.
+This file is intentionally minimal. Replit's checkpoint subsystem auto-rewrites
+`replit.md` on every "Loop ended" event, so durable governance lives elsewhere.
+A CI guard (`.github/workflows/replit-md-guard.yml`) fails any PR that grows
+this file past its stub size, and `PROJECT_EVOLUTION_LOG.md` (2026-04-18 entry)
+documents the rationale.
 
-## User Preferences
-- **Engineering Bar (No-Compromise)**: Aim for Lighthouse perfection on meaningful pages; do not accept regressions casually. Maintain Observatory A+ posture with target score >=120. Maintain strict security/privacy posture: no trackers, no cookies, no unnecessary frameworks. Build cleanly from the start; avoid "ship now, fix later" practices. Prioritize readable, maintainable foundations over flashy shortcuts. Treat best practices as symbiotic: security, speed, accessibility, UX psychology, and maintainability must all reinforce each other. Do not optimize one axis while degrading another and call it "done."
-- **Site Philosophy**: No tracking, no cookies, no frameworks. Professional confidence without salesy/desperate elements. Link to verified Google Reviews (not embedded testimonials). Transparent pricing, no retainers, no kickbacks. `base_url` stays as production URL (Replit preview quirks are acceptable).
-- **Development Workflow**: Work on `replit/working` branch, push to GitHub, create PRs, and merge to `main` via squash and merge. After every PR merge, run the specified `git fetch`, `git checkout`, `git reset --hard`, and `git push --force` commands to reset the working branch.
-- **Deployment Restrictions**: NEVER use Replit's "Publish" button as it causes SEO collision with the production site.
-- **Visual System Changes**: If changes are made to the visual system, tokens, or hero/logo treatment, `STYLE_GUIDE.md` must be updated, an entry added to `PROJECT_EVOLUTION_LOG.md`, and `zola build` run.
+## Canonical Sources (read in this order)
 
-## System Architecture
-The site is structured with `content/` for Markdown files (pages, blog posts, JSON-LD schema), `templates/` for Zola HTML, `themes/abridge/` for the Abridge theme (SEO macros, partials), `sass/`, and `static/` for assets. `config.toml` manages Zola configuration.
+1. `AGENTS.md` — agent governance, engineering bar, dev workflow, deploy pipeline, architecture pointers
+2. `STYLE_GUIDE.md` — visual system, design tokens, brand rules
+3. `PROJECT_EVOLUTION_LOG.md` — change history with rollback references
 
-**UI/UX Decisions:**
-- **Design Principles**: Privacy-first, no-tracking, no-cookies. Emphasis on professional confidence.
-- **Navigation**: Single-line navigation with `white-space: nowrap` for items. Hamburger menu threshold at 960px. Compact-desktop band (769–960px) hides phone label.
-- **Topbar**: Apple-style glass topbar with `backdrop-filter` and `color-mix()`. WCAG-correct nav polish with `aria-current` for active pages/sections and enhanced focus-visible states. Stratified topbar for consistent background and adaptive styles based on media queries (desktop, touch). Decorative elements (`.circuit-bg`, `.logo-constellation`) use `mask-image` for smooth transitions.
-- **Accessibility**: `prefers-reduced-motion` applied to decorative elements. `aria-current="page"` for exact matches, `aria-current="true"` for section ancestors. Topbar bottom-border alpha adjusted to 38% for WCAG 1.4.11 contrast.
-- **Typography**: `@media print` stylesheet with letterhead and paper typography.
-- **Hero Section**: Hero tagline rewritten for concise brand messaging, with `in motion` highlighted in gold.
-
-**Technical Implementations:**
-- **Static Site Generation**: Zola is used for building the site.
-- **SEO Architecture**: Theme SEO macros (`themes/abridge/templates/macros/seo.html`) handle base meta, OG, Twitter. Per-page overrides are managed via content frontmatter. JSON-LD schema is embedded directly in Markdown content files. Blog index (`templates/blog.html`) adds Blog schema.
-- **Build Process**: `zola build` outputs to `public/`.
-- **Deployment Pipeline (GitHub Actions)**:
-    - Zola build.
-    - PurgeCSS for unused styles.
-    - KaTeX assets removed if unused.
-    - CSP hashes auto-regenerated via `infra/cloudfront/update_policy.sh`.
-    - S3 sync with proper cache headers.
-    - CloudFront invalidation.
-    - **Post-deploy audit gate**: Runs Lighthouse mobile/desktop and Mozilla Observatory checks against URLs defined in `infra/audit/audit.config.json`. Fails if Performance, Accessibility, Best Practices, or SEO drop below 98, or Observatory below A+/score 120 (median of N samples). `infra/audit/run-lighthouse.mjs` implements median-of-N sampling for robustness against single-sample jitter.
-- **CSS Architecture**: Specific load order for stylesheets: `critical.min.css` (inlined), `cls-fixes.css`, `abridge.css`, `override.min.css`, `late-overrides.css`.
-- **Content Pages**: Defined content pages include Home, Services, Billing, About, DNS Tool, Blog Index, and Blog Posts, each with specific Schema Types for SEO.
-- **LLM Integration**: `static/robots.txt` explicitly lists AI bot permissions, `static/llms.txt` provides an LLM-friendly site summary, and `static/llms-full.txt` contains full content for LLM context.
-
-## External Dependencies
-- **Static Site Generator**: Zola
-- **Theme**: Abridge (Zola theme)
-- **Deployment/Hosting**: GitHub Actions, Amazon S3, Amazon CloudFront
-- **Performance/Security Auditing**: Google Lighthouse, Mozilla Observatory
-- **CSS Processing**: PurgeCSS
-- **Mathematical Typesetting**: KaTeX (if used)
+Production site: https://www.it-help.tech/


### PR DESCRIPTION
## Problem

Replit's checkpoint subsystem auto-rewrites `replit.md` on every "Loop ended" event. Three consecutive strips observed in a single agent session: **137 → 46 → 78 → 45 lines**, each commit titled "Restore..." but actually deleting 90+ lines.

**Definitive evidence:**
- Author trailer: `careybalboa <43527839-careybalboa@users.noreply.replit.com>` (platform-side noreply, not Replit Agent and not the owner)
- Commit headers: `Replit-Commit-Checkpoint-Type: full_checkpoint` + `Replit-Helium-Checkpoint-Created: true`
- Commit messages are platform-generated and unreliable (claim "restore" while deleting)
- No documented `.replit` flag disables the behavior
- The 137-line `replit.md` we kept restoring this session was itself a prior platform summary, not the owner's original — confirming this file has not been durably owner-controlled for some time

## Architect-validated fix

Deny the auto-summarizer anything meaningful to manage; enforce the stub at PR boundary.

Five mitigation options were considered:
- ✅ **(a) Stub `replit.md` + AGENTS.md as sole governance** — picked
- ❌ (b) `.gitignore replit.md` — breaks fresh-clone bootstrap, requires index surgery
- ❌ (c) Pre-commit hook on author/line-delta — fragile heuristic, may not run for platform commits
- ❌ (d) `.replit` config flag — no supported flag exists
- ❌ (e) Procedural session-end guard alone — incomplete

## Changes

| File | Change |
|---|---|
| `replit.md` | 137 → 15-line stub. Title, one paragraph explaining stub policy, canonical-sources block pointing to `AGENTS.md`, `STYLE_GUIDE.md`, `PROJECT_EVOLUTION_LOG.md` |
| `AGENTS.md` | Folded in **Development Workflow** (branch model + post-merge reset commands), **Deploy & Build Pipeline** (Zola → PurgeCSS → CSP regen → llms-full generator → S3 → CloudFront → median-of-3 audit gate), **Project Architecture (At-a-Glance)** (stack, layout, content-pages schema table, SEO arch, CSS load order, LLM/bot files), and **"Why replit.md Is a Stub"** explanatory section. Mandatory Read updated to drop `replit.md` and elevate `AGENTS.md` itself as primary. Now 155 lines of durable governance. |
| `.github/workflows/replit-md-guard.yml` | New PR-time CI guard. Fails any PR where `replit.md` exceeds 30 lines or drops the canonical-sources pointers. Least-privilege `contents: read`. Action SHA pinned to match repo convention. Triggers only on `replit.md` or workflow path changes. |
| `PROJECT_EVOLUTION_LOG.md` | 2026-04-18 entry: trigger, root cause, ranked options, decision rationale, rollback note |

## Verification

Local stub-policy check (mirrors CI guard):
```
replit.md lines: 15 (max 30)
✓ size OK
✓ references AGENTS.md
✓ references STYLE_GUIDE.md
✓ references PROJECT_EVOLUTION_LOG.md
```

Workflow shell logic syntax-checked. AGENTS.md retains all engineering governance (Hard Quality Bar, Acceptance Gates, Non-Negotiable Rules, Visual Change Process, Canonical Files) plus the migrated sections.

## Risk

- ✅ No production impact. Pure docs + CI guard. No Zola templates, content, styles, or build pipeline touched.
- ✅ Engineering bar preserved exactly. All Lighthouse/Observatory/CSP/audit-gate language now lives in `AGENTS.md`.
- ⚠️ This changes the documented source-of-truth hierarchy. AI agents (Codex, Claude Code, Cursor, Copilot, Anti-Gravity, Replit Agent) following AGENTS.md's Mandatory Read will now read the new ordering: `AGENTS.md` → `STYLE_GUIDE.md` → `PROJECT_EVOLUTION_LOG.md`. The repo's existing `AGENTS.md` Mandatory Read section already declared this audience.
- ⚠️ If reverted, the strip-cycle resumes on every checkpoint and governance content is re-orphaned into a file the platform overwrites unpredictably.

## Rollout note

After this lands and the next checkpoint inevitably rewrites `replit.md`, the CI guard will catch it on the next PR. Expected workflow when that happens: hard-reset the offending commit before pushing, or let the guard fail loudly and reset then.
