### PR TITLE
fix(field-notes): stop hand-written JSON-LD leaking into listing-page excerpts

### DIFF
--- a/content/field-notes/dns-security-best-practices.md
+++ b/content/field-notes/dns-security-best-practices.md
@@ -19,29 +19,6 @@ extra:
 ---
 
 This guide explains how to configure and verify DNS email security controls so you can reduce spoofing, phishing, and business email compromise risk with defensible evidence — citing the IETF RFCs and federal guidance each control derives from.
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "TechArticle",
-  "isAccessibleForFree": true,
-  "headline": "DNS Security Best Practices: Defend Your Domain with DMARC, SPF & DKIM",
-  "description": "Step-by-step setup guide for DMARC, SPF, DKIM, DNSSEC, and email transport controls to prevent spoofing and phishing.",
-  "proficiencyLevel": "Intermediate",
-  "author": { 
-    "@type": "Person", 
-    "name": "Carey Balboa",
-    "url": "https://www.it-help.tech/about/"
-  },
-  "publisher": { 
-    "@id": "https://www.it-help.tech/#business"
-  },
-  "image": "https://www.it-help.tech/images/dns-security-dmarc.png",
-  "datePublished": "2025-05-25",
-  "dateModified": "2026-04-19",
-  "mainEntityOfPage": "https://www.it-help.tech/field-notes/dns-security-best-practices/",
-  "keywords": ["DMARC", "SPF", "DKIM", "DNSSEC", "Email Security", "DNS Security", "BEC", "IT Help San Diego"]
-}
-</script>
 
 ### TL;DR
 Email-authentication failures are rarely failures of *missing* records. They are failures of misinterpreting what the records actually enforce. The robust modern configuration for an active sending domain is **SPF `~all` + DKIM (2048-bit) + DMARC `p=reject`**, layered with **MTA-STS, TLS-RPT, and DANE** at the transport tier and **DNSSEC** beneath. Each control is defined by a specific IETF RFC, and the most common operational error — using SPF `-all` "for safety" — is explicitly warned against in RFC 7489 §10.1 because it can short-circuit DMARC. The sections below walk through what each control actually does, what threat it actually defends against, and how to validate behavior rather than just record presence.
@@ -196,61 +173,7 @@ When setting up DMARC and SPF, watch out for these common mistakes:
 * Setting overly strict policies initially.
 * Be cautious with automated "DNS auto-fix" platforms that request full zone access. Some tools modify records beyond the intended scope. Review diffs before publishing and keep a rollback snapshot of your zone file.
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Can I set up DMARC and SPF myself?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, but only if you fully understand how SPF, DKIM, and DMARC interact. Misconfigurations are common and can silently break email delivery or weaken spoofing protection."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What happens if I don’t set up DMARC or SPF?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Your domain remains easier to impersonate in phishing and BEC campaigns, which can damage trust, disrupt operations, and create direct financial risk."
-      }
-    }
-  ]
-}
-</script>
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "How to Set Up DMARC, SPF, and DKIM",
-  "description": "A step-by-step guide to securing your business email and domain with SPF, DKIM, DMARC, and practical verification.",
-  "step": [
-    {
-      "@type": "HowToStep",
-      "name": "Check Current Security Status",
-      "text": "Run a baseline audit of your domain to capture current SPF, DKIM, and DMARC posture before making changes."
-    },
-    {
-      "@type": "HowToStep",
-      "name": "Send a Test Email",
-      "text": "Use Red Sift Investigate to generate a test email address. Send an email to it from your CRM or marketing platform to verify delivery headers from those specific services."
-    },
-    {
-      "@type": "HowToStep",
-      "name": "Configure DNS Records",
-      "text": "Log in to your DNS provider (e.g. Cloudflare, GoDaddy) and add the reliable SPF, DKIM, and DMARC records tailored to your domain."
-    },
-    {
-      "@type": "HowToStep",
-      "name": "Verify Enforcement",
-      "text": "Verify propagation and enforcement across SPF, DKIM, and DMARC, then confirm transport controls and mailbox-provider delivery behavior."
-    }
-  ]
-}
-</script>
 
 ## FAQs: Your DNS Security Questions Answered
 
