### PR TITLE
services(managed-agent): add 'what the agent does' paragraph back

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -412,6 +412,8 @@ macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientifi
 
 An optional month-to-month maintenance and security layer that keeps your devices current between consulting sessions — across macOS, Windows, Linux, iPhone/iPad, Android, and ChromeOS. $50 per device per month, no managed service contracts.
 
+Once enrolled, the agent handles automated OS updates and application patching, security policy enforcement, centralized device visibility, and remote support access. The goal: spend live consulting time on actual problems, not routine maintenance.
+
 IT Consulting Sessions work stays on the same transparent break-fix on-demand billing.
 
 Your devices will have the same advanced monitoring agent trusted by top managed service providers — at a fraction of the typical cost. Platform: ManageEngine Endpoint Central Cloud — Security Edition.


### PR DESCRIPTION
## Owner-approved follow-up to #569 — restore the "what the agent does" paragraph

PR #569 shipped the lean 3-paragraph version. Owner asked to add back the capability-summary paragraph between the opener and the break-fix line.

### Single insert

```
Once enrolled, the agent handles automated OS updates and application
patching, security policy enforcement, centralized device visibility,
and remote support access. The goal: spend live consulting time on
actual problems, not routine maintenance.
```

Section is now 4 paragraphs:

1. Optional month-to-month + platform list + price + no managed service contracts.
2. **NEW** — what the agent does + "spend live time on actual problems" hook.
3. IT Consulting Sessions stays on transparent break-fix on-demand billing.
4. Vendor-legitimacy + ManageEngine Endpoint Central Cloud — Security Edition.

### Scope

- Single file: `content/services.md`
- 1 paragraph inserted, nothing else touched
- JSON-LD description left as set in #569 (already aligned with the opener)
- No structural / front-matter / other-schema changes

Owner-directed copy.