### PR TITLE
Refresh /brand-colors to gold-led owl identity

### DIFF
--- a/PROJECT_EVOLUTION_LOG.md
+++ b/PROJECT_EVOLUTION_LOG.md
@@ -13,6 +13,17 @@ Purpose: Track meaningful AI/developer changes with enough context to roll back 
 
 ## Entries
 
+### 2026-04-23 — `/brand-colors` refresh: Athenian-owl medallion + gold-led wordmark identity, demote legacy logo blue ramp
+- Actor: AI+Developer
+- Scope: Public brand-colors reference page (`/brand-colors`), STYLE_GUIDE top section
+- Files:
+  - `content/brand-colors.md`
+  - `static/css/brand-colors.css`
+  - `STYLE_GUIDE.md`
+- Change: Updated the brand-colors page to accurately reflect the live identity. Added a top "Brand Mark — Athenian Owl" section that displays the owl medallion (`/img/brand/owl-720.{webp,png}`) with `<picture>` + WebP/PNG fallback. Replaced the misleading "Logo Authority Blue Ramp" (no longer consumed by any selector) with "Logo Authority Gold Ramp (Athenian-Owl Banner)" — `--brand-logo-gold-top #E0C58A`, `--brand-logo-gold-mid #D2B56F`, `--brand-logo-gold-bottom #A8843E` — and noted that `--brand-logo-gold-mid` is the live fill of `.logo-it` and `.logo-help`. Demoted the blue ramp to a "Legacy" section with a clear "retained as token aliases only" pill tag at reduced opacity. Reordered the priority chip strip to lead with Logo Gold + Plus Red + gold highlight/shadow, then Action Blue + Primary Blue. Rewrote the intro and Brand Rules to make gold-led IT+HELP wordmark + owl medallion explicit. Added matching CSS for the new swatches, the brand-mark figure (circular crop, gold rim, deep shadow), the heritage section pill tag, and a `(max-width: 699px)` mobile shrink for the medallion. Updated `STYLE_GUIDE.md` top section to lead with the owl mark and gold ramp; bumped Last-updated date.
+- Why: User reported the brand-colors page no longer matched the live look and feel. Investigation confirmed the IT+HELP wordmark transitioned from blue to the owl-banner gold ramp, but the page was still presenting the legacy blue ramp as the "logo authority" colors and never displayed the owl medallion at all.
+- Rollback: this branch/PR (`content/brand-colors-owl-gold-refresh`).
+
 ### 2026-04-23 — Homepage "How we work" 2-up imagery (on-site + remote)
 - Actor: AI (owner-supplied marketing imagery: `attached_assets/on-site_*.png`, `attached_assets/remote_*.png`, both 1254×1254 PNG ~2.0–2.4 MB).
 - Scope: Add a "How we work" section to the homepage with two side-by-side branded panels (On-site across San Diego / Remote anywhere). Visually communicates the two engagement modes that the existing copy hints at but never shows.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -9,8 +9,9 @@ Purpose: Keep the visual system consistent and readable across the site. Update 
 ## Brand Colors
 - IT+HELP Wordmark Gold Ramp (Athenian-Owl Banner) — **the live wordmark fill**:
   - Top: `#E0C58A` (`--brand-logo-gold-top`)
-  - Mid: `#D2B56F` (`--brand-logo-gold-mid`) — used by `.logo-it` and `.logo-help`
+  - Mid: `#D2B56F` (`--brand-logo-gold-mid`) — dark-mode fill of `.logo-it` and `.logo-help`
   - Bottom: `#A8843E` (`--brand-logo-gold-bottom`)
+  - Light-mode override: `html.switch .logo-it` and `html.switch .logo-help` use `--brand-gold` (`#C2A15A`) — one luminance step down — for contrast against the off-white surface (see `static/css/late-overrides.css`).
 - Primary Blue (shared hue anchor for actions/glow/particles): `#58A6FF`
   - Source of truth: `--brand-blue` in `static/css/tokens.css`
   - If changed, also update:

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,18 +1,25 @@
 # Style Guide (Living)