@@ -308,3 +231,83 @@ If you want a second set of eyes, we offer practical DNS/email security reviews 
 A BibTeX file for these references is available at [`/field-notes/dns-security-best-practices.bib`](/field-notes/dns-security-best-practices.bib) for one-click import into Zotero or any reference manager.
 
 *Last updated April 19, 2026 — verified against RFC 7489, RFC 7208, RFC 6376, NIST SP 800-177 Rev. 1, and current operational email-authentication best practices.*
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "isAccessibleForFree": true,
+  "headline": "DNS Security Best Practices: Defend Your Domain with DMARC, SPF & DKIM",
+  "description": "Step-by-step setup guide for DMARC, SPF, DKIM, DNSSEC, and email transport controls to prevent spoofing and phishing.",
+  "proficiencyLevel": "Intermediate",
+  "author": { 
+    "@type": "Person", 
+    "name": "Carey Balboa",
+    "url": "https://www.it-help.tech/about/"
+  },
+  "publisher": { 
+    "@id": "https://www.it-help.tech/#business"
+  },
+  "image": "https://www.it-help.tech/images/dns-security-dmarc.png",
+  "datePublished": "2025-05-25",
+  "dateModified": "2026-04-19",
+  "mainEntityOfPage": "https://www.it-help.tech/field-notes/dns-security-best-practices/",
+  "keywords": ["DMARC", "SPF", "DKIM", "DNSSEC", "Email Security", "DNS Security", "BEC", "IT Help San Diego"]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I set up DMARC and SPF myself?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, but only if you fully understand how SPF, DKIM, and DMARC interact. Misconfigurations are common and can silently break email delivery or weaken spoofing protection."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happens if I don’t set up DMARC or SPF?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Your domain remains easier to impersonate in phishing and BEC campaigns, which can damage trust, disrupt operations, and create direct financial risk."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Set Up DMARC, SPF, and DKIM",
+  "description": "A step-by-step guide to securing your business email and domain with SPF, DKIM, DMARC, and practical verification.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Check Current Security Status",
+      "text": "Run a baseline audit of your domain to capture current SPF, DKIM, and DMARC posture before making changes."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Send a Test Email",
+      "text": "Use Red Sift Investigate to generate a test email address. Send an email to it from your CRM or marketing platform to verify delivery headers from those specific services."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Configure DNS Records",
+      "text": "Log in to your DNS provider (e.g. Cloudflare, GoDaddy) and add the reliable SPF, DKIM, and DMARC records tailored to your domain."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Verify Enforcement",
+      "text": "Verify propagation and enforcement across SPF, DKIM, and DMARC, then confirm transport controls and mailbox-provider delivery behavior."
+    }
+  ]
+}
+</script>

--- a/content/field-notes/mac-cybersecurity-threats.md
+++ b/content/field-notes/mac-cybersecurity-threats.md
@@ -16,30 +16,6 @@ extra:
   canonical_url: "https://www.it-help.tech/field-notes/mac-cybersecurity-threats/"
 ---
 
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "TechArticle",
-  "isAccessibleForFree": true,
-  "headline": "Mac Cybersecurity Threats: What Apple Already Protects, What It Doesn't, and the Magic Combo That Closes the Gap",
-  "description": "What Apple's built-in stack (XProtect, XProtect Remediator, Gatekeeper, Notarization) actually defends against on macOS, where the real gaps are, and the practical Magic Combo — ManageEngine Security Edition plus LuLu — that closes them on real client machines.",
-  "proficiencyLevel": "Intermediate",
-  "author": {
-    "@type": "Person",
-    "name": "Carey Balboa",
-    "url": "https://www.it-help.tech/about/"
-  },
-  "publisher": {
-    "@id": "https://www.it-help.tech/#business"
-  },
-  "image": "https://www.it-help.tech/images/mac-cybersecurity.jpeg",
-  "datePublished": "2025-05-23",
-  "dateModified": "2026-04-19",
-  "mainEntityOfPage": "https://www.it-help.tech/field-notes/mac-cybersecurity-threats/",
-  "keywords": ["macOS Security", "iOS Security", "XProtect", "Gatekeeper", "Lockdown Mode", "Stolen Device Protection", "LuLu", "ManageEngine", "Pegasus", "FORCEDENTRY", "IT Help San Diego"]
-}
-</script>
-
 ### TL;DR
 
 Apple's built-in stack on a current Mac is genuinely good. **XProtect** (signature scan), **XProtect Remediator** (background remediation), **Gatekeeper** (code-signing enforcement), and **Notarization** (Apple-side malware scan of every distributed binary) together stop the overwhelming majority of commodity malware before it ever touches user data [^1]. The myth that Macs are immune is wrong; the inverted myth that Apple ships a defenseless OS is also wrong. The real threats are narrower and more interesting: WebKit memory-corruption chains exploited by state-grade spyware (the **FORCEDENTRY** case is the canonical primary-source example) [^2][^3], adware and potentially-unwanted programs (PUPs) that Apple's stack tolerates because they are technically "valid" software, social engineering, and the persistent network-egress problem — software you trusted at install time talking to places you didn't authorize.
