### PR TITLE
field-notes(schema): complete + reorder ItemList to match section content

### DIFF
--- a/content/field-notes/_index.md
+++ b/content/field-notes/_index.md
@@ -18,31 +18,38 @@ twitter_description = "Practitioner field notes on macOS, Wi‑Fi, DNS, email de
   "@context": "https://schema.org",
   "@type": "ItemList",
   "name": "Latest Field Notes",
+  "itemListOrder": "https://schema.org/ItemListOrderDescending",
+  "numberOfItems": 6,
   "itemListElement": [
     {
       "@type": "ListItem",
       "position": 1,
-      "url": "https://www.it-help.tech/field-notes/dns-security-best-practices/"
+      "url": "https://www.it-help.tech/field-notes/hack-your-engrams-to-remember-passwords/"
     },
     {
       "@type": "ListItem",
       "position": 2,
-      "url": "https://www.it-help.tech/field-notes/why-your-wireless-network-sucks/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
       "url": "https://www.it-help.tech/field-notes/apple-sends-you-to-ijail/"
     },
     {
       "@type": "ListItem",
+      "position": 3,
+      "url": "https://www.it-help.tech/field-notes/it-problem-solving-scientific-method/"
+    },
+    {
+      "@type": "ListItem",
       "position": 4,
-      "url": "https://www.it-help.tech/field-notes/mac-cybersecurity-threats/"
+      "url": "https://www.it-help.tech/field-notes/dns-security-best-practices/"
     },
     {
       "@type": "ListItem",
       "position": 5,
-      "url": "https://www.it-help.tech/field-notes/hack-your-engrams-to-remember-passwords/"
+      "url": "https://www.it-help.tech/field-notes/why-your-wireless-network-sucks/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "url": "https://www.it-help.tech/field-notes/mac-cybersecurity-threats/"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Architect-review follow-up to PR #573. The `Latest Field Notes` ItemList JSON-LD on the section index was incomplete and out of order — listed only 5 of 6 posts and the order did not match Zola newest-first sort.

## Changes
- **Added** `it-problem-solving-scientific-method` (was missing entirely from the list).
- **Reordered** all entries to match `section.pages` newest-first by published date:
  1. hack-your-engrams-to-remember-passwords (2025-06-03)
  2. apple-sends-you-to-ijail (2025-06-01)
  3. it-problem-solving-scientific-method (2025-05-26)
  4. dns-security-best-practices (2025-05-25)
  5. why-your-wireless-network-sucks (2025-05-24)
  6. mac-cybersecurity-threats (2025-05-23)
- Added `itemListOrder: ItemListOrderDescending` and `numberOfItems: 6` to make the ordering explicit for crawlers.

## Why
The list was incomplete since before the rename — it predated PR #573 and was simply preserved through the rename. Architect review caught the gap; fixing it now while the section file is freshly touched.

## Verification
- Single file changed (`content/field-notes/_index.md`), 12 insertions / 5 deletions.
- Zola dev server reloads cleanly with the updated JSON-LD.
- All six URLs in the list resolve (verified via sitemap).

## Rollback
`git revert` of the merge commit. JSON-LD is content-only; no template or routing changes.