-Last updated: 2026-02-11
+Last updated: 2026-04-23
 
 Purpose: Keep the visual system consistent and readable across the site. Update this file whenever palette, typography, or motion choices change.
 
+## Brand Mark
+- Primary identity element: the **Athenian owl medallion** at `/img/brand/owl-720.{webp,png}`. Greek-key border, gold owl on dark ground. Pairs with the IT+HELP wordmark across hero, topbar, polos, and collateral.
+
 ## Brand Colors
-- Primary Blue (shared hue anchor): `#58A6FF`  
-  - Source of truth: `--brand-blue` in `static/css/late-overrides.css`
+- IT+HELP Wordmark Gold Ramp (Athenian-Owl Banner) — **the live wordmark fill**:
+  - Top: `#E0C58A` (`--brand-logo-gold-top`)
+  - Mid: `#D2B56F` (`--brand-logo-gold-mid`) — used by `.logo-it` and `.logo-help`
+  - Bottom: `#A8843E` (`--brand-logo-gold-bottom`)
+- Primary Blue (shared hue anchor for actions/glow/particles): `#58A6FF`
+  - Source of truth: `--brand-blue` in `static/css/tokens.css`
   - If changed, also update:
     - `--brand-blue-rgb` (comma RGB)
     - `--brand-blue-glow` (particle glow)
-- Logo Authority Blue Ramp (deeper tone for premium trust feel):
-  - Top: `#327ED6` (`--logo-blue-top`)
-  - Mid: `#2662AA` (`--logo-blue-mid`)
-  - Bottom: `#13437A` (`--logo-blue-bottom`)
+- Legacy Logo Blue Ramp (retained as token aliases only — **no longer used on IT+HELP letters**; do not use for new components):
+  - Top: `#327ED6` (`--brand-logo-blue-top` / `--logo-blue-top`)
+  - Mid: `#2662AA` (`--brand-logo-blue-mid` / `--logo-blue-mid`)
+  - Bottom: `#13437A` (`--brand-logo-blue-bottom` / `--logo-blue-bottom`)
 - Schedule Indigo Depth Ramp:
   - Top: `#6CAFEF` (`--schedule-blue-top`)
   - Mid: `#3F86D8` (`--schedule-blue-mid`)

--- a/content/brand-colors.md
+++ b/content/brand-colors.md
@@ -78,7 +78,7 @@ scripts = ["js/brand-colors.js"]
 <section class="brand-section" aria-labelledby="logo-gold-ramp">
 <div class="brand-section-head">
 <h2 id="logo-gold-ramp">Logo Authority Gold Ramp (Athenian-Owl Banner)</h2>
