### PR TITLE
content(services): rephrase cross-platform line to remove 'C:\>' literal

### DIFF
--- a/content/services.md
+++ b/content/services.md
@@ -400,7 +400,7 @@ For law firms and legal professionals: structured extraction of email and iPhone
 
 ## Cross-Platform & Systems Work {#cross-platform}
 
-macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. We engage the problem, not the logo. The same instinct for reading logs, tracing packets, and reasoning from evidence applies whether the prompt is `$`, `#`, or `C:\>`.
+macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. We engage the problem, not the logo. The same instinct for analyzing logs, tracing packets, and deducing from evidence is applicable regardless of the prompt.
 
 * **Shell scripting and automation** — Bash, Zsh, and PowerShell for repeatable, auditable operations instead of click-by-click drift.
 * **File servers and shared storage** — SMB and NFS that hold up across macOS, Windows, and Linux clients without permissions roulette.


### PR DESCRIPTION
## Summary

Editorial-only one-line copy change to `content/services.md`. Replaces the literal Windows-prompt example (`C:\>`) in the Cross-Platform & Systems Work section with a paraphrase that preserves the meaning ("same diagnostic instinct regardless of the OS").

## Why

The federal Qualys vulnerability scan flagged 11 QID 150059 (CWE-201) findings on `www.it-help.tech`, all triggered by that single literal. They were already documented as false positives in `PROJECT_EVOLUTION_LOG.md` (2026-04-20 entry, Task #23). This change removes the trigger string so future federal scans return clean without needing the disposition note.

## Diff

```diff
-We engage the problem, not the logo. The same instinct for reading logs, tracing packets, and reasoning from evidence applies whether the prompt is `$`, `#`, or `C:\>`.
+We engage the problem, not the logo. The same instinct for analyzing logs, tracing packets, and deducing from evidence is applicable regardless of the prompt.
```

## Verification

- `zola build` clean (317ms, 12 pages + 1 section).
- No code, template, or policy changes.
- No CSP / Observatory / Lighthouse impact.