### PR TITLE
feat(seo): site-wide Schema.org JSON-LD via single _jsonld.html partial

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,28 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-04-19 — Site-wide Schema.org JSON-LD: auto-emitted Organization + Article + BreadcrumbList + Blog from a single partial
+- Actor: AI (owner-directed remediation β following the architect-driven discovery that 3 of 6 field-notes shipped zero structured data).
+- Trigger: Whole-repo audit revealed JSON-LD coverage was inconsistent — `dns-security`, `mac-cybersecurity`, and `wireless` had hand-written `<script type="application/ld+json">` blocks embedded in their markdown bodies, while `apple-sends-you-to-ijail`, `hack-your-engrams-to-remember-passwords`, and `it-problem-solving-scientific-method` had none. Initial scratchpad diagnosis (that `templates/macros/seo.html` was missing and `{% block seo %}` was unwired) was wrong: the file exists in the abridge theme via inheritance, and the `{% block seo %}` definitions in `page.html`/`field-notes.html` are dead code because `base.html` defines no parent block. Real SEO source of truth is `templates/partials/head.html`, which generates title/meta/OG/Twitter from frontmatter but emitted **zero** JSON-LD. So the gap was: no automatic structured-data layer existed at all; coverage came entirely from per-author markdown body discipline.
+- Files:
+  - `templates/partials/_jsonld.html` (NEW) — single source of truth. Emits Organization (every page, with stable `@id` anchor for graph linking), plus Article (or TechArticle via `extra.schema_type`) + BreadcrumbList on field-notes posts, plus Blog on the field-notes section index. All values driven from frontmatter (`page.title`, `page.description`, `page.date`, `page.updated`, `page.extra.og_image`/`extra.image`, `page.extra.author`, `page.permalink`). Strings routed through Tera's `json_encode` filter so apostrophes/em-dashes/quotes serialize as valid JSON automatically. Opt-out via `page.extra.skip_auto_jsonld = true` for any page that wants to suppress the auto-emitted Article block (defensive escape hatch; not used by any current page).
+  - `templates/partials/head.html` — added `{% include "partials/_jsonld.html" %}` directly before the `head_extra` injection point so structured data ships with every rendered page.
+  - `PROJECT_EVOLUTION_LOG.md` — this entry.
+- Build verification (local `zola build`, every JSON-LD block parsed with stdlib `json.loads`):
+  - apple-sends-you-to-ijail: 0 → 3 blocks `[Organization, Article, BreadcrumbList]`
+  - hack-your-engrams-to-remember-passwords: 0 → 3 blocks `[Organization, Article, BreadcrumbList]`
+  - it-problem-solving-scientific-method: 0 → 3 blocks `[Organization, Article, BreadcrumbList]`
+  - dns-security-best-practices: 3 → 6 blocks (3 new auto + 3 hand-curated TechArticle/FAQPage/HowTo retained)
+  - mac-cybersecurity-threats: 1 → 4 blocks (3 new auto + existing TechArticle retained)
+  - why-your-wireless-network-sucks: 1 → 4 blocks (3 new auto + existing TechArticle retained)
+  - field-notes section index: 0 → 2 blocks `[Organization, Blog]`
+  - All other pages (home, about, services): pre-existing rich JSON-LD intact, plus the new Organization baseline (consistent `@id` link target across the site).
+  - All blocks parsed cleanly. No Tera template errors. Build time 498ms.
+- Why duplicate Organization/Article on hand-curated pages is intentional: Google supports multiple JSON-LD blocks per page (they are merged into a single graph), and the consistent `@id` anchor on Organization lets crawlers de-duplicate the publisher entity across all blocks. Removing the hand-written blocks from the 3 curated markdowns is a separate, lower-priority cleanup deferred to a follow-up PR — keeping them avoids any risk of regression in the rich types (HowTo, FAQPage) that the auto layer doesn't yet emit.
+- Why `_jsonld.html` and not a Tera macro: includes execute in the `page`/`section` template context automatically (no need to pass them as macro arguments through every call site), and adding to a partial is a one-line wire-up vs. modifying every template that extends `base.html`.
+- CSP compatibility: production `style-src 'self'` is unaffected — JSON-LD ships in `<script type="application/ld+json">` tags, which fall under `script-src` (which already permits inline + same-origin per the existing CSP).
+- Rollback: this branch/PR (`feat/jsonld-structured-data`), baseline commit on main pre-merge.
+
 ### 2026-04-19 — Google Indexing API integration (keyless OIDC, shared URL collector with IndexNow)
 - Actor: AI (owner-directed remediation following the architect-driven discovery that no Google Indexing code existed in the repo despite the GCP-side WIF setup being in place).
 - Trigger: Earlier sessions documented "tasks #21/#22 merged" for Google Indexing, but a direct check of the repo confirmed the truth: the GCP/Search-Console plumbing was real (Workload Identity Pool `github-actions-pool`, OIDC provider `github-oidc`, SA `id-web-search-indexing-api@it-help-indexing.iam.gserviceaccount.com` bound to repo `IT-Help-San-Diego/it-help-tech-site`, SA owner of `https://www.it-help.tech/` in Search Console, repo Variables `GCP_WIF_PROVIDER` + `GCP_INDEXING_SA_EMAIL`), but **no GitHub Actions job, no Python script, and no `infra/google-indexing/` directory ever landed on `main`**. GitHub code search confirmed: zero occurrences of `indexing.googleapis.com` in the repo before this commit. So the keyless auth was dangling — provisioned but unused. This PR connects the wire.