-<p>IT+HELP wordmark fill and topbar banner gold tones. <code>--brand-logo-gold-mid</code> is the live letter color of <code>.logo-it</code> and <code>.logo-help</code>.</p>
+<p>IT+HELP wordmark fill and topbar banner gold tones. <code>--brand-logo-gold-mid</code> is the dark-mode letter color of <code>.logo-it</code> and <code>.logo-help</code>; in light mode (<code>html.switch</code>) the letters drop one luminance step to <code>--brand-gold</code> (<code>#C2A15A</code>) for contrast against the off-white surface.</p>
 </div>
 <div class="brand-grid brand-grid-3up">
 <article class="brand-card">
@@ -93,7 +93,7 @@ scripts = ["js/brand-colors.js"]
 <h3>Logo Gold Mid</h3>
 <p class="brand-token"><code>--brand-logo-gold-mid</code></p>
 <p class="brand-value"><code>#D2B56F</code></p>
-<p class="brand-note">Live IT+HELP letter fill. Same value as <code>--brand-gold-solid</code> (different role).</p>
+<p class="brand-note">Dark-mode IT+HELP letter fill. Light mode steps down to <code>--brand-gold</code> (<code>#C2A15A</code>). Same value as <code>--brand-gold-solid</code> (different role).</p>
 </article>
 <article class="brand-card">
 <div class="brand-swatch swatch-logo-gold-bottom" aria-hidden="true"></div>
@@ -334,7 +334,7 @@ scripts = ["js/brand-colors.js"]
 </div>
 <ol>
 <li>The Athenian owl medallion is the primary brand mark; the IT+HELP wordmark is its lockup partner.</li>
-<li>IT+HELP letters render in the owl-banner gold ramp (<code>--logo-gold-mid</code> / <code>#D2B56F</code>). The legacy logo-blue ramp is retained as token aliases only and is not used on the wordmark.</li>
+<li>IT+HELP letters render in the owl-banner gold ramp: <code>--logo-gold-mid</code> (<code>#D2B56F</code>) in dark mode, stepping down to <code>--brand-gold</code> (<code>#C2A15A</code>) in light mode for surface contrast. The legacy logo-blue ramp is retained as token aliases only and is not used on the wordmark in either theme.</li>
 <li>Red is reserved for the plus symbol — never for body text, links, or other accents.</li>
 <li>Action / link / schedule blues sit one luminance step below the wordmark gold so the lockup remains the dominant signal.</li>
 <li>Gold accent (<code>--brand-gold</code>) and gold stroke (<code>--brand-gold-solid</code>) are used in restrained doses on hero pill border and CTA trim; they share hue with the logo gold ramp by design.</li>

--- a/content/brand-colors.md
+++ b/content/brand-colors.md
@@ -13,18 +13,32 @@ scripts = ["js/brand-colors.js"]
 +++
 <div class="brand-colors-page">
 <p class="brand-colors-kicker">IT Help San Diego Inc.</p>
-<p class="brand-colors-intro">Canonical palette and token reference for design, engineering, and vendor handoff. This page is public for sharing and is marked <code>noindex, nofollow</code>.</p>
+<p class="brand-colors-intro">Canonical palette and token reference for design, engineering, and vendor handoff. The brand is led by the <strong>Athenian owl medallion</strong> with a <strong>gold IT+HELP wordmark</strong>; blue is the action / link family. This page is public for sharing and is marked <code>noindex, nofollow</code>.</p>
 <div class="brand-copy-actions brand-top-actions" role="group" aria-label="Copy all values">
 <button type="button" class="brand-copy-btn" id="copy-all-hex">Copy all HEX</button>
 <button type="button" class="brand-copy-btn" id="copy-all-css">Copy all CSS vars</button>
 </div>
 <div class="brand-priority-palette" role="list" aria-label="Primary brand palette preview">
-<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-brand-blue" aria-hidden="true"></span>Primary Blue <code>#58A6FF</code></span>
-<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-logo-blue-top" aria-hidden="true"></span>Logo Blue <code>#327ED6</code></span>
+<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-logo-gold-mid" aria-hidden="true"></span>Logo Gold <code>#D2B56F</code></span>
 <span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-plus-red" aria-hidden="true"></span>Plus Red <code>#FF0066</code></span>
-<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-gold-accent" aria-hidden="true"></span>Gold Accent <code>#C2A15A</code></span>
-<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-gold-stroke" aria-hidden="true"></span>Gold Stroke <code>#D2B56F</code></span>
+<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-logo-gold-top" aria-hidden="true"></span>Gold Highlight <code>#E0C58A</code></span>
+<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-logo-gold-bottom" aria-hidden="true"></span>Gold Shadow <code>#A8843E</code></span>
+<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-schedule-blue-mid" aria-hidden="true"></span>Action Blue <code>#3F86D8</code></span>
+<span class="brand-priority-chip" role="listitem"><span class="brand-mini-swatch swatch-brand-blue" aria-hidden="true"></span>Primary Blue <code>#58A6FF</code></span>
 </div>
+<section class="brand-section brand-mark-section" aria-labelledby="brand-mark">
+<div class="brand-section-head">
+<h2 id="brand-mark">Brand Mark — Athenian Owl</h2>
+<p>Primary identity element. Pairs with the IT+HELP wordmark across hero, topbar, polos, and collateral.</p>
+</div>
+<figure class="brand-mark-figure">
+<picture>
+<source srcset="/img/brand/owl-720.webp" type="image/webp">
+<img src="/img/brand/owl-720.png" alt="Athenian owl medallion — IT Help San Diego brand mark" width="360" height="360" loading="lazy" decoding="async" class="brand-mark-image">
+</picture>
+<figcaption>Greek-key border, gold owl on dark ground. Source: <code>/img/brand/owl-720.webp</code> (WebP) and <code>/img/brand/owl-720.png</code> (PNG fallback). Reference: Athena's owl, classical iconography.</figcaption>
+</figure>
+</section>
 <section class="brand-section" aria-labelledby="core-brand-colors">
 <div class="brand-section-head">
 <h2 id="core-brand-colors">Core Brand Colors</h2>
@@ -61,28 +75,57 @@ scripts = ["js/brand-colors.js"]
 </article>
 </div>
 </section>
-<section class="brand-section" aria-labelledby="logo-ramp">
+<section class="brand-section" aria-labelledby="logo-gold-ramp">
 <div class="brand-section-head">
-<h2 id="logo-ramp">Logo Authority Blue Ramp</h2>
-<p>IT+HELP hierarchy and depth tones.</p>
+<h2 id="logo-gold-ramp">Logo Authority Gold Ramp (Athenian-Owl Banner)</h2>
+<p>IT+HELP wordmark fill and topbar banner gold tones. <code>--brand-logo-gold-mid</code> is the live letter color of <code>.logo-it</code> and <code>.logo-help</code>.</p>
+</div>
+<div class="brand-grid brand-grid-3up">
+<article class="brand-card">
+<div class="brand-swatch swatch-logo-gold-top" aria-hidden="true"></div>
+<h3>Logo Gold Top</h3>
+<p class="brand-token"><code>--brand-logo-gold-top</code></p>
+<p class="brand-value"><code>#E0C58A</code></p>
+<p class="brand-note">Highlight tone for wordmark dimensionality.</p>
+</article>
+<article class="brand-card">
+<div class="brand-swatch swatch-logo-gold-mid" aria-hidden="true"></div>
+<h3>Logo Gold Mid</h3>
+<p class="brand-token"><code>--brand-logo-gold-mid</code></p>
+<p class="brand-value"><code>#D2B56F</code></p>
+<p class="brand-note">Live IT+HELP letter fill. Same value as <code>--brand-gold-solid</code> (different role).</p>
+</article>
+<article class="brand-card">
+<div class="brand-swatch swatch-logo-gold-bottom" aria-hidden="true"></div>
+<h3>Logo Gold Bottom</h3>
+<p class="brand-token"><code>--brand-logo-gold-bottom</code></p>
+<p class="brand-value"><code>#A8843E</code></p>
+<p class="brand-note">Shadow tone for banner depth and weight.</p>
+</article>
+</div>
+</section>
+<section class="brand-section brand-section-heritage" aria-labelledby="legacy-logo-blue">
+<div class="brand-section-head">
+<h2 id="legacy-logo-blue">Legacy Logo Blue Ramp <span class="brand-section-tag">retained as token aliases only</span></h2>
+<p>The IT+HELP wordmark used this blue ramp before the gold transition. Tokens remain in <code>tokens.css</code> for back-compat but are no longer consumed by any selector. Do not use for new components.</p>
 </div>
 <div class="brand-grid brand-grid-3up">
 <article class="brand-card">
 <div class="brand-swatch swatch-logo-blue-top" aria-hidden="true"></div>
-<h3>Logo Blue Top</h3>
-<p class="brand-token"><code>--logo-blue-top</code></p>
+<h3>Legacy Logo Blue Top</h3>
+<p class="brand-token"><code>--brand-logo-blue-top</code></p>
 <p class="brand-value"><code>#327ED6</code></p>
 </article>
 <article class="brand-card">
 <div class="brand-swatch swatch-logo-blue-mid" aria-hidden="true"></div>
-<h3>Logo Blue Mid</h3>
-<p class="brand-token"><code>--logo-blue-mid</code></p>
+<h3>Legacy Logo Blue Mid</h3>
+<p class="brand-token"><code>--brand-logo-blue-mid</code></p>
 <p class="brand-value"><code>#2662AA</code></p>
 </article>
 <article class="brand-card">
 <div class="brand-swatch swatch-logo-blue-bottom" aria-hidden="true"></div>
-<h3>Logo Blue Bottom</h3>
-<p class="brand-token"><code>--logo-blue-bottom</code></p>
+<h3>Legacy Logo Blue Bottom</h3>
+<p class="brand-token"><code>--brand-logo-blue-bottom</code></p>
 <p class="brand-value"><code>#13437A</code></p>
 </article>
 </div>
@@ -290,12 +333,13 @@ scripts = ["js/brand-colors.js"]
 <h2 id="brand-rules">Brand Rules</h2>
 </div>
 <ol>
-<li>Blue is primary identity; logo blues remain the strongest signal.</li>
-<li>Red is reserved for the plus symbol.</li>
-<li>Gold is utility accent: perimeter, hero pill border, and gold CTA.</li>
-<li>Schedule CTA remains one luminance step below the logo blues.</li>
-<li><code>san diego</code> stays subordinate steel-blue gray.</li>
-<li>Do not mint ad hoc colors without updating style docs.</li>
+<li>The Athenian owl medallion is the primary brand mark; the IT+HELP wordmark is its lockup partner.</li>
+<li>IT+HELP letters render in the owl-banner gold ramp (<code>--logo-gold-mid</code> / <code>#D2B56F</code>). The legacy logo-blue ramp is retained as token aliases only and is not used on the wordmark.</li>
+<li>Red is reserved for the plus symbol — never for body text, links, or other accents.</li>
+<li>Action / link / schedule blues sit one luminance step below the wordmark gold so the lockup remains the dominant signal.</li>
+<li>Gold accent (<code>--brand-gold</code>) and gold stroke (<code>--brand-gold-solid</code>) are used in restrained doses on hero pill border and CTA trim; they share hue with the logo gold ramp by design.</li>
+<li><code>san diego</code> stays subordinate steel-blue gray (<code>#566376</code> dark / <code>#404D5B</code> light).</li>
+<li>Do not mint ad hoc colors without updating <code>STYLE_GUIDE.md</code> and <code>static/css/tokens.css</code> in the same PR; <code>scripts/check-token-parity.sh</code> enforces no-hex-in-component-CSS.</li>
 </ol>
 </section>
 </div>

--- a/static/css/brand-colors.css
+++ b/static/css/brand-colors.css
@@ -245,6 +245,85 @@
   font-size: 0.88rem;
 }
 
+.brand-mark-section .brand-section-head {
+  margin-bottom: 0.6rem;
+}
+
+.brand-mark-figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 0.5rem 0.4rem;
+}
+
+.brand-mark-figure picture {
+  display: inline-flex;
+  border-radius: 50%;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(210, 181, 111, 0.42),
+    0 14px 36px rgba(2, 8, 18, 0.42);
+}
+
+.brand-mark-image {
+  display: block;
+  width: 360px;
+  max-width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+}
+
+.brand-mark-figure figcaption {
+  text-align: center;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  color: var(--text-color-dark);
+  max-width: 64ch;
+}
+
+html.switch .brand-mark-figure figcaption {
+  color: var(--text-color-light);
+}
+
+.brand-section-tag {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.18rem 0.5rem;
+  border-radius: 0.42rem;
+  border: 1px solid rgba(210, 181, 111, 0.42);
+  background: rgba(168, 132, 62, 0.18);
+  color: #e0c58a;
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+html.switch .brand-section-tag {
+  border-color: rgba(168, 132, 62, 0.5);
+  background: rgba(224, 197, 138, 0.22);
+  color: #6f5424;
+}
+
+.brand-section-heritage {
+  opacity: 0.86;
+}
+
+.brand-section-heritage:hover,
+.brand-section-heritage:focus-within {
+  opacity: 1;
+}
+
+@media (max-width: 699px) {
+  .brand-mark-image {
+    width: 240px;
+  }
+}
+
 .brand-rules ol {
   margin: 0.3rem 0 0;
   padding-left: 1.15rem;
@@ -268,6 +347,10 @@
 .swatch-logo-blue-top { background: #327ED6; }
 .swatch-logo-blue-mid { background: #2662AA; }
 .swatch-logo-blue-bottom { background: #13437A; }
+
+.swatch-logo-gold-top { background: #E0C58A; }
+.swatch-logo-gold-mid { background: #D2B56F; }
+.swatch-logo-gold-bottom { background: #A8843E; }
 
 .swatch-schedule-blue-top { background: #6CAFEF; }
 .swatch-schedule-blue-mid { background: #3F86D8; }


### PR DESCRIPTION
## Why

The public `/brand-colors` reference page no longer matched the live look and feel of the IT+HELP wordmark. The page presented the **Logo Authority Blue Ramp** (`#327ED6` / `#2662AA` / `#13437A`) as the canonical identity colors, but `.logo-it` and `.logo-help` actually render with `var(--logo-gold-mid)` (`#D2B56F`) — the gold ramp added later for the Athenian-owl banner. Zero CSS selectors consume the legacy `--logo-blue-*` aliases anymore. The page also never displayed the owl medallion itself.

## What changed

### `content/brand-colors.md`
- **NEW** *Brand Mark — Athenian Owl* section displaying the medallion via `<picture>` + WebP/PNG fallback at `/img/brand/owl-720.{webp,png}`.
- **REPLACED** *Logo Authority Blue Ramp* with *Logo Authority Gold Ramp (Athenian-Owl Banner)* — three swatches:
  - `--brand-logo-gold-top` `#E0C58A` (highlight)
  - `--brand-logo-gold-mid` `#D2B56F` (live IT+HELP letter fill — same value as `--brand-gold-solid`, different role)
  - `--brand-logo-gold-bottom` `#A8843E` (shadow)
- **DEMOTED** the blue ramp to a *Legacy Logo Blue Ramp* section with a clear `RETAINED AS TOKEN ALIASES ONLY` pill tag, slight opacity reduction, and a do-not-use note.
- **REORDERED** the priority chip strip to lead with Logo Gold + Plus Red + gold highlight/shadow, then Action Blue + Primary Blue.
- **REWROTE** the intro and *Brand Rules* to make the gold-led IT+HELP wordmark + owl medallion lockup explicit; reserve red for the plus only; keep blues one luminance step below the wordmark.

### `static/css/brand-colors.css`
- Add `.swatch-logo-gold-{top,mid,bottom}` swatch backgrounds.
- Add `.brand-mark-figure` / `.brand-mark-image` styles: circular gold-rim crop, deep ground shadow, 360px desktop / 240px on ≤699px viewports.
- Add `.brand-section-tag` pill style (light + dark theme).
- Add `.brand-section-heritage { opacity: 0.86 }` with hover/focus reset to 1 for visual subordination of the legacy ramp.

### `STYLE_GUIDE.md`
- Add *Brand Mark* section pointing at `/img/brand/owl-720.{webp,png}`.
- Lead *Brand Colors* with the gold ramp (live wordmark fill).
- Demote the legacy blue ramp with explicit *no longer used on IT+HELP letters* call-out.
- Bump *Last updated* to 2026-04-23.

### `PROJECT_EVOLUTION_LOG.md`
- New 2026-04-23 entry: actor / scope / files / change / why / rollback.

## Verification
- Local Zola serve render confirmed: owl medallion centered with gold rim and dark shadow; gold ramp displays with live letter-fill note; legacy blue ramp displays subordinated with the pill tag.
- No token values changed in `tokens.css`; only the documentation page and STYLE_GUIDE updated. Existing CSS that references `--logo-blue-*` aliases (none currently) remains valid.
- No new web requests; the owl images already exist at `/img/brand/owl-720.{webp,png}`.

## Rollback
Revert this PR. Branch: `content/brand-colors-owl-gold-refresh`.