### PR TITLE
llms-full: nest in-page headings, canonicalize URLs, clean hero whitespace

### DIFF
--- a/infra/llms/README.md
+++ b/infra/llms/README.md
@@ -9,7 +9,7 @@ Auto-generates `llms-full.txt` from `content/*.md` so it never drifts from the l
 ## How it works
 
 1. `infra/llms/build-llms-full.mjs` reads `infra/llms/llms-full.config.json` for the canonical page order, then walks each referenced `content/*.md`.
-2. For each page: parses frontmatter (TOML `+++` or YAML `---`, both supported), strips JSON-LD `<script>` blocks, strips HTML comments and `<svg>` blocks, normalizes `<br>`/`<p>`, converts inline `<a>` tags to markdown links, strips remaining HTML conservatively, decodes common HTML entities, strips Zola heading-anchor `{#anchor}` syntax, normalizes whitespace.
+2. For each page: parses frontmatter (TOML `+++` or YAML `---`, both supported), strips JSON-LD `<script>` blocks, strips HTML comments and `<svg>` blocks, normalizes `<br>`/`<p>`, converts inline `<a>` tags to markdown links, strips remaining HTML conservatively, decodes common HTML entities, strips Zola heading-anchor `{#anchor}` syntax, **demotes in-page headings** so the highest level is at least `####` (nesting under the `### Page Label`), normalizes whitespace including stripping leading-whitespace residue left by stripped inline HTML wrappers like `<h1><span>...</span></h1>`.
 3. Writes the assembled output to `build/llms-full.txt` (UTF-8, LF line endings, deterministic — same input always produces the same output, byte-for-byte).
 4. Deploy uploads `build/llms-full.txt` directly to S3 with a 1-hour TTL plus `stale-while-revalidate=86400`.
 
@@ -58,6 +58,11 @@ If a content author wants the LLM-facing label to differ from the page `<title>`
 - **Phase A** (this PR): Add generator + config + PR-validate workflow + deploy.yml updates (output path + cache-control). `static/llms-full.txt` stays in repo as fallback. After merge, deploy proves the generator works against current production.
 - **Phase B**: Inspect generator output vs current `static/llms-full.txt`, tune config/labels until parity is good or deliberate-improvement is achieved. Document any intentional differences.
 - **Phase C**: Delete `static/llms-full.txt` from repo. Generator becomes sole source of truth.