@@ -266,3 +242,27 @@ Call **619-853-5008** or [schedule a consultation](https://schedule.it-help.tech
 A BibTeX file for these references is available at [`/field-notes/mac-cybersecurity-threats.bib`](/field-notes/mac-cybersecurity-threats.bib) for one-click import into Zotero or any reference manager.
 
 *Last updated April 19, 2026 — verified against Apple Platform Security Guide, Citizen Lab FORCEDENTRY disclosure, MITRE CVE entries, vendor product documentation, and current operational deployment experience.*
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "isAccessibleForFree": true,
+  "headline": "Mac Cybersecurity Threats: What Apple Already Protects, What It Doesn't, and the Magic Combo That Closes the Gap",
+  "description": "What Apple's built-in stack (XProtect, XProtect Remediator, Gatekeeper, Notarization) actually defends against on macOS, where the real gaps are, and the practical Magic Combo — ManageEngine Security Edition plus LuLu — that closes them on real client machines.",
+  "proficiencyLevel": "Intermediate",
+  "author": {
+    "@type": "Person",
+    "name": "Carey Balboa",
+    "url": "https://www.it-help.tech/about/"
+  },
+  "publisher": {
+    "@id": "https://www.it-help.tech/#business"
+  },
+  "image": "https://www.it-help.tech/images/mac-cybersecurity.jpeg",
+  "datePublished": "2025-05-23",
+  "dateModified": "2026-04-19",
+  "mainEntityOfPage": "https://www.it-help.tech/field-notes/mac-cybersecurity-threats/",
+  "keywords": ["macOS Security", "iOS Security", "XProtect", "Gatekeeper", "Lockdown Mode", "Stolen Device Protection", "LuLu", "ManageEngine", "Pegasus", "FORCEDENTRY", "IT Help San Diego"]
+}
+</script>

--- a/content/field-notes/why-your-wireless-network-sucks.md
+++ b/content/field-notes/why-your-wireless-network-sucks.md
@@ -16,29 +16,6 @@ extra:
 ---
 
 Slow Wi-Fi is rarely a router problem. It is almost always a chain problem — and the chain has a physics layer underneath it that explains exactly why each wireless hop without a wired backhaul degrades like a photocopy of a photocopy. This guide names that physics, then walks through what an Ethernet backbone, proper cabling, and modern Wi-Fi 6/7 actually fix.
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "TechArticle",
-  "isAccessibleForFree": true,
-  "headline": "Why Your Wireless Network Sucks: Copy of a Copy, and the Ethernet Backbone That Fixes It",
-  "description": "Why wireless degrades like a photocopy of a photocopy — half-duplex CSMA/CA, Shannon-Hartley capacity, and retransmit compounding — and how an Ethernet backbone, proper Cat6A/Cat8 cabling, and modern Wi-Fi 6/7 deliver the speed you are paying for to your endpoint.",
-  "proficiencyLevel": "Intermediate",
-  "author": {
-    "@type": "Person",
-    "name": "Carey Balboa",
-    "url": "https://www.it-help.tech/about/"
-  },
-  "publisher": {
-    "@id": "https://www.it-help.tech/#business"
-  },
-  "image": "https://www.it-help.tech/images/sad-wifi-extender.png",
-  "datePublished": "2025-05-24",
-  "dateModified": "2026-04-19",
-  "mainEntityOfPage": "https://www.it-help.tech/field-notes/why-your-wireless-network-sucks/",
-  "keywords": ["Wi-Fi", "Ethernet backbone", "Cat6A", "Cat8", "Wi-Fi 6", "Wi-Fi 7", "CSMA/CA", "mesh", "PoE", "IT Help San Diego"]
-}
-</script>
 
 ### TL;DR
 Each wireless extender or mesh node *without a wired backhaul* shares one half-duplex radio between talking to the upstream access point and talking to your device. The IEEE 802.11 medium access protocol (CSMA/CA) cannot do both at full speed simultaneously, so per-hop usable throughput is roughly halved, and noise plus retransmits compound the loss [^1][^2]. After two relayed hops you are typically at ~25% of nominal; after three, ~12.5%. That is the "copy of a copy" problem expressed in physics. The fix is an Ethernet backbone — Cat6A or Cat8 cable feeding access points so the radio's airtime is spent on *you*, not on relaying its own backhaul. Modern Wi-Fi 6/7 with proper wired backhaul (for example, a Ubiquiti Dream Machine plus U7-class APs on Cat6A) does soften the older "always halve" rule when deployed correctly, and the section below names that honestly. Specialized environments — mine rescue, military operations — solve wireless backhaul with leaky-feeder cable systems and dedicated MANET radios, not consumer 802.11 gear from a big-box store. Tracking the gap between speed paid for and speed actually delivered to the endpoint has been my discipline for fifteen years (out of 27+ in IT overall), and the work below is the engineering that makes it possible.
