### PR TITLE
robots: explicitly allow AhrefsBot and AhrefsSiteAudit

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -28,4 +28,9 @@ User-agent: Googlebot
 User-agent: Bingbot
 Allow: /
 
+# SEO Crawlers - explicitly allowed (site owner uses these tools)
+User-agent: AhrefsBot
+User-agent: AhrefsSiteAudit
+Allow: /
+
 Sitemap: https://www.it-help.tech/sitemap.xml


### PR DESCRIPTION
## What

Adds a new labeled `# SEO Crawlers - explicitly allowed` block to `static/robots.txt` for the two Ahrefs crawlers:

- `AhrefsBot` — general SEO indexing
- `AhrefsSiteAudit` — on-demand site audits triggered by the site owner

## Why

Site owner uses Ahrefs for SEO monitoring (the recent audit findings on robots-txt accessibility, redirect chains, and 3XX warnings all came from Ahrefs). An explicit `User-agent: ...  Allow: /` declaration makes intent crystal clear to:

- Future readers of the robots.txt source
- Anyone debugging crawl issues with sitebulb / screaming frog / etc.
- Ahrefs's own bot logic, which preferentially honors named directives over the wildcard

## Notes

- The default `User-agent: *  Allow: /` block at the top already permits these bots. The explicit declaration is **not** functionally required — it documents intent and gives Ahrefs a stable signal.
- Edits the live source: `static/robots.txt`. The theme template `themes/abridge/templates/robots.txt` is overridden by Zola's `static/` precedence and remains unused (out of scope to clean up here).
- Same explicit-allow style as the existing `# AI/LLM Search Bots` and `# Traditional Search Bots` groups.

## Verification

```
zola build  →  Done in 319ms.  (clean)
```

Rendered `public/robots.txt` now contains, in order:

1. `User-agent: *  Allow: /` (default)
2. AI/LLM Search Bots block
3. Traditional Search Bots block (Googlebot, Bingbot)
4. **SEO Crawlers block (new — AhrefsBot, AhrefsSiteAudit)** ← this PR
5. `Sitemap: https://www.it-help.tech/sitemap.xml`