+
+## Known limitations
+
+- **Heading demotion is regex-based, not code-fence-aware.** If a content page introduces a fenced code block whose lines start with `#`, `##`, etc. (e.g., a Bash or Python comment), the demoter will treat them as headings and shift them. Current configured pages contain no such content. If this becomes an issue, make the demoter walk the body and skip lines inside fenced (` ``` `) regions.
+- **`<h1><span>...</span></h1>` and similar inline-wrapper hero markup**: text content survives, but original layout is flattened — multi-line spans collapse onto separate plain-text lines.
 
 ## Out of scope
 

--- a/infra/llms/build-llms-full.mjs
+++ b/infra/llms/build-llms-full.mjs
@@ -189,18 +189,63 @@ function transformBody(body, filePath) {
   // 6. Strip Zola heading-anchor syntax {#anchor} from heading lines.
   s = s.replace(/^(#{1,6}\s+.*?)\s*\{#[^}]+\}\s*$/gm, "$1");
 
+  // 6b. Demote in-page headings so they nest under the page label.
+  //     The page label is rendered at level 3 ("### Label"), so the highest
+  //     in-page heading must be at least level 4 to maintain a valid outline.
+  //     Otherwise an in-page h2 emits at the same level as the "## Main"
+  //     section heading (an outline violation that confuses LLMs and TOC tools).
+  //     We compute the minimum heading level present in the body and shift
+  //     every heading by max(0, 4 - min). Result is capped at h6.
+  s = demoteHeadings(s, 4);
+
   // 7. Normalize whitespace.
-  s = s.replace(/[ \t]+\n/g, "\n");           // trailing spaces
-  s = s.replace(/\n{3,}/g, "\n\n");            // collapse 3+ blank lines
-  s = s.replace(/^\s+|\s+$/g, "");             // trim
+  //    - Strip trailing spaces on every line.
+  //    - Collapse 3+ consecutive blank lines to 2.
+  //    - Trim leading/trailing whitespace overall.
+  //    - Strip leading whitespace from text lines (lines that begin with a
+  //      letter). Defends against the residue left when inline HTML wrappers
+  //      like <h1><span>...</span><span>...</span></h1> are stripped — the
+  //      inner text keeps the original indentation and reads as garbage.
+  //      Lines beginning with list/quote/heading/code markers are preserved.
+  s = s.replace(/[ \t]+\n/g, "\n");
+  s = s.replace(/^[ \t]+(?=[A-Za-z])/gm, "");
+  s = s.replace(/\n{3,}/g, "\n\n");
+  s = s.replace(/^\s+|\s+$/g, "");
 
   return s;
+}
+
+// Demote every heading line in `s` so the smallest level present is at least
+// `targetMin`. Caps at level 6. No-op if all headings already satisfy the
+// floor. Operates on Markdown ATX-style headings only (`# ` through `###### `).
+function demoteHeadings(s, targetMin) {
+  const headings = [...s.matchAll(/^(#{1,6})\s/gm)];
+  if (headings.length === 0) return s;
+  let minLevel = 6;
+  for (const h of headings) minLevel = Math.min(minLevel, h[1].length);
+  const shift = Math.max(0, targetMin - minLevel);
+  if (shift === 0) return s;
+  return s.replace(/^(#{1,6})(\s)/gm, (_, hashes, sp) => {
+    const newLevel = Math.min(6, hashes.length + shift);
+    return "#".repeat(newLevel) + sp;
+  });
 }
 
 // --- Main ---
 function main() {
   const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
   const site = readSiteConfig();
+
+  // Build a Zola-canonical URL for a content file (always trailing-slash,
+  // matching the live site's URL canonicalization for both root and section pages).
+  // content/_index.md      → ${base_url}/
+  // content/services.md    → ${base_url}/services/
+  // content/blog/_index.md → ${base_url}/blog/
+  // content/blog/foo.md    → ${base_url}/blog/foo/
+  const fileToUrl = (file) => {
+    const stripped = file.replace(/^content\//, "").replace(/\.md$/, "").replace(/(^|\/)_index$/, "$1");
+    return `${site.base_url}/${stripped}${stripped && !stripped.endsWith("/") ? "/" : ""}`;
+  };
 
   // Validate config: dup URLs/labels.
   const seenLabels = new Set();
@@ -209,7 +254,7 @@ function main() {
     for (const entry of sec.entries) {
       if (seenLabels.has(entry.label)) die(`duplicate label in config: ${entry.label}`);
       seenLabels.add(entry.label);
-      const url = entry.url ?? (entry.file ? `${site.base_url}/${entry.file.replace(/^content\//, "").replace(/\.md$/, "").replace(/_index$/, "")}` : null);
+      const url = entry.url ?? (entry.file ? fileToUrl(entry.file) : null);
       if (url) {
         if (seenUrls.has(url)) die(`duplicate URL in config: ${url}`);
         seenUrls.add(url);
@@ -249,7 +294,7 @@ function main() {
       const raw = fs.readFileSync(filePath, "utf8");
       const { fm, body } = parseFrontmatter(raw, entry.file);
       const finalLabel = entry.label ?? fm.llms_label ?? fm.title;
-      const url = `${site.base_url}/${entry.file.replace(/^content\//, "").replace(/\.md$/, "").replace(/_index$/, "")}`;
+      const url = fileToUrl(entry.file);
       const cleanedBody = transformBody(body, entry.file);
 
       out.push(`### ${finalLabel}`);


### PR DESCRIPTION
## What

Phase B parity tuning of the `llms-full.txt` auto-generator (Phase A merged in #564).

Three fixes inside `infra/llms/build-llms-full.mjs`:

1. **Heading hierarchy (structural)** — `demoteHeadings(s, 4)` shifts every page-internal heading so the smallest level is at least `####`. Page labels emit at level 3 (`### Label`); without this fix, an in-page `## Trust signals` collided with the section heading `## Main` and rendered *above* its own page label. Result is capped at h6.
2. **Source URL parity** — new `fileToUrl()` helper always emits Zola-canonical trailing-slash URLs (`/services/`, `/blog/`, `/`). Used in both duplicate-URL validation and the per-page `Source:` line so they never disagree.
3. **Hero whitespace artifact** — strip leading whitespace on text-only lines (preserves list/quote/heading/code prefixes). Defends against the residue left when inline HTML wrappers like `<h1><span>line1</span><span>line2</span></h1>` are stripped.

## What stayed legacy-divergent on purpose

Two "missing" sections vs the legacy `static/llms-full.txt` are **not** restored:

| Section | Why |
| --- | --- |
| FAQ ("Can you help with PC, Linux..." etc.) | Lives only in `FAQPage` JSON-LD schema in `content/_index.md` (correctly stripped by the generator). Live home page no longer renders it as visible markdown. |
| "Why Choose IT Help San Diego?" | Removed from `content/_index.md` long ago — replaced by Trust signals + The Method on the live page. |

Both omissions are correct alignment with the live site, not regressions.

## Output diff

24,371 → 24,439 bytes (+68 bytes). Line count unchanged at 385. Diff vs prior auto-gen output is exactly the three intended changes.

## Safety

- Existing CodeQL hardening (`stripUntilStable`, single-pass entity decode) untouched.
- No changes to `.github/workflows/llms-validate.yml` or `deploy.yml`.
- Documented heading-demotion limitation (regex-based, not code-fence-aware) in the README's new "Known limitations" section. Currently configured pages contain no fenced code blocks with `#`-prefix lines.

## Architect review

Pass. One non-blocking observation (fence-awareness edge case) — verified absent from current content and documented as a known limitation.

## Next

Phase C (delete `static/llms-full.txt`) follows in a separate PR after this lands and the deploy proves clean.
