### PR TITLE
services: clarify Managed Agent paragraph — break-fix is the default

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -416,7 +416,7 @@ It is the same class of agent used in larger managed-service programs, delivered
 
 The agent handles ongoing maintenance from a single console: remediations, configuration changes, and security-policy updates across Mac, Windows, iOS, and Android where platform controls allow. Final OS-version upgrades on unsupervised devices still require user action; clients who want full remote OS control can opt into supervised MDM, and many choose not to. Security Edition adds managed threat detection. We continue billing on-demand for diagnostics and architecture.
 
-The service is month-to-month with no minimum term, and it is designed as continuous protection rather than short-term surge support. While enrolled, supported devices are kept aligned with current security baselines: when a policy-required update is due, you receive a clear prompt to save your work, and the change is scheduled in a defined maintenance window (typically after hours where possible). In practice, that gives you MSP-grade operating discipline without long-term contracts or separate incident billing.
+The service is month-to-month with no minimum term, and it is designed as continuous protection rather than short-term surge support. While enrolled, supported devices are kept aligned with current security baselines: when a policy-required update is due, you receive a clear prompt to save your work, and the change is scheduled in a defined maintenance window (typically after hours where possible). In practice, that gives you MSP-grade operating discipline without long-term contracts or bundled retainers. IT Consulting Sessions work stays on the same transparent break-fix billing as everything else.
 
 ## Our Recommendations
 


### PR DESCRIPTION
## What

Fixes a self-contradictory sentence in the Managed Agent section of `content/services.md`.

## Why

The closing sentence read:

> In practice, that gives you MSP-grade operating discipline without long-term contracts or **separate incident billing**.

But separate incident billing IS the break-fix model the rest of the site sells. The paragraph immediately above this one already states:

> We continue billing on-demand for diagnostics and architecture.

So the two paragraphs disagreed. The closing also implicitly disparaged break-fix billing as something to escape from — opposite of the brand.

## The change

Two-word swap on the troublesome clause, plus an owner-provided clarifying sentence:

**Before:**
> ...without long-term contracts or separate incident billing.

**After:**
> ...without long-term contracts or **bundled retainers**. **IT Consulting Sessions work stays on the same transparent break-fix billing as everything else.**

- `separate incident billing` → `bundled retainers` flips the second item from something we offer to something MSPs do that's actually undesirable.
- New second sentence (verbatim wording from the owner) explicitly re-grounds Managed Agent in the break-fix default, so the paragraph now reinforces line 420's "We continue billing on-demand for diagnostics and architecture" instead of contradicting it.

## Scope

- 1 file, 1 line, +1 / -1.
- No infrastructure, schema, or markup changes.
- No new dependencies, no template touches, no CI changes.
