### PR TITLE
Add green safe-side line + downward arrows under red line on PoE field note

### DIFF
--- a/content/field-notes/why-your-wireless-network-sucks.md
+++ b/content/field-notes/why-your-wireless-network-sucks.md
@@ -92,7 +92,12 @@ The category ratings are not marketing — they are defined by the ANSI/TIA-568.
 * **Cat5e:** rated to 100 MHz. Adequate only for 1 Gbps (1000BASE-T). Not future-ready; we discourage new installs.
 * **Cat6:** rated to 250 MHz. Supports 10GBASE-T at limited distances (up to ~55 m under the right conditions) [^11]. Cat6 remains acceptable for legacy data-only runs, and for light PoE Type 1/2 loads when bundle and thermal limits are validated; what it is *not* is the cable to design a new property around once that property starts collecting PoE cameras, PoE thermostats, PoE access points, and PoE++ gear in shared bundles. The reason is thermal: PoE current flowing through twisted-pair conductors produces I²R resistive heating, and the temperature rise inside a cable bundle is a function of bundle density, ambient temperature, and per-conductor resistance — variables that compound at the higher PoE classes. **TIA TSB-184-A** is the canonical industry document on bundle-temperature derating for power-over-cabling installations and provides the category and bundling guidance installers actually use [^14]; **IEEE 802.3bt-2018** defines the *power* envelope (Type 3 up to 60 W and Type 4 up to 90 W per port at the PSE) [^7], but the bundle-thermal math is TIA's territory, not IEEE's. The conservative engineering call for new PoE-dense installs is **Cat6A or better, every time.** <span class="red-line-text">Red line for modern PoE-rich smart-home builds — do not cross.</span>
 
-<hr class="red-line" role="separator" aria-label="Red line: do not cross — Cat6A and above are the modern smart-home minimum">
+<div class="red-green-pair">
+<hr class="red-line" role="separator" aria-label="Red line: do not cross — Cat5e and Cat6 sit above this line">
+<div class="red-green-arrows" aria-hidden="true">▼ ▼ ▼</div>
+<hr class="green-line" role="separator" aria-label="Green line: safe side — Cat6A and Cat8 are the modern PoE-rich minimum">
+<span class="red-green-caption">Safe side — Cat6A and Cat8 below</span>
+</div>
 
 * **Cat6A:** rated to 500 MHz. Full 10GBASE-T at the standard 100 m channel length, and supports the higher PoE classes (PoE++ up to 90 W per port at the PSE per IEEE 802.3bt) [^7].
 * **Cat8:** rated to 2000 MHz (2 GHz). Defined for 25GBASE-T and 40GBASE-T (IEEE 802.3bq) [^13] but **only at short distances — typically up to 30 m for the full 40 Gbps channel** [^11]. That is why Cat8 is found in data-center top-of-rack runs, high-end creative studios (8K video workflows), and demanding home-office runs that fit inside the 30-meter envelope.

--- a/sass/_custom.scss
+++ b/sass/_custom.scss
@@ -97,3 +97,56 @@ hr.red-line {
   color: var(--status-danger);
   font-weight: 700;
 }
+
+/* Green safety-line companion to .red-line. Used together as a
+   red-line / arrows / green-line stack to demonstrate visually which
+   side of the cable-category boundary is the safe specification.
+   Outer wrapper keeps the same 2em vertical breathing room as the
+   standalone red line; inner separators sit flush so the demonstration
+   reads as one block. */
+hr.green-line {
+  border: 0;
+  height: 6px;
+  background: var(--status-success);
+  margin: 2em 0;
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px rgba(63, 185, 80, 0.35);
+}
+
+.red-green-pair {
+  margin: 2em 0;
+}
+
+.red-green-pair hr.red-line,
+.red-green-pair hr.green-line {
+  margin: 0;
+}
+
+.red-green-pair .red-green-arrows {
+  display: block;
+  text-align: center;
+  color: var(--status-success);
+  font-size: 1.6rem;
+  line-height: 1;
+  letter-spacing: 0.5em;
+  padding: 0.55em 0 0.45em 0.5em; /* trailing pad balances letter-spacing */
+  user-select: none;
+  text-shadow: 0 0 8px rgba(63, 185, 80, 0.45);
+}
+
+.red-green-pair .red-green-caption {
+  display: block;
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--status-success);
+  margin-top: 0.55em;
+}
+
+/* Light-mode caption: --status-success (#3fb950) lacks WCAG AA contrast
+   on near-white surfaces, so step the caption text down to a deeper
+   forest green that hits ~5.5:1 against the off-white body. */
+html.switch .red-green-pair .red-green-caption {
+  color: #1f6b2a;
+}


### PR DESCRIPTION
## Why

The cabling-categories section in `why-your-wireless-network-sucks` already draws a red separator labeled *Red line for modern PoE-rich smart-home builds — do not cross* between the Cat5e/Cat6 bullets (above) and the Cat6A/Cat8 bullets (below). Owner asked to make the demonstration unambiguous: a green line should sit directly under the red, with arrows pointing downward, so the visual instantly conveys **stop above, go below**.

## What changed

### `content/field-notes/why-your-wireless-network-sucks.md`
- Wrap the existing red-line `<hr>` in a `.red-green-pair` container that also contains:
  - a centered row of three green downward arrows (`▼ ▼ ▼`, `aria-hidden`),
  - a matching `<hr class="green-line" role="separator">` with its own aria-label, and
  - a `Safe side — Cat6A and Cat8 below` caption.
- Tighten both separator aria-labels so they read together: red marks *Cat5e and Cat6 sit above this line*; green marks *Cat6A and Cat8 are the modern PoE-rich minimum*.

### `sass/_custom.scss`
- New `hr.green-line` mirroring `hr.red-line`: 6px tall bar in `var(--status-success)` (`#3fb950`), 3px radius, soft green ring shadow.
- New `.red-green-pair` wrapper: keeps the original 2em outer breathing room the standalone red line had; flushes the inner separators to `margin: 0` so the demonstration reads as a single block.
- New `.red-green-pair .red-green-arrows`: centered 1.6rem `▼` row in green with letter-spacing and a soft text-shadow halo for emphasis.
- New `.red-green-pair .red-green-caption`: bold green caption text under the green line.
- **Light-mode override** for the caption: `--status-success` (`#3fb950`) only hits ~2.6:1 on the off-white `html.switch` body (fails WCAG AA). Caption switches to `#1f6b2a` for ~5.5:1 contrast.

## Verification
Local Zola serve confirms the stack reads cleanly: red bar → 3 green ▼ arrows → green bar → green caption → Cat6A bullet starts immediately below. Token values unchanged; both colors come from the existing tokens.css `--status-success` / `--status-danger` families. CSP-safe — class-based styles only, no inline styles.

## Rollback
Revert this PR. Branch: `content/poe-cat6a-green-safe-line`.