--- a/templates/partials/_jsonld.html
+++ b/templates/partials/_jsonld.html
@@ -1,0 +1,104 @@
+{# =============================================================================
+   _jsonld.html — auto-emitted JSON-LD structured data (Schema.org)
+
+   Single source of truth for site-wide structured data. Included from
+   templates/partials/head.html so every page emits Organization + (when
+   applicable) Article/TechArticle + BreadcrumbList + Blog markup, all
+   driven from frontmatter — no per-page hand-coded JSON-LD required.
+
+   Emitted contexts:
+     • ALL pages         → Organization (publisher), with stable @id anchor
+     • field-notes posts → Article (or TechArticle via extra.schema_type)
+                           + BreadcrumbList (Home → Field Notes → post)
+     • field-notes index → Blog
+
+   Frontmatter knobs (all optional):
+     extra.schema_type        → "TechArticle" (default "Article")
+     extra.skip_auto_jsonld   → true to opt this page out (e.g. when the
+                                markdown body already contains a richer
+                                hand-written JSON-LD block and we don't
+                                want any auto-generated supplement)
+     extra.author             → author display name (falls back to
+                                page.author, then "Carey Balboa")
+     extra.og_image           → image URL (falls back to extra.image,
+                                then config.extra.default_og_image)
+
+   CSP-safe: emitted as <script type="application/ld+json"> blocks, which
+   are not subject to the production style-src 'self' restriction. All
+   string values are routed through Tera's `json_encode` filter so titles
+   and descriptions containing apostrophes, em-dashes, or quotes serialize
+   as valid JSON automatically.
+   ============================================================================ #}
+
+{%- set org_id = config.base_url ~ "/#organization" -%}
+{%- set org_logo = "https://www.it-help.tech/logo.svg" -%}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": {{ org_id | json_encode | safe }},
+  "name": {{ config.title | json_encode | safe }},
+  "url": {{ config.base_url | json_encode | safe }},
+  "logo": {{ org_logo | json_encode | safe }}
+}
+</script>
+
+{%- if page is defined and page.title and page.path is starting_with("/field-notes/") and not page.extra.skip_auto_jsonld %}
+{%- set art_type    = page.extra.schema_type | default(value="Article") -%}
+{%- set art_url     = page.permalink -%}
+{%- set art_desc    = page.description | default(value=config.description) -%}
+{%- set art_img_rel = page.extra.og_image | default(value=page.extra.image | default(value=config.extra.default_og_image | default(value="/images/og-home.png"))) -%}
+{%- set art_img     = get_url(path=art_img_rel, trailing_slash=false) -%}
+{%- set art_author  = page.extra.author | default(value=page.author | default(value="Carey Balboa")) -%}
+{%- set art_date    = page.date | date(format="%Y-%m-%d") -%}
+{%- set art_updated = page.updated | default(value=page.date) | date(format="%Y-%m-%d") -%}
+{%- set fn_index_url = config.base_url ~ "/field-notes/" -%}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": {{ art_type | json_encode | safe }},
+  "headline": {{ page.title | json_encode | safe }},
+  "description": {{ art_desc | json_encode | safe }},
+  "image": {{ art_img | json_encode | safe }},
+  "datePublished": {{ art_date | json_encode | safe }},
+  "dateModified": {{ art_updated | json_encode | safe }},
+  "author": {
+    "@type": "Person",
+    "name": {{ art_author | json_encode | safe }}
+  },
+  "publisher": { "@id": {{ org_id | json_encode | safe }} },
+  "mainEntityOfPage": {{ art_url | json_encode | safe }},
+  "isAccessibleForFree": true,
+  "inLanguage": "en-US"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home",        "item": {{ config.base_url | json_encode | safe }} },
+    { "@type": "ListItem", "position": 2, "name": "Field Notes", "item": {{ fn_index_url | json_encode | safe }} },
+    { "@type": "ListItem", "position": 3, "name": {{ page.title | json_encode | safe }}, "item": {{ art_url | json_encode | safe }} }
+  ]
+}
+</script>
+
+{%- elif section is defined and section.path == "/field-notes/" %}
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  "name": {{ section.title | json_encode | safe }},
+  "description": {{ section.description | default(value=config.description) | json_encode | safe }},
+  "url": {{ section.permalink | json_encode | safe }},
+  "publisher": { "@id": {{ org_id | json_encode | safe }} },
+  "inLanguage": "en-US"
+}
+</script>
+
+{%- endif %}

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -232,6 +232,12 @@
   {%- endfor %}
 {%- endif %}
 
