### PR TITLE
SEO: stop ranking for 'computer repair la jolla' — remove repair-shop bigrams from the homepage FAQ

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -38,10 +38,10 @@ twitter_card        = "summary_large_image"
     },
     {
       "@type": "Question",
-      "name": "Do you fix cracked iPhone screens?",
+      "name": "Do you service physical device damage?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "No. We are not a hardware repair shop—we specialize in operating systems, software, networking, and data security. For existing clients, we can do a concierge replacement: pick up a factory-fresh iPhone from Apple and migrate your data on-site while you watch. Prefer glass replacement? We can refer you to a vetted local technician."
+        "text": "No. We work on operating systems, software, networking, and data security — not physical device damage. For existing clients, we offer a concierge device replacement: we pick up a factory-fresh iPhone from Apple and migrate your data on-site while you watch. For physical-screen work, we refer to a vetted local technician."
       }
     },
     {

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -61,9 +61,9 @@ Absolutely! Our primary expertise lies with **macOS and iOS support**, and we ex
 
 We take a different approach focused on transparency and on-demand support. Unlike many MSPs that lock clients into fixed monthly fees regardless of usage, **we believe you should only pay for IT help when needed.** There are no long-term contracts or arbitrary retainers with us – just fair, transparent billing for actual work performed. Think of it as having an elite IT team on call: we can essentially become part of your team on an as-needed basis. This flexible model saves you money and builds trust. Our goal is to resolve issues efficiently and effectively. We offer high-touch, on-demand IT support as an ethical alternative to the traditional MSP model.
 
-### Do you fix cracked iPhone screens?
+### Do you service physical device damage?
 
-**No, we’re not a hardware repair shop.** We specialize in operating systems, software, networking, and data security. For existing clients with a cracked screen, **we offer a concierge replacement:** we pick up a factory-fresh iPhone from Apple, meet you on-site, and migrate your data while you watch. Your phone never leaves your side, so your contacts and sensitive info stay shielded from prying eyes. Prefer a glass replacement? We’ll refer you to a vetted local technician.
+**No — we work on operating systems, software, networking, and data security, not physical device damage.** For existing clients who need a new device, **we offer a concierge replacement:** we pick up a factory-fresh iPhone from Apple, meet you on-site, and migrate your data while you watch. Your phone never leaves your side, so your contacts and sensitive info stay shielded from prying eyes. For physical-screen work, we refer you to a vetted local technician.
 
 ---
 


### PR DESCRIPTION
## What
Stop ranking for the consumer intent **"computer repair la jolla"** in Ahrefs (and any other bag-of-words SERP classifier) by removing the bait bigrams from the homepage FAQ.

## Why
We are a systems shop. We do not do hardware. But the homepage FAQ contained:

- `"Do you fix cracked iPhone screens?"` (the question itself)
- `"No. We are not a hardware repair shop ... Prefer glass replacement?"` (the answer)

Bag-of-words classifiers do not read the "No, we are not" in front of "hardware repair shop." They see the bigrams **"hardware repair"** + **"cracked iPhone screens"** + **"glass replacement"** on a page geo-tagged "La Jolla" everywhere (title, OG, JSON-LD `addressLocality`) and bucket us into the consumer **"computer repair la jolla"** intent — exactly the intent we explicitly deny.

## Fix
Rewrite the FAQ Q&A in both places without changing what we actually do or don't do:

| Before | After |
|---|---|
| Q: "Do you fix cracked iPhone screens?" | Q: "Do you service physical device damage?" |
| A: "No. We are not a hardware repair shop … Prefer glass replacement?" | A: "No. We work on operating systems, software, networking, and data security — not physical device damage. … For physical-screen work, we refer to a vetted local technician." |

Touched:
- `content/_index.md` — the FAQ JSON-LD `Question` / `Answer` strings
- `static/llms-full.txt` — the matching prose paragraph

## Verification
- `rg -i '\b(hardware repair|cracked|glass replacement|fix.{0,5}screen)\b'` across `content/`, `static/`, `templates/` → **zero matches** for the bait bigrams.
- Remaining `hardware` mentions are all legitimate and unrelated:
  - "**No hardware sales**" in the meta description (explicitly denies retail — keep)
  - "**hardware security key**" in field-note security context (Yubico/passkeys — keep)
  - "**enterprise networking hardware**" on `/services/` (Ubiquiti referral — keep)
- `zola build` → clean (Done in 354ms, 0 orphans, 0 broken anchors).
- Rendered `public/index.html` FAQ now reads `"name": "Do you service physical device damage?"`.

## Owner-law check
The corrected answer says exactly the same true thing as before — we don't service physical device damage, we offer concierge replacement for existing clients, we refer physical-screen work to a vetted local technician. No claim has been weakened, removed, or invented; only the consumer-search vocabulary has been swapped out so SERP classifiers stop misreading the page.