### PR TITLE
audit(lighthouse): retry transient Chromium/CDP errors per sample

### DIFF
--- a/infra/audit/README.md
+++ b/infra/audit/README.md
@@ -31,12 +31,31 @@ single sample dipped below threshold but the median still passed. That
 is a leading indicator of thinning margin on a page and is worth
 investigating before the next deploy, even if the gate is green.
 
-## Editing thresholds, sample count, or URLs
+## Transient-error retry
+
+Headless-Chromium occasionally aborts a Lighthouse run with a runtime
+error that has nothing to do with the site under test —
+`NO_NAVSTART`, `NO_FCP`, `INSUFFICIENT_FCP`, `PROTOCOL_TIMEOUT`, or a
+"Target closed" trace-recording failure. Without retry these flakes
+fail the entire deploy gate even though the site itself is healthy.
+
+Each sample therefore gets up to `1 + lighthouse.retriesPerSample`
+attempts (default 2 retries, so 3 attempts per sample). Retries are
+**only** triggered when stderr matches one of the known-transient
+patterns in `TRANSIENT_ERROR_PATTERNS` inside `run-lighthouse.mjs`;
+any other lighthouse failure is fatal exactly as before, so a real
+regression cannot hide behind retry. Each retry is logged inline
+(`run 1/3: transient lighthouse error (NO_NAVSTART) on attempt 1/3 — retrying`).
+
+Set `lighthouse.retriesPerSample` to `0` to disable retries.
+
+## Editing thresholds, sample count, retries, or URLs
 
 Open `audit.config.json`. Add a URL to `lighthouse.urls`, change a
 number in `lighthouse.thresholds` / `observatory`, or adjust
-`lighthouse.samplesPerAudit`. No workflow changes required. Setting
-`samplesPerAudit` to 1 reverts to the original single-sample behavior.
+`lighthouse.samplesPerAudit` / `lighthouse.retriesPerSample`. No
+workflow changes required. Setting `samplesPerAudit` to 1 reverts to
+the original single-sample behavior.
 
 ## Cost
 

--- a/infra/audit/audit.config.json
+++ b/infra/audit/audit.config.json
@@ -9,6 +9,7 @@
     ],
     "formFactors": ["mobile", "desktop"],
     "samplesPerAudit": 3,
+    "retriesPerSample": 2,
     "thresholds": {
       "performance": 98,
       "accessibility": 98,

--- a/infra/audit/run-lighthouse.mjs
+++ b/infra/audit/run-lighthouse.mjs
@@ -32,10 +32,63 @@ const config = JSON.parse(
 );
 
 const { urls, formFactors, thresholds } = config.lighthouse;
-const samplesPerAudit = Number(config.lighthouse.samplesPerAudit ?? 3);
+
+// Strict config validation: a misconfigured count must fail loudly at
+// startup rather than silently producing zero loop iterations or NaN
+// retry budgets at runtime.
+function readBoundedInt(name, raw, fallback, { min, max }) {
+  const value = raw == null ? fallback : Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(
+      `audit.config.json: lighthouse.${name} must be an integer in ` +
+        `[${min}, ${max}], got ${JSON.stringify(raw)}`,
+    );
+  }
+  return value;
+}
+const samplesPerAudit = readBoundedInt(
+  "samplesPerAudit",
+  config.lighthouse.samplesPerAudit,
+  3,
+  { min: 1, max: 25 },
+);
+const retriesPerSample = readBoundedInt(
+  "retriesPerSample",
+  config.lighthouse.retriesPerSample,
+  2,
+  { min: 0, max: 10 },
+);
 const categories = Object.keys(thresholds);
 
