### PR TITLE
feat(seo): add /privacy/ + /contact/ pages, restore /blog/* link equity via aliases

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -2,6 +2,7 @@
 title = "Our Expertise"
 description = "Learn about Carey Balboa, the founder of IT Help San Diego, with 27 years of experience providing expert, ethical IT support."
 path = "about"
+aliases = ["/about-us/"]
 render = true
 template_macros = ["macros/images.html"]
 

--- a/content/billing.md
+++ b/content/billing.md
@@ -2,6 +2,11 @@
 title: Rates & Billing Policies
 description: "Transparent IT support rates ($275/hour, On-site 1-hour minimum, Remote 30-min minimum), billing policies, payment terms, and our commitment to ethical service."
 path: billing
+aliases:
+  - /terms/
+  - /terms-of-service/
+  - /tos/
+  - /pricing/
 extra:
   skip_image: true
   skip_author: true

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,56 @@
++++
+title = "Contact"
+description = "Phone, scheduling, address, hours, and security contact for IT Help San Diego Inc. La Jolla and San Diego County."
+path = "contact"
+aliases = ["/contact-us/", "/support/"]
+
+[extra]
+skip_image = true
+skip_author = true
++++
+
+## Book an appointment
+
+The fastest way to start is to book directly. Tell us what you're
+dealing with and pick a time.
+
+[Schedule an appointment →](https://schedule.it-help.tech/)
+
+## Call
+
+**(619) 853-5008** — answered during business hours.
+[Tap to call](tel:+16198535008)
+
+For existing clients: short questions of ten minutes or less are not
+billed. See [Rates & Billing](/billing/) for the full policy.
+
+## Address
+
+IT Help San Diego Inc.  
+888 Prospect Street, Suite 200  
+La Jolla, CA 92037
+
+[Open in Google Maps](https://maps.app.goo.gl/hXw49HPZZkWU7s5E9)
+
+## Hours
+
+By appointment, seven days a week — Monday through Sunday, 8:00 AM to
+8:00 PM Pacific.
+
+## Service area
+
+La Jolla and San Diego County. Out-of-area engagements are available by
+prior arrangement; see the travel policy on the
+[Rates & Billing](/billing/) page.
+
+## Security disclosures
+
+For responsible disclosure of security vulnerabilities in systems we
+operate, email `security@it-help.tech`. Full procedure on the
+[Security Policy](/security-policy/) page.
+
+## What we don't do
+
+We don't take general inquiries by chat widget, contact form, or
+unsolicited email blast. We don't have a sales line. We don't take
+walk-ins. The phone and the scheduling page are the front door.

--- a/content/field-notes/_index.md
+++ b/content/field-notes/_index.md
@@ -3,6 +3,7 @@ title = "IT Help San Diego Field Notes | Tech Insights & Support Stories"
 description = "Field Notes from IT Help San Diego: practitioner write-ups on macOS, iOS, Wi‑Fi, DNS, email deliverability, DMARC, and cybersecurity."
 sort_by = "date"
 template = "field-notes.html"
+aliases = ["/blog/"]
 
 [extra]
 seo_title = "IT Help Field Notes"

--- a/content/field-notes/apple-sends-you-to-ijail.md
+++ b/content/field-notes/apple-sends-you-to-ijail.md
@@ -6,6 +6,8 @@ author: Carey Balboa
 categories: [Apple, Google, Security, Passwords]
 tags: [Apple Account, Google Account, password reset, account recovery, security keys, passkeys, metacognition, tip of the tongue]
 description: "Why repeated wrong-password guessing locks you out of Apple and Google, what the cognitive science says about your sense of 'almost knowing it,' and the protocol that keeps you out of iJail."
+aliases:
+  - /blog/apple-sends-you-to-ijail/
 extra:
   seo_title: "Apple and Google Account Lockouts: The Don't-Guess-Wrong Protocol"
   image: images/wrong-password.png

--- a/content/field-notes/dns-security-best-practices.md
+++ b/content/field-notes/dns-security-best-practices.md
@@ -6,6 +6,8 @@ author: Carey Balboa
 categories: [DNS Security, Email Security]
 tags: [DMARC, SPF, DKIM, DNSSEC, MTA-STS, TLS-RPT, DANE, BIMI, email deliverability, cybersecurity, BEC, IC3, threat model]
 description: "Configure and verify SPF, DKIM, DMARC, MTA-STS, TLS-RPT, DANE, and DNSSEC to defensibly reduce spoofing, phishing, and BEC risk — with primary-source citations to every standard the controls depend on."
+aliases:
+  - /blog/dns-security-best-practices/
 extra:
   seo_title: "DMARC, SPF & DKIM Security Guide"
   image: /images/dns-security-dmarc.png

--- a/content/field-notes/hack-your-engrams-to-remember-passwords.md
+++ b/content/field-notes/hack-your-engrams-to-remember-passwords.md
@@ -6,6 +6,8 @@ author: Carey Balboa
 categories: [Security, Passwords]
 tags: [passphrase, password security, NIST, memory, negativity bias, engram, passkeys]
 description: "Use the neuroscience of emotional memory to build long passphrases that satisfy NIST SP 800-63B-4 and that you would never type in front of the people standing behind you."
+aliases:
+  - /blog/hack-your-engrams-to-remember-passwords/
 extra:
   image: images/engram-hack.png
   og_title: "Hack Your Engrams: Memorable Passphrases That Stay Private"

--- a/content/field-notes/it-problem-solving-scientific-method.md
+++ b/content/field-notes/it-problem-solving-scientific-method.md
@@ -6,6 +6,8 @@ author: Carey Balboa
 categories: [Consulting, Troubleshooting, Methodology]
 tags: [scientific method, IT consulting, problem solving, diagnostic reasoning, cognitive bias, falsifiability, Cynefin, postmortem]
 description: "How a working adaptation of the scientific method — grounded in Popper, Peirce, and the medical diagnostic-error literature — defeats the cognitive biases that derail most IT troubleshooting."
+aliases:
+  - /blog/it-problem-solving-scientific-method/
 extra:
   seo_title: "IT Problem-Solving as Hypothesis-Driven Inquiry"
   image: images/it-problem-solving-scientific-method.webp

--- a/content/field-notes/mac-cybersecurity-threats.md
+++ b/content/field-notes/mac-cybersecurity-threats.md
@@ -6,6 +6,8 @@ author: Carey Balboa
 categories: [Apple, Security, Cybersecurity]
 tags: [macOS, iOS, cybersecurity, malware, phishing, Apple security, endpoint protection, EDR, LuLu, ManageEngine, Pegasus, threat model, XProtect, Lockdown Mode, Stolen Device Protection]
 description: "What Apple's built-in stack (XProtect, XProtect Remediator, Gatekeeper, Notarization) actually defends against on macOS, where the real gaps are, and the practical Magic Combo — ManageEngine Security Edition plus LuLu — that closes them on real client machines."
+aliases:
+  - /blog/mac-cybersecurity-threats/
 extra:
   seo_title: "Mac Cybersecurity Threats: The Real Magic Combo"
   image: images/mac-cybersecurity.jpeg

--- a/content/field-notes/why-your-wireless-network-sucks.md
+++ b/content/field-notes/why-your-wireless-network-sucks.md
@@ -6,6 +6,8 @@ author: Carey Balboa
 categories: [Networking, WiFi, IT Infrastructure]
 tags: [ethernet, wifi, wi-fi 6, wi-fi 7, networking, home networking, office networking, cat6a, cat8, mesh, csma-ca, shannon, ubiquiti, poe]
 description: "Wireless degrades like a photocopy of a photocopy — and the physics of half-duplex CSMA/CA, Shannon-Hartley capacity, and retransmit compounding explains why. Here is how an Ethernet backbone, proper Cat6A/Cat8 cabling, and (sometimes) modern Wi-Fi 6/7 with wired backhaul actually deliver the speed you are paying for to your endpoint."
+aliases:
+  - /blog/why-your-wireless-network-sucks/
 extra:
   image: images/sad-wifi-extender.png
   og_title: "Why Your Wireless Network Sucks: Copy of a Copy, and the Ethernet Backbone That Fixes It"

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,134 @@
++++
+title = "Privacy"
+description = "What this website does and doesn't collect, how client data is handled during engagements, and our 27-year record on data ethics."
+path = "privacy"
+aliases = ["/privacy-policy/"]
+
+[extra]
+skip_image = true
+skip_author = true
++++
+
+## What this website does
+
+This site is a static collection of pages. There is no application, no
+account system, no comment system, no newsletter form, and no shopping
+cart. You read it; you leave; nothing follows you out.
+
+## What this website does not do
+
+We do not set cookies. We do not run analytics. We do not load Google
+Analytics, Google Tag Manager, Facebook Pixel, Plausible, Fathom,
+Hotjar, or any other measurement script. We do not embed any
+third-party tracking widgets. We do not feed visitor data to ad
+networks, marketing platforms, AI training pipelines, or data brokers.
+We do not sell, rent, or share any visitor information with anyone, for
+any purpose, ever.
+
+You can verify this in your browser's developer tools. Open Network and
+reload the page. Every request goes to `it-help.tech` or its own
+subdomains. No third parties.
+
+## What our infrastructure sees
+
+This site is served by Amazon CloudFront in front of an Amazon S3 bucket.
+For DDoS protection and access logging, CloudFront and S3 record
+standard request metadata — IP address, timestamp, requested path,
+user-agent string, response code. We do not query those logs for
+analytics, audience profiling, or marketing purposes. They exist to
+keep the site reachable and to investigate abuse if it occurs.
+
+## How we handle client data during engagements
+
+The honest version, because anything else would be a fairy tale:
+
+**Every modern IT firm uses third-party tools.** The Mac on the desk is
+third-party. iCloud is third-party. Google Workspace is third-party.
+The encrypted password vault is third-party. Anyone telling you "we
+never touch third-party storage" is either lying or running a
+typewriter. The real questions are: *what is stored where, who can read
+it, and what are they allowed to do with it.* Our answers:
+
+- **Personally identifying information (PII) is encrypted and
+  isolated.** Passwords, credentials, payment information, account
+  recovery keys, and other deeply sensitive material live in
+  end-to-end encrypted vaults that only we can decrypt. Vendors do not
+  see them. AI services do not see them. No one outside the engagement
+  sees them.
+- **Technical work product is worked on without client-identifying
+  context.** When a network configuration, a DNS issue, or a
+  troubleshooting question goes into an AI assistant for analysis, the
+  client's name and identifying details are not part of the question.
+  The tools see "this is the network topology I need to debug," not
+  "this belongs to so-and-so."
+- **Tools we use are configured to not train on customer data.** Where
+  a vendor offers an opt-out from model training, we take it. Where a
+  vendor will not offer that opt-out, we don't use the tool for
+  client work.
+- **No data goes to ad networks, marketing platforms, or data brokers.**
+  Ever.
+- **We don't share client data with vendors, marketers, or referral
+  partners, and we accept no commissions, kickbacks, or affiliate
+  fees.** There is no commercial incentive to disclose anything.
+- **We do not speak with media or third parties about client matters.**
+  Not journalists. Not paparazzi. Not "industry analysts." Not anyone.
+  Period.
+- **For sensitive legal work** — eDiscovery, iMessage extractions for
+  law firms, and similar — the work is done **on-site, on your
+  equipment**, so the data never leaves your office. We document the
+  workflow on first engagement and train your staff so future
+  extractions can be done in-house.
+
+## Our track record
+
+We have served high-profile and security-sensitive clients for over
+twenty-seven years. For long-standing clients, that includes holding
+credentials, payment information, and other deeply sensitive material
+under strong encryption that only we can decrypt. **We have never had a
+breach. We have never had a leak. We have never spoken about a client to
+a journalist, a paparazzi, or any third party.** That track record
+exists because of how the work is structured, and the same clients have
+referred us to other clients on the strength of it for nearly three
+decades.
+
+## What we record, and what we tell you about it
+
+When you call our main line, the recorded greeting tells you: *"All
+calls are transcribed by AI to help us provide better service."* That's
+not a tagline — it's a disclosure under California's two-party consent
+law (Penal Code § 632). The transcript is used to keep accurate notes
+of what we discussed. It is not shared, not sold, and not used for
+marketing.
+
+When we're on-site at your home or office, we sometimes use a meeting
+transcription tool (Fireflies.ai) so the technical decisions made in
+the room are documented and can be referred back to. We turn it on
+visibly and walk you through it before it starts. The transcript becomes
+part of the engagement record. If you'd rather we don't transcribe a
+particular visit or conversation, tell us and we don't.
+
+## Recommendations are independent
+
+We don't sell products and we don't accept commissions, affiliate fees,
+or kickbacks. Recommendations are made on technical merit. You purchase
+hardware and software directly from the vendor at vendor pricing. See
+[Rates & Billing](/billing/) for the full ethics statement.
+
+## Reporting a security issue
+
+For vulnerability disclosures or security incidents involving systems
+we operate, see the [Security Policy](/security-policy/) or email
+`security@it-help.tech`.
+
+## Contact
+
+For questions about this policy or about how your data has been handled
+during an engagement, call **(619) 853-5008** or use the contact methods
+on the [Contact page](/contact/).
+
+---
+
+*This page describes the practices of IT Help San Diego Inc. for the
+website at `it-help.tech`. The DNS Tool web app at
+`dnstool.it-help.tech` has its own privacy disclosure at
+[dnstool.it-help.tech/privacy](https://dnstool.it-help.tech/privacy).*

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -22,8 +22,12 @@ Analytics, Google Tag Manager, Facebook Pixel, Plausible, Fathom,
 Hotjar, or any other measurement script. We do not embed any
 third-party tracking widgets. We do not feed visitor data to ad
 networks, marketing platforms, AI training pipelines, or data brokers.
-We do not sell, rent, or share any visitor information with anyone, for
-any purpose, ever.
+We do not sell, rent, or share visitor information with anyone, for any
+purpose. The only exception that could ever change that is a valid
+court order — in which case we would comply with the order, tell the
+truth under oath, and notify the affected party to the extent the law
+permits. That's it. There is no other circumstance under which your
+information leaves this site.
 
 You can verify this in your browser's developer tools. Open Network and
 reload the page. Every request goes to `it-help.tech` or its own
@@ -40,21 +44,23 @@ keep the site reachable and to investigate abuse if it occurs.
 
 ## How we handle client data during engagements
 
-The honest version, because anything else would be a fairy tale:
+Every IT firm runs on tools made by other companies — laptops,
+operating systems, cloud storage, encrypted password vaults,
+accounting software. The question worth asking isn't "do you use
+third-party tools" — every honest answer is yes. The questions worth
+asking are *what is stored where, who can read it, and what are they
+allowed to do with it.* Our answers:
 
-**Every modern IT firm uses third-party tools.** The Mac on the desk is
-third-party. iCloud is third-party. Google Workspace is third-party.
-The encrypted password vault is third-party. Anyone telling you "we
-never touch third-party storage" is either lying or running a
-typewriter. The real questions are: *what is stored where, who can read
-it, and what are they allowed to do with it.* Our answers:
-
-- **Personally identifying information (PII) is encrypted and
-  isolated.** Passwords, credentials, payment information, account
+- **Personally identifying information (PII) is encrypted with keys
+  only we hold.** Passwords, credentials, payment information, account
   recovery keys, and other deeply sensitive material live in
-  end-to-end encrypted vaults that only we can decrypt. Vendors do not
-  see them. AI services do not see them. No one outside the engagement
-  sees them.
+  zero-knowledge encrypted vaults. The vault vendor's servers host the
+  encrypted blobs; the vendor cannot decrypt them and has no way to
+  read them. **In nearly three decades, we have never had to tell a
+  client that a tool we use was breached** — because we deliberately
+  choose tools with stronger security track records than the industry
+  average, and we revisit that choice every time a new disclosure
+  surfaces.
 - **Technical work product is worked on without client-identifying
   context.** When a network configuration, a DNS issue, or a
   troubleshooting question goes into an AI assistant for analysis, the
@@ -89,16 +95,20 @@ breach. We have never had a leak. We have never spoken about a client to
 a journalist, a paparazzi, or any third party.** That track record
 exists because of how the work is structured, and the same clients have
 referred us to other clients on the strength of it for nearly three
-decades.
+decades. If anything were ever to change about that — a breach, a legal
+compulsion to disclose, a policy change — affected clients would be
+told directly, in writing, before any other communication.
 
 ## What we record, and what we tell you about it
 
 When you call our main line, the recorded greeting tells you: *"All
 calls are transcribed by AI to help us provide better service."* That's
-not a tagline — it's a disclosure under California's two-party consent
-law (Penal Code § 632). The transcript is used to keep accurate notes
-of what we discussed. It is not shared, not sold, and not used for
-marketing.
+an audible consent notice. California Penal Code § 632 requires both
+parties to consent to the recording of confidential communications, and
+an audible notice on connect — combined with continuing the call — is
+how every California business handles this, from rideshare to banking.
+The transcript is used to keep accurate notes of what we discussed. It
+is not shared, not sold, and not used for marketing.
 
 When we're on-site at your home or office, we sometimes use a meeting
 transcription tool (Fireflies.ai) so the technical decisions made in

--- a/templates/partials/_footer-org.html
+++ b/templates/partials/_footer-org.html
@@ -108,14 +108,15 @@
         <div class="ftr-cell">
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-shield"/></svg> Trust</span>
             <a href="/security-policy" class="ftr-link">Security Policy</a>
+            <a href="/privacy" class="ftr-link">Privacy</a>
             <a href="/billing" class="ftr-link">Billing &amp; Pricing</a>
             <a href="/full-day-engagements" class="ftr-link">Full-Day Engagements</a>
-            <a href="https://dnstool.it-help.tech/privacy" target="_blank" rel="noopener" class="ftr-link">Privacy</a>
             <a href="/brand-colors" class="ftr-link">Brand Colors</a>
         </div>
         <div class="ftr-cell">
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-building"/></svg> Company</span>
             <a href="/about" class="ftr-link">About</a>
+            <a href="/contact" class="ftr-link">Contact</a>
             <a href="https://schedule.it-help.tech" target="_blank" rel="noopener" class="ftr-link">Schedule</a>
             <a href="tel:+16198535008" class="ftr-link">(619) 853-5008</a>
             <a href="https://github.com/IT-Help-San-Diego" target="_blank" rel="noopener" class="ftr-link">GitHub Org</a>


### PR DESCRIPTION
## Summary

  Closes the E-E-A-T gap on missing default pages and stops the link-equity bleed from PR #573's silent `/blog/` → `/field-notes/` rename (commit `4c6c791`, 2026-04-18) which left no forwarding addresses for the six pre-rename posts that already had external backlinks.

  ## Why now

  External tester confirmed (after correcting an earlier "bot block" misdiagnosis caused by a workspace-side firewall) that:

  - Production allows all UAs (verified for default curl, empty UA, Googlebot, AhrefsBot, GPTBot, ClaudeBot, PerplexityBot — all return HTTP 200).
  - `/blog/dns-security-best-practices/` is genuinely 403 and is being linked to from external referring domains.
  - `/contact`, `/privacy`, `/terms`, `/about-us` all 403 because the URLs simply don't exist; Google rater guidelines specifically expect accessible privacy and contact pages.

  This PR fixes both classes of finding.

  ## What this PR does

  ### New pages

  | Path | File | Notes |
  |------|------|-------|
  | `/privacy/` | `content/privacy.md` | Zero-tracker disclosure; honest taxonomy of third-party tools used during engagements with controls applied to each; 27-year track record (no client names); AI-transcription disclosure citing California Penal Code § 632. Aliases: `/privacy-policy/`. |
  | `/contact/` | `content/contact.md` | Phone, scheduling, NAP, hours (Mon–Sun 8am–8pm by appointment), service area (La Jolla + San Diego County, no geo expansion), security disclosure path. Aliases: `/contact-us/`, `/support/`. |

  ### Aliases on existing pages

  Zola front-matter `aliases` generate `public/<old-path>/index.html` stubs containing `<meta http-equiv="refresh">` plus `<link rel="canonical">` to the canonical URL. Google treats this as a soft 301 and consolidates link equity onto the canonical URL within a few crawl cycles.

  | File | Aliases added |
  |------|---------------|
  | `content/about.md` | `/about-us/` |
  | `content/billing.md` | `/terms/`, `/terms-of-service/`, `/tos/`, `/pricing/` |
  | `content/field-notes/apple-sends-you-to-ijail.md` | `/blog/apple-sends-you-to-ijail/` |
  | `content/field-notes/dns-security-best-practices.md` | `/blog/dns-security-best-practices/` |
  | `content/field-notes/hack-your-engrams-to-remember-passwords.md` | `/blog/hack-your-engrams-to-remember-passwords/` |
  | `content/field-notes/it-problem-solving-scientific-method.md` | `/blog/it-problem-solving-scientific-method/` |
  | `content/field-notes/mac-cybersecurity-threats.md` | `/blog/mac-cybersecurity-threats/` |
  | `content/field-notes/why-your-wireless-network-sucks.md` | `/blog/why-your-wireless-network-sucks/` |

  The seventh field-notes post (`the-real-bot-hasnt-been-built-yet`, PR #616) is intentionally **not** aliased because it is brand new and never lived at `/blog/` before the rename.

  ### Footer (`templates/partials/_footer-org.html`)

  - **Trust column**: replace stale `https://dnstool.it-help.tech/privacy` link (that was the DNS Tool app's privacy page, not the main site's) with `/privacy`. The DNS Tool privacy page is footnoted at the bottom of the new `content/privacy.md` so users arriving via either subdomain can find the right disclosure.
  - **Company column**: add `/contact` link.

  ## Verification

  - `zola build`: clean (Done in 94ms, 16 pages, 0 orphans, 0 broken anchors).
  - All 14 alias paths return HTTP 200 in dev preview with body containing both `<meta http-equiv="refresh">` and `<link rel="canonical">` pointing to the canonical URL.
  - Privacy and Contact pages render with all expected H2 sections.
  - Zero new third-party requests verified via Network tab on the rendered pages.

  ## Out of scope (deferred)

  - **CloudFront 403 → 404 mapping** for the long tail of guessed paths (`/wp-admin/`, etc.) is a console-side change against the Distribution's Custom Error Responses, not in any IaC currently in this repo. Will be delivered as a runbook in a separate change.

  ## Independence from other open PRs

  - PR #616 (manifesto field note): independent, no file overlap.
  - PR #618 (SEO no-repair-bigrams): independent, no file overlap; this PR is rebased off `origin/main` and does not depend on #618.
  