+{# --- Structured data (Schema.org JSON-LD) ---
+   Sourced from a single partial so every page emits Organization +
+   (when applicable) Article/TechArticle + BreadcrumbList + Blog markup,
+   driven entirely by frontmatter. See _jsonld.html for details. #}
+{% include "partials/_jsonld.html" %}
+
 {# --- Extra items injected from config --- #}
 {%- if config.extra.head_extra %}
   {{ config.extra.head_extra | safe }}


### PR DESCRIPTION
## Summary

Closes the gap where **3 of 6 field-notes shipped zero structured data** because Schema.org JSON-LD was hand-written into markdown bodies on an ad-hoc basis only. After this PR every page emits structured data automatically from frontmatter, with a single source of truth.

## What lands

| File | Status | Purpose |
|---|---|---|
| `templates/partials/_jsonld.html` | NEW (95 lines) | Single source of truth. Emits Organization always (with stable `@id`), Article+BreadcrumbList on field-notes posts, Blog on the field-notes index. All values pulled from frontmatter and routed through Tera's `json_encode` filter for safe escaping. |
| `templates/partials/head.html` | +5 lines | One-line `{% include %}` directly before the `head_extra` injection point. |
| `PROJECT_EVOLUTION_LOG.md` | new entry | Full diagnosis + verification table + rollback. |

## Build verification (every block parsed with `json.loads`)

| Page | Before | After |
|---|---|---|
| `apple-sends-you-to-ijail` | 0 | **3** `[Organization, Article, BreadcrumbList]` |
| `hack-your-engrams-to-remember-passwords` | 0 | **3** |
| `it-problem-solving-scientific-method` | 0 | **3** |
| `dns-security-best-practices` | 3 | 6 *(3 new + 3 hand-curated TechArticle/FAQPage/HowTo retained)* |
| `mac-cybersecurity-threats` | 1 | 4 *(3 new + existing TechArticle retained)* |
| `why-your-wireless-network-sucks` | 1 | 4 *(3 new + existing TechArticle retained)* |
| `field-notes/` (section index) | 0 | **2** `[Organization, Blog]` |

All blocks parsed cleanly. No Tera template errors. Build time 498ms.

## Why duplicate Organization/Article on hand-curated pages is fine

Google supports multiple JSON-LD blocks per page (they're merged into a single graph), and the consistent `@id` anchor on Organization lets crawlers de-duplicate the publisher entity automatically. Removing the hand-written rich blocks from the 3 curated markdowns is a separate, lower-priority cleanup deferred to a follow-up — keeping them avoids any regression risk in the rich types (HowTo, FAQPage) the auto layer doesn't yet emit.

## Frontmatter knobs added (all optional)

- `extra.schema_type` → defaults to `"Article"`, set to `"TechArticle"` for technical posts
- `extra.skip_auto_jsonld` → defensive opt-out (not used by any current page)
- `extra.author` → display name (falls back to page.author, then "Carey Balboa")
- `extra.og_image` / `extra.image` → image URL (falls back to default_og_image)

## CSP compatibility

Production `style-src 'self'` is unaffected. JSON-LD ships in `<script type="application/ld+json">` tags, which fall under `script-src` (which already permits inline + same-origin per the existing CSP).

## Diagnosis correction worth noting

Initial scratchpad guess (that `templates/macros/seo.html` was missing and `{% block seo %}` was unwired) was **wrong**: the file exists in the abridge theme via inheritance, and the `{% block seo %}` definitions in `page.html`/`field-notes.html` are dead code because `base.html` defines no parent block. Real SEO source of truth is `templates/partials/head.html`, which generates title/meta/OG/Twitter from frontmatter but emitted **zero** JSON-LD. Cleaning up the dead `{% block seo %}` calls is separate scope and not done here.

## Rollback

This PR. Pre-merge baseline = current `main` HEAD.