### PR TITLE
home(method): point closing CTA to Zenodo concept DOI

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -274,7 +274,7 @@ If you've ever called for tech support and bounced through tiers trying to reach
 
 **Email going to customers' spam folders.** The off-the-shelf answer is to sign up for a deliverability service or an inbox "warm-up" subscription. The evidence-led answer is to look at what's actually sending mail in your name: usually it's an old appointment-reminder app, or an invoicing tool from three providers ago, that was never properly authorized at the DNS level when it was added. Authorize the ones you still use, shut off the ones you don't, and mail lands. One afternoon of cleanup, no recurring fee.
 
-The same instinct produced our public DNS research platform at <a href="https://dnstool.it-help.tech" class="gold-link" target="_blank" rel="noopener noreferrer">dnstool.it-help.tech</a>, where we publish what we learn from the wire. <a href="/blog/it-problem-solving-scientific-method/" class="gold-link">Read the field notes →</a>
+The same instinct produced our public DNS research platform at <a href="https://dnstool.it-help.tech" class="gold-link" target="_blank" rel="noopener noreferrer">dnstool.it-help.tech</a>, where we publish what we learn from the wire. <a href="https://doi.org/10.5281/zenodo.19468134" class="gold-link" target="_blank" rel="noopener noreferrer">Read the published science →</a>
 
 ## Local credibility
 


### PR DESCRIPTION
## Closing CTA on `## The Method` was setting up something it didn't deliver

The closing line frames our DNS research as **"what we publish from the wire"** — but the prior CTA (`Read the field notes →`) sent visitors into the blog, which is *not* where the published research lives. The handoff didn't match the setup.

### Two changes inside the single closing paragraph

| | Was | Now |
|---|---|---|
| **CTA text** | Read the field notes → | Read the published science → |
| **CTA target** | `/blog/it-problem-solving-scientific-method/` | `https://doi.org/10.5281/zenodo.19468134` |

### Why the **concept** DOI, not the version DOI

Zenodo gives every record two DOIs:
- A **version DOI** — points at one specific version (e.g. `10.5281/zenodo.19622372` = v26.46.14, published 2026-04-17)
- A **concept DOI** — always resolves to the *latest* version under that concept

Linking the concept DOI (`10.5281/zenodo.19468134`) means the homepage doesn't need to be edited each time a new Zenodo version is published. Click-through always lands on whatever the most current published record is. That's also the canonical citation form scientists expect.

### Scope
- Single file: `content/_index.md`
- 1 line changed
- New external link gets the same `target="_blank" rel="noopener noreferrer"` attributes as the adjacent `dnstool.it-help.tech` link in the same sentence
- Adjacent in narrative to PR #571 (already merged) — this is the natural follow-up that closes the loop on the Method-section refresh

Owner-approved copy.