### PR TITLE
footer: bump "25+ Years Experience" -> "27+ Years Experience"

### DIFF
--- a/templates/partials/_footer-org.html
+++ b/templates/partials/_footer-org.html
@@ -100,7 +100,7 @@
         </div>
         <div class="ftr-cell">
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-microchip"/></svg> Expertise</span>
-            <a href="/about" class="ftr-link">25+ Years Experience</a>
+            <a href="/about" class="ftr-link">27+ Years Experience</a>
             <a href="/about#clients" class="ftr-link">High-Profile Clients</a>
             <a href="https://dnstool.it-help.tech" target="_blank" rel="noopener" class="ftr-link">Research Platform</a>
             <a href="/field-notes" class="ftr-link">Field Notes</a>


### PR DESCRIPTION
One-line copy fix.

Footer `Expertise` column was the lone outlier saying *"25+ Years Experience"*. Every other place that mentions the year count already says 27:

- `content/about.md` front-matter description: *"...with 27 years of experience..."*
- `content/about.md` JSON-LD `Person.description`: *"27+ years experience in IT support..."*
- `content/about.md` JSON-LD `WebPage.description`: *"...with 27 years of experience..."*
- `static/llms-full.txt`: *"With over 27 years of experience..."*
- `content/privacy.md` (just shipped in #619): *"served high-profile and security-sensitive clients for over twenty-seven years"* and *"nearly three decades"*

This change rode the back of #619 in dev (commit `671fd24` on the `seo/blog-aliases-privacy-contact` branch) but did not make the squash-merge — #619 was merged at HEAD `dcbaf6e` while the footer commit was still in flight. This PR delivers the missed one-liner cleanly.

## Verification

`zola build` clean. Rendered `public/index.html` now contains exactly one `27+ Years Experience` and zero `25+`.