### PR TITLE
services: add LibreOffice to Our Recommendations (top of list)

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -422,6 +422,7 @@ Your devices will have the same advanced monitoring agent trusted by top managed
 
 We believe in using best-in-class tools to achieve the best security and reliability. We often work with and recommend the following platforms and services:
 
+* **<a href="https://www.libreoffice.org/" target="_blank" rel="noopener noreferrer" class="gold-link">LibreOffice:</a>** Free, open-source office suite from The Document Foundation. Full-featured word processing, spreadsheets, presentations, drawings, and databases on **Linux, Windows 11 Pro, and macOS** — no Microsoft Office license required, and you are not missing features. Mature, transparently developed, and what we run on our own machines.
 * **<a href="https://www.cloudflare.com/" target="_blank" rel="noopener noreferrer" class="gold-link">Cloudflare:</a>** For DNS, WAF, CDN.
 * **<a href="https://aws.amazon.com/route53/" target="_blank" rel="noopener noreferrer" class="gold-link">Amazon Route 53:</a>** For highly available and scalable DNS services.
 * **<a href="https://landing.google.com/advancedprotection/" target="_blank" rel="noopener noreferrer" class="gold-link">Google Advanced Protection Program:</a>** For Google's strongest account security.


### PR DESCRIPTION
## Summary

Owner-directed addition. Adds **LibreOffice** as the first bullet in the `## Our Recommendations` section of `/services/`.

## Why top of the list

Owner runs LibreOffice on his own Mac, has no Microsoft Office on it, and is missing nothing. Two reasons it leads the recommendations rather than slotting in alphabetically:

1. **Highest dollar impact of any single recommendation on the page.** For any client paying for Microsoft 365 purely for the Office apps, switching to LibreOffice eliminates the line item entirely.
2. **Open-source and transparently developed**, which fits the science-grounded framing the rest of the practice runs on.

## What was added

Single bullet, formatted to match the existing pattern (gold-link class, target=_blank, rel=noopener noreferrer):

> **LibreOffice:** Free, open-source office suite from The Document Foundation. Full-featured word processing, spreadsheets, presentations, drawings, and databases on **Linux, Windows 11 Pro, and macOS** — no Microsoft Office license required, and you are not missing features. Mature, transparently developed, and what we run on our own machines.

The three OSes named (Linux, Windows 11 Pro, macOS) match what the owner specifically called out.

## URL choice

Linked to `https://www.libreoffice.org/` (the project home page) rather than the `/download/` page the owner sent, to match the convention of every other entry in the list (1Password, Cloudflare, etc. all link to product home pages, not download pages).

## Verification

All four phrase checks against the live preview:

- `LibreOffice`: 1
- `Document Foundation`: 1
- `no Microsoft Office license required`: 1
- `Linux, Windows 11 Pro, and macOS`: 1

Build clean; `/services/` serves `200`; diff: 1 file, +1 line. Source order at lines 428–429 confirms LibreOffice renders before Cloudflare.

## No JSON-LD changes

The recommendations list in `services.md` is not enumerated in the page's structured data (`@graph`), so no schema updates are required.

## Files

- `content/services.md` — single bullet inserted at the top of `## Our Recommendations`

## PROJECT_EVOLUTION_LOG.md intentionally not touched

PR #586 is currently open and is adding an entry to the same log file. Touching the log here would create a guaranteed merge conflict on whichever PR merges second. The PR description and commit message provide the full audit trail for this single-bullet addition; if a log entry is wanted retroactively, it can be added in a tiny follow-up after #586 merges.