@@ -169,3 +146,27 @@ Call 619-853-5008 and [schedule a walkthrough](https://schedule.it-help.tech/) f
 A BibTeX file for these references is available at [`/field-notes/why-your-wireless-network-sucks.bib`](/field-notes/why-your-wireless-network-sucks.bib) for one-click import into Zotero or any reference manager.
 
 *Last updated April 19, 2026 — verified against IEEE 802.11-2020, IEEE 802.11ax-2021, IEEE 802.3-2022, ANSI/TIA-568.2-D, and current operational deployment experience.*
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "isAccessibleForFree": true,
+  "headline": "Why Your Wireless Network Sucks: Copy of a Copy, and the Ethernet Backbone That Fixes It",
+  "description": "Why wireless degrades like a photocopy of a photocopy — half-duplex CSMA/CA, Shannon-Hartley capacity, and retransmit compounding — and how an Ethernet backbone, proper Cat6A/Cat8 cabling, and modern Wi-Fi 6/7 deliver the speed you are paying for to your endpoint.",
+  "proficiencyLevel": "Intermediate",
+  "author": {
+    "@type": "Person",
+    "name": "Carey Balboa",
+    "url": "https://www.it-help.tech/about/"
+  },
+  "publisher": {
+    "@id": "https://www.it-help.tech/#business"
+  },
+  "image": "https://www.it-help.tech/images/sad-wifi-extender.png",
+  "datePublished": "2025-05-24",
+  "dateModified": "2026-04-19",
+  "mainEntityOfPage": "https://www.it-help.tech/field-notes/why-your-wireless-network-sucks/",
+  "keywords": ["Wi-Fi", "Ethernet backbone", "Cat6A", "Cat8", "Wi-Fi 6", "Wi-Fi 7", "CSMA/CA", "mesh", "PoE", "IT Help San Diego"]
+}
+</script>


### PR DESCRIPTION
## Why

Field-notes index template generates listing-page post excerpts via `page.content | striptags | truncate(160)`. Three field-notes had hand-written `<script type="application/ld+json">` blocks at the *top* of their markdown body. `striptags` removes the `<script>` element wrapper but **not the JSON text inside**, so the listing page rendered:

> *Mac Cybersecurity Threats: …*
> *{ "@context": "https://schema.org", "@type": "TechArticle", "isAccessibleForFree": true, "headline": "Mac Cybersecurity Threats: What Apple Already Pro…*

Owner reported this visible on production today.

## What

Move every hand-written JSON-LD block in the 3 affected field-notes to the **end** of the markdown body. Files touched:

- `content/field-notes/mac-cybersecurity-threats.md` (1 block moved)
- `content/field-notes/dns-security-best-practices.md` (3 blocks moved — TechArticle, FAQPage, HowTo)
- `content/field-notes/why-your-wireless-network-sucks.md` (1 block moved)

## Why this is safe

Position of `<script type="application/ld+json">` blocks does not affect SEO — Google reads them all regardless of where they sit in the HTML. The change is purely about where the excerpt fallback finds its first 160 characters of content.

## Verification (local rebuild)

| Listing-page excerpt | Now starts with |
|---|---|
| Mac Cybersecurity | "TL;DR Apple's built-in stack on a current Mac is genuinely good…" |
| DNS Security | "This guide explains how to configure and verify DNS email security controls…" |
| Wireless | "Slow Wi-Fi is rarely a router problem. It is almost always a chain problem…" |

All 6 listing excerpts: clean prose. JSON leak count: 0.

Per-page JSON-LD coverage unchanged:
- dns-security: 6 blocks (Organization, Article, BreadcrumbList, **TechArticle, FAQPage, HowTo**) ✅
- mac-cybersecurity-threats: 4 blocks (Organization, Article, BreadcrumbList, **TechArticle**) ✅
- why-your-wireless-network-sucks: 4 blocks (Organization, Article, BreadcrumbList, **TechArticle**) ✅

All blocks parse as valid JSON.

## Provenance

This commit was originally pushed to PR #592 as a follow-up after the listing-page leak was reported, but landed ~2 minutes after that PR merged. Re-opening it as its own PR so it gets a clean review path.