-function runLighthouse(url, formFactor) {
+// Lighthouse runtime errors that reflect headless-Chromium / CDP plumbing
+// flakes rather than a real site regression. When stderr matches any of
+// these we treat the run as a transient failure and retry the sample.
+// Adding a new pattern here is the safe way to absorb a newly-observed
+// flake; do NOT add patterns that could mask a real defect (e.g. an HTTP
+// 5xx from origin, a CSP violation, etc.).
+const TRANSIENT_ERROR_PATTERNS = [
+  /NO_NAVSTART/,
+  /NO_FCP/,
+  /INSUFFICIENT_FCP/,
+  /PROTOCOL_TIMEOUT/,
+  /Something went wrong with recording the trace/i,
+  /Target closed/i,
+];
+
+function isTransientError(stderrText) {
+  if (!stderrText) return false;
+  return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(stderrText));
+}
+
+class TransientLighthouseError extends Error {
+  constructor(message, stderrText) {
+    super(message);
+    this.name = "TransientLighthouseError";
+    this.stderrText = stderrText;
+  }
+}
+
+function runLighthouseOnce(url, formFactor) {
   const workdir = mkdtempSync(join(tmpdir(), "lh-"));
   const outPath = join(workdir, "report.json");
 
@@ -49,14 +102,23 @@ function runLighthouse(url, formFactor) {
   ];
   if (formFactor === "desktop") args.push("--preset=desktop");
 
+  // stderr is piped (not inherited) so we can pattern-match transient
+  // Lighthouse runtime errors. We forward the captured stderr to the
+  // build log unconditionally so the verbose Lighthouse output remains
+  // visible (matches the prior --quiet+inherit behavior in CI).
   const result = spawnSync("lighthouse", args, {
-    stdio: ["ignore", "inherit", "inherit"],
+    stdio: ["ignore", "inherit", "pipe"],
   });
+  const stderrText = result.stderr ? result.stderr.toString() : "";
+  if (stderrText) process.stderr.write(stderrText);
+
   if (result.status !== 0) {
     rmSync(workdir, { recursive: true, force: true });
-    throw new Error(
-      `lighthouse exited ${result.status} for ${url} (${formFactor})`,
-    );
+    const baseMsg = `lighthouse exited ${result.status} for ${url} (${formFactor})`;
+    if (isTransientError(stderrText)) {
+      throw new TransientLighthouseError(baseMsg, stderrText);
+    }
+    throw new Error(baseMsg);
   }
   const report = JSON.parse(readFileSync(outPath, "utf8"));
   rmSync(workdir, { recursive: true, force: true });
@@ -67,6 +129,33 @@ function runLighthouse(url, formFactor) {
     scores[cat] = raw == null ? null : Math.round(raw * 100);
   }
   return scores;
+}
+
+// Retry wrapper. Each sample gets up to (1 + retriesPerSample) attempts.
+// Only TransientLighthouseError triggers a retry — any other error
+// (including a real non-transient lighthouse failure) is fatal as before.
+function runLighthouse(url, formFactor, sampleIndex, sampleTotal) {
+  const maxAttempts = 1 + Math.max(0, retriesPerSample);
+  let lastErr;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return runLighthouseOnce(url, formFactor);
+    } catch (err) {
+      lastErr = err;
+      if (!(err instanceof TransientLighthouseError)) throw err;
+      if (attempt < maxAttempts) {
+        const matched = TRANSIENT_ERROR_PATTERNS.find((re) =>
+          re.test(err.stderrText || ""),
+        );
+        const codeLabel = matched ? matched.source : "transient";
+        console.log(
+          `    run ${sampleIndex}/${sampleTotal}: transient lighthouse error ` +
+            `(${codeLabel}) on attempt ${attempt}/${maxAttempts} — retrying`,
+        );
+      }
+    }
+  }
+  throw lastErr;
 }
 
 // Median per-category-independently (NOT median over the full report).
@@ -92,7 +181,7 @@ for (const url of urls) {
     // Collect samplesPerAudit runs; per-category arrays for median.
     const runs = [];
     for (let i = 1; i <= samplesPerAudit; i++) {
-      const scores = runLighthouse(url, formFactor);
+      const scores = runLighthouse(url, formFactor, i, samplesPerAudit);
       runs.push(scores);
       const oneLine = categories
         .map((c) => `${c}=${scores[c]}`)


### PR DESCRIPTION
## What & why

Single-sample Lighthouse runs against CloudFront occasionally fail with headless-Chromium runtime errors that have nothing to do with the site under test:

- `NO_NAVSTART` — page never reported nav start to CDP
- `NO_FCP` / `INSUFFICIENT_FCP` — first contentful paint never observed
- `PROTOCOL_TIMEOUT` — CDP command timed out
- `Target closed` / `Something went wrong with recording the trace` — Chromium target died mid-run

Until now `infra/audit/run-lighthouse.mjs` had **zero** retry logic — one such flake on any of the 24 runs (4 URLs × 2 form factors × 3 samples) failed the entire deploy gate even though every other sample scored 99–100. Most recent occurrence: the deploy for #567, where `/billing/` desktop sample 1 hit `NO_NAVSTART` while the other 5 desktop samples all returned 100/100/100/100. The only fix today is a manual workflow re-run.

## What changed

- **Per-sample retry on a narrow allowlist**. Each sample now gets up to `1 + lighthouse.retriesPerSample` attempts (default `2` retries → 3 attempts/sample). Retries are gated on stderr matching `TRANSIENT_ERROR_PATTERNS`. Any other lighthouse failure (a real perf regression, an HTTP 5xx, a CSP violation) still fails fast as before, so a regression cannot hide behind retry.
- **Visibility preserved**. stderr is now captured (so we can pattern-match) but is unconditionally re-emitted to the build log, so verbose Lighthouse output looks the same in CI. Each retry is logged inline:
  ```
      run 1/3: transient lighthouse error (NO_NAVSTART) on attempt 1/3 — retrying
  ```
- **Strict config validation**. `samplesPerAudit` and `retriesPerSample` are now bounded integers; the script fails loudly at startup on a malformed config instead of silently producing zero loop iterations or NaN budgets.
- **README updated** documenting the new knob and the `retriesPerSample=0` opt-out.

## Safety

The `TRANSIENT_ERROR_PATTERNS` list is intentionally narrow (CDP/runtime fault signatures). Smoke-tested against:

| Stderr | Classified as |
|---|---|
| `Runtime error encountered: ... NO_NAVSTART` | TRANSIENT (retry) |
| `PROTOCOL_TIMEOUT (Page.navigate)` | TRANSIENT (retry) |
| `Something went wrong with recording the trace` | TRANSIENT (retry) |
| `Target closed` | TRANSIENT (retry) |
| `Real regression: Performance score 45 < 98` | FATAL (fail fast) |
| `HTTP 503 Service Unavailable` | FATAL (fail fast) |

Adding a new pattern is the safe way to absorb a newly-observed flake; the comment in code explicitly warns against adding patterns that could mask real defects.

## Scope

CI-only. **No content/site impact.** No workflow changes (script picks up the new config key automatically).

## Architect review

PASS. Verified: regex set is sound, retry budget matches docs, fail-fast preserved for non-transient errors, stderr forwarding preserved, edge cases (`status===null`, empty stderr, partial JSON on transient) handled. Recommendation to add bounded-int config validation has been applied.