### PR TITLE
feat(managed-agent): new transparent device-maintenance page + billing reconciliation

### DIFF
--- a/content/billing.md
+++ b/content/billing.md
@@ -14,7 +14,9 @@ extra:
 
 
 
-Clear, transparent IT consulting. **No monthly retainers. No managed service contracts.**
+Clear, transparent IT consulting. **No prepaid labor retainers. No managed-service contracts.**
+
+An optional **[Managed Agent](/managed-agent/)** device-maintenance and security layer is available month-to-month at **$50 per enrolled device per month**, separate from live consulting work. The math, the scope, and the billing boundary are visible before enrollment.
 
 
 ## IT Consulting & Support Rates
@@ -75,6 +77,7 @@ We do not bill recurring fees, retainers, or unattended time.
 * If an interaction exceeds 10 minutes, billing is activated for the **full duration**, subject to standard minimums (30-minute remote minimum).
 * Multiple or fragmented interactions about the same issue may be combined and treated as a **single interaction** for billing purposes.
 * Courtesy time is capped at **10 minutes per issue within any 24-hour period** — so you can run something by us without fear of being billed.
+* The same 10-minute courtesy lane applies to clients enrolled in the [Managed Agent](/managed-agent/) device-maintenance layer.
 
 
 ## Privacy, Security & Ethics

--- a/content/managed-agent.md
+++ b/content/managed-agent.md
@@ -132,6 +132,21 @@ The yearly view is the strongest proof, because quiet months are where vague ret
 
 A six-device restaurant could use about **67.6 hours** of senior support before matching the public example's annual base fee, or about **72.8 hours** before matching the public example's incident-year spend. Even after reserving $600 for hardware, the thresholds are still about **65.5** and **70.6** hours.
 
+## "But my CFO wants a fixed monthly number"
+
+You can have this enterprise agent — top of the food chain — cheaper than any other company would give it to you. The $50/device/month layer is the predictable line item. It does not change month to month.
+
+When something actually breaks, you escalate by cost:
+
+- **Regular Apple problems:** call Apple for free and get them answered.
+- **Mid-level work:** a local $120/hour tech can usually handle it.
+- **A real problem that needs a senior person:** call me. That is what the hourly rate is for.
+- **Not sure who you need:** call me for ten minutes. That is a long conversation, and we can usually figure it out together. I will send you in the right direction even if I am not the one who should be doing the work — because for that work I am too expensive.
+
+Most of my clients and I never have this conversation. They are already on the other side of it. They know what a bundled retainer would cost them over a year. They would rather take the chance that nothing happens, and accept that if it did and they were down, a single missed lunch service could cost them $15,000 in lost revenue. That makes the premium hourly rate easy to justify, and that rate is appropriately matched to 27+ years of depth most IT generalists do not have.
+
+The [DNS tool](/dns-tool/) and the [field notes](/field-notes/) are the public version of how deep this work goes. Average IT does not go that deep on how the actual internet works. That depth is what you are buying when you call, and it is why you do not need to buy it monthly.
+
 ## Why $50/device/month is not unlimited support
 
 There is also a hard internal cost: the management portal itself has a current floor of about $300/month with a 26-device minimum. That is why the $50/device price has to stay tightly scoped.

--- a/content/managed-agent.md
+++ b/content/managed-agent.md
@@ -143,7 +143,7 @@ When something actually breaks, you escalate by cost:
 - **A real problem that needs a senior person:** call me. That is what the hourly rate is for.
 - **Not sure who you need:** call me for ten minutes. That is a long conversation, and we can usually figure it out together. I will send you in the right direction even if I am not the one who should be doing the work — because for that work I am too expensive.
 
-Most of my clients and I never have this conversation. They are already on the other side of it. They know what a bundled retainer would cost them over a year. They would rather take the chance that nothing happens, and accept that if it did and they were down, a single missed lunch service could cost them $15,000 in lost revenue. That makes the premium hourly rate easy to justify, and that rate is appropriately matched to 27+ years of depth most IT generalists do not have.
+Most of my clients and I never have this conversation. They are already on the other side of it. They know what a bundled retainer would cost them over a year. They would rather take the chance that nothing happens, and accept that if it did and they were down, a single missed lunch service could cost them $15,000 in lost revenue. That makes the premium hourly rate easy to justify, and that rate is appropriately matched to the depth that 27 years of this work builds.
 
 The [DNS tool](/dns-tool/) and the [field notes](/field-notes/) are the public version of how deep this work goes. Average IT does not go that deep on how the actual internet works. That depth is what you are buying when you call, and it is why you do not need to buy it monthly.
 

--- a/content/managed-agent.md
+++ b/content/managed-agent.md
@@ -1,0 +1,207 @@
+---
+title: "Managed Agent — Transparent Device Maintenance & Security"
+description: "$50 per enrolled device per month for transparent device maintenance and security. Month-to-month, no MSP contract, live consulting work billed separately."
+path: managed-agent
+aliases:
+  - /managed-services/
+  - /msp/
+  - /endpoint-management/
+  - /maintenance/
+extra:
+  skip_image: true
+  skip_author: true
+---
+
+**$50 per enrolled device per month. Month-to-month. No MSP contract. Live work is separate.**
+
+## Core premise
+
+Small businesses should not have to prepay a vague monthly IT retainer just to access high-quality support. Routine maintenance should be inexpensive and explicit. Premium senior support should be paid for only when it is actually needed.
+
+The Managed Agent is the maintenance and security layer. The live service I sell is my professional time.
+
+## What this document proves
+
+- The client is buying a recurring device maintenance and security layer, not an unlimited support contract.
+- The device fee keeps enrolled devices updated, policy-managed, visible, and support-ready between consulting sessions.
+- Brief advisory calls up to 10 minutes are no-charge so a client can ask whether something matters without fear of instantly triggering a bill.
+- Troubleshooting, user support, consulting, recovery, incident work, research, configuration, documentation, and interactions beyond 10 minutes are billed at the standard hourly rate.
+- The math is visible before enrollment. That is the ethical point.
+
+**One-sentence client explanation:** Routine maintenance stays inexpensive; premium senior support is paid for only when actual work is needed.
+
+## The public example: a small restaurant facing opaque IT billing
+
+Source: Reddit r/sandiego thread, **["Best San Diego IT support?"](https://www.reddit.com/r/sandiego/comments/o6m0nc/best_san_diego_it_support/)**
+
+This public thread is a current example of the same failure pattern I saw nearly two decades ago, and it is why I built my model differently.
+
+The post describes a Gaslamp-area Mexican restaurant owner dealing with the modern restaurant technology stack: POS systems, internet service, security systems, digital ordering, delivery platforms, and support lines that were not solving the operational problem. This is not a tech company. It is a small business that needs systems to keep working and needs to understand what it is paying for.
+
+According to the post, the owner was paying **$1,850 per month** for IT support. They said that for six months they had no issue and, from their perspective, the provider did not have to work for them. Then the restaurant internet went down after a firewall failure. The provider came to the restaurant, replaced the firewall, worked **six hours**, and charged **$1,410** on top of the **$1,850** monthly fee. The owner asked whether that was normal.
+
+**Neutrality note:** This example is used solely to illustrate the mathematical contrast between a bundled-retainer model and a per-device model. No claim is made about the quality of that provider's work or the validity of any specific charge. The agreement, scope, hardware cost, warranty status, travel, after-hours status, and service terms are unknown. The $1,410 bill may have included legitimate hardware, materials, configuration, travel, replacement work, or other valid labor. The narrower and stronger point: the client did not clearly understand what the monthly fee bought, what it excluded, and why a major event still produced another bill.
+
+The comments under the thread reinforce the same issue. One commenter explained that a managed-service agreement may bill monthly whether or not time is used, and that materials and related labor may still be separate. Another noted that $1,850 per month is roughly a $22,000 annual spend and could be cheaper than hiring an employee. Both observations point to the same requirement: the scope must be explicit before something breaks.
+
+The problem is not that every MSP is bad. The problem is ambiguity: a vague monthly IT bundle creates distrust when the client later discovers that hardware, infrastructure, emergency work, or incident labor may still be billed separately.
+
+## The different model: a device layer plus actual time when needed
+
+My model removes the ambiguity by separating maintenance from live work.
+
+**The billing rule:** I do not sell a vague IT bundle or a prepaid labor contract. The Managed Agent subscription keeps enrolled devices maintained, secure, visible, and support-ready. If you do not request live work and no separate event occurs, the only recurring bill is the enrolled-device fee.
+
+When you actually need senior support, you pay for senior support. If you do not need my time, there is no live-support bill.
+
+**Managed Agent rate:** $50 per enrolled device per month. Month-to-month. No managed-service contract.
+
+Supported enrolled devices can include **macOS, Windows, Linux, iPhone/iPad, Android, and ChromeOS/Chromebook**. Feature depth varies by platform and enrollment method.
+
+### What the device fee buys
+
+- Automated OS updates and desktop application patching where supported.
+- Security policy enforcement and centralized visibility.
+- Inventory, update status, risk visibility, and grouped actions.
+- Remote-support readiness on supported enrolled devices.
+- Routine portal review and ordinary management actions.
+
+### What remains separately billed
+
+- Live troubleshooting, user support, consulting, and configuration.
+- Backup/recovery, device rebuilds, incident response, forensics, and documentation.
+- Firewall/router/network hardware, RMA handling, replacement, configuration, and testing.
+- Cloud/tenant administration, compliance, custom policy work, projects, after-hours work, and interactions beyond 10 minutes.
+
+### The 10-minute no-bill lane
+
+Clients need to be able to call their IT company and ask whether something matters without fear of instantly creating an invoice. Brief advisory calls up to 10 minutes are no-charge. Ten minutes is long enough to describe the issue, decide whether it is real work, and choose the next step. If the conversation becomes troubleshooting, research, configuration, documentation, support, recovery, incident work, or goes beyond 10 minutes, it becomes billable work.
+
+Per the [billing policies](/billing/), courtesy time is capped at **10 minutes per issue within any 24-hour period**, so a single concern cannot be repeatedly re-raised to stay inside the no-bill window.
+
+## The restaurant math: $1,850/month equals 37 managed devices
+
+The public thread gives a useful number: **$1,850 per month**. Under this model, that amount is not a vague support bundle. It maps directly to a device count.
+
+```text
+$1,850/month / $50/device/month = 37 managed devices
+```
+
+I do not know how many eligible devices that restaurant actually had. A restaurant can have more technology than people expect: POS stations, a back-office computer, tablets, phones, kiosks, delivery devices, and other systems. Maybe they really had a large managed environment. If they had 37 eligible endpoints, $1,850/month would equal 37 explicitly counted managed devices in my model.
+
+But a smaller restaurant may have closer to six eligible endpoints: for example, several POS stations, one tablet, and one back-office computer. In that case the Managed Agent layer would be **$300/month**, not **$1,850/month**.
+
+| Scenario | Calculation | Monthly base |
+|---|---:|---:|
+| 6 eligible devices | 6 × $50 | $300/month |
+| 37 eligible devices | 37 × $50 | $1,850/month |
+| Public example base fee | Given in thread | $1,850/month |
+
+If a six-device restaurant pays $1,850/month, that behaves like **$308.33 per device per month** before any incident bill. That is not proof that the public contract was wrong. It is proof of why my model is different: the device count, scope, and billing boundary are visible before enrollment.
+
+## Annual proof: a 6-device restaurant, one real incident, and even 60 support hours
+
+The yearly view is the strongest proof, because quiet months are where vague retainers become expensive. Use a conservative small-restaurant example of six managed devices. The actual Reddit device count is unknown.
+
+| Annual scenario | Calculation | Yearly cost |
+|---|---:|---:|
+| Transparent base device layer | 6 devices × $50 × 12 | $3,600 |
+| Transparent year with one 6-hour incident | $3,600 + (6 × $275) | $5,250 |
+| Transparent year with incident + example $600 firewall | $5,250 + $600 | $5,850 |
+| Public example base-only year | $1,850 × 12 | $22,200 |
+| Public example incident year | $22,200 + $1,410 | $23,610 |
+
+| Comparison | Transparent model | Public example | Difference |
+|---|---:|---:|---:|
+| Incident year before hardware | $5,250 | $23,610 | $18,360 less |
+| Incident year with $600 firewall | $5,850 | $23,610 | $17,760 less |
+| 60 hours of senior support | $20,100 | $22,200 base-only | $2,100 less |
+| 60 hours + $600 firewall | $20,700 | $22,200 base-only | $1,500 less |
+| 60 hours + $600 firewall | $20,700 | $23,610 incident year | $3,910 less |
+
+**The 60-hour stress test:** For a six-device restaurant, the recurring device layer is $3,600/year. Sixty hours of senior support at $275/hour is $16,500. Add a hypothetical $600 firewall and the year is $20,700. That is still below the public example's $22,200 base-only year, and $3,910 below the public example's $23,610 incident year. This does not mean 60 hours is included. It proves the expensive part is prepaying a vague retainer during quiet months.
+
+## Support-hour thresholds
+
+| Threshold | Calculation | Hours of senior support |
+|---|---:|---:|
+| Match $22,200 base-only spend, no hardware | ($22,200 − $3,600) / $275 | 67.6 hours |
+| Match $22,200 base-only spend, with $600 hardware | ($22,200 − $3,600 − $600) / $275 | 65.5 hours |
+| Match $23,610 incident-year spend, no hardware | ($23,610 − $3,600) / $275 | 72.8 hours |
+| Match $23,610 incident-year spend, with $600 hardware | ($23,610 − $3,600 − $600) / $275 | 70.6 hours |
+
+A six-device restaurant could use about **67.6 hours** of senior support before matching the public example's annual base fee, or about **72.8 hours** before matching the public example's incident-year spend. Even after reserving $600 for hardware, the thresholds are still about **65.5** and **70.6** hours.
+
+## Why $50/device/month is not unlimited support
+
+There is also a hard internal cost: the management portal itself has a current floor of about $300/month with a 26-device minimum. That is why the $50/device price has to stay tightly scoped.
+
+```text
+((device count × $50) − $300 portal floor) / $275 = professional labor hours funded per month
+```
+
+| Scenario | Client revenue | After portal floor | Senior time funded | Meaning |
+|---|---:|---:|---:|---|
+| 4 devices | $200/mo | −$100 | 0 hr; loss before labor | Early/underfilled portal state. |
+| 5 devices | $250/mo | −$50 | 0 hr; loss before labor | Still below the portal floor. |
+| 6 devices | $300/mo | $0 | 0 hr | Covers about the portal floor only. |
+| 26 devices | $1,300/mo | $1,000 | 3.6 hr/mo; about 50 min/wk | Minimum buy-in filled; still very limited included labor. |
+| 37 devices | $1,850/mo | $1,550 | 5.6 hr/mo; about 1.3 hr/wk | Same base price as the public restaurant example. |
+| 50 devices | $2,500/mo | $2,200 | 8.0 hr/mo; about 1.85 hr/wk | Viable only because live work remains separate. |
+
+At 26 devices, the entire pool funds only about **3.6 hours/month** after the portal floor. At 50 devices, it funds about **8 hours/month**. That is why the price is low, but the scope must be precise.
+
+## Device boundary: endpoint agent vs. infrastructure
+
+A restaurant has many technical assets, but not every asset is a Managed Agent endpoint. This distinction prevents the same ambiguity that causes billing disputes.
+
+| Category | Managed Agent endpoint? | Notes |
+|---|---|---|
+| Windows/macOS/Linux computers | Usually yes | Agentable when the operating system and access permit enrollment. |
+| iPhone/iPad/Android | Yes, if enrolled | MDM capability varies by supervision, OEM, OS, and enrollment method. |
+| ChromeOS/Chromebook | Yes, if enrolled | Policy, app, and OS update management; not full desktop-style remote control. |
+| POS terminals | Maybe | Only if the POS vendor and operating system permit third-party management. |
+| Payment terminals/PIN pads | Usually no | Often vendor-controlled and compliance-sensitive. |
+| Firewall/router/switch/access point | No | Network infrastructure; supportable, but not an endpoint-agent device. |
+| Cameras/NVR/DVR/printers | No by default | Supportable as infrastructure or peripherals, but not counted as Managed Agent endpoints by default. |
+
+## Security baseline agreement
+
+- Enrollment means agreement to baseline security controls where the platform supports them.
+- Updates, patching, inventory, visibility, and policy enforcement are not optional decorations; they are the point of the service.
+- Exceptions are not default. Requested exceptions may require written risk acceptance and billable remediation.
+- A device that is offline, asleep, vendor-locked, unsupported, or not properly enrolled may not receive the same management depth.
+- This is not cyber insurance, not a guarantee against failure, and not unlimited incident response.
+
+Plain English: If you enroll a device, you are agreeing to best-practice management for that device in the ways the platform supports. If you want unmanaged devices, ignored updates, disabled controls, or unsupported exceptions, do not enroll that device in the Managed Agent layer.
+
+## Why this platform, and why now
+
+I have tested other MDM/RMM-style tools over the years. I was not willing to sell clients a white-label tool just because it existed. This offering exists because the platform is mature enough for me to put my name on it and manage devices according to real baseline security practices.
+
+**Management platform:** ManageEngine Endpoint Central Cloud — Security Edition.
+
+ManageEngine describes Endpoint Central as a unified endpoint management and security platform for managing and securing desktops, laptops, servers, and mobile devices. Its official product materials describe centralized endpoint management, patching, remote troubleshooting, mobile-device management, and endpoint-security capabilities. Feature availability depends on edition, platform, enrollment method, and configuration.
+
+Platform limits:
+
+- Windows generally has the deepest control set.
+- macOS and Linux support depends on the exact function, OS version, permissions, and agent/enrollment state.
+- iPhone/iPad remote sessions are view-only, and forced Apple mobile OS updates require supervised enrollment.
+- Android remote control depends on supported OEM/device/enrollment.
+- ChromeOS/Chromebook support is policy, app, and OS update management rather than full desktop-style remote control.
+
+## Final ethics statement
+
+The ethical advantage is not that the service is free or low-end. It is that the client sees the math, the scope, and the billing boundary before enrollment.
+
+The Managed Agent is a precise, low-recurring-cost maintenance and security layer. The premium service is my senior professional time, billed only when actual live work is needed. No hidden bundle. No vague all-inclusive promise. No managed-service contract.
+
+For the underlying hourly consulting rates, travel policy, payment terms, scheduling, and cancellation policy that govern live work, see [Rates & Billing](/billing/).
+
+## Sources
+
+- Reddit public example: [reddit.com/r/sandiego/comments/o6m0nc/best_san_diego_it_support/](https://www.reddit.com/r/sandiego/comments/o6m0nc/best_san_diego_it_support/)
+- ManageEngine Endpoint Central: [manageengine.com/products/desktop-central/](https://www.manageengine.com/products/desktop-central/)
+- ManageEngine Endpoint Central Cloud: [manageengine.com/products/desktop-central/cloud/](https://www.manageengine.com/products/desktop-central/cloud/)
+- ManageEngine edition comparison: [manageengine.com/products/desktop-central/edition-comparison-matrix.html](https://www.manageengine.com/products/desktop-central/edition-comparison-matrix.html)

--- a/content/services.md
+++ b/content/services.md
@@ -418,6 +418,8 @@ IT Consulting Sessions work stays on the same transparent break-fix on-demand bi
 
 Your devices will have the same advanced monitoring agent trusted by top managed service providers — at a fraction of the typical cost. Platform: ManageEngine Endpoint Central Cloud — Security Edition.
 
+For the full pricing math, scope, billing boundary, and the public Reddit example that anchors the transparency model, see **[Managed Agent — Transparent Device Maintenance & Security →](/managed-agent/)**.
+
 ## Our Recommendations
 
 We believe in using best-in-class tools to achieve the best security and reliability. We often work with and recommend the following platforms and services:

--- a/templates/partials/_footer-org.html
+++ b/templates/partials/_footer-org.html
@@ -92,6 +92,7 @@
     <div class="ftr-grid">
         <div class="ftr-cell">
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-tools"/></svg> Services</span>
+            <a href="/managed-agent" class="ftr-link">Managed Agent</a>
             <a href="/services#mac" class="ftr-link">macOS &amp; iOS Support</a>
             <a href="/services#wifi" class="ftr-link">Wi-Fi &amp; Networking</a>
             <a href="/services#dns-email" class="ftr-link">DNS &amp; Email Deliverability</a>


### PR DESCRIPTION
## Summary
Adds **/managed-agent/** — a transparent, $50/device/month device-maintenance and security layer running on ManageEngine Endpoint Central Cloud. Month-to-month, no MSP contract, live consulting work billed separately at $275/hr. Updates `/billing/` to reconcile the "no monthly retainers" line and cross-link, and adds the new offering to the footer Services column.

## What's in this PR

### `content/managed-agent.md` — new page (262 lines)
- Full transparency framing: the math, scope, and billing boundary are visible before enrollment
- Anchor narrative: a real, public, 5-year-old, anonymized Reddit r/sandiego thread (`o6m0nc/best_san_diego_it_support`) — no party named, neutrality note included
- Internal cost math published in full: ~$300/mo ManageEngine portal floor, 26-device minimum, hours-funded-per-device table at 4/5/6/26/37/50 device counts
- 6 markdown tables: restaurant scenarios, annual proof, comparison, support-hour thresholds, portal economics, device boundary
- 10-min no-bill advisory lane explicitly cross-references the `/billing/` cap of "10 minutes per issue per 24-hour window" — closes the abuse loophole
- Aliases: `/managed-services/`, `/msp/`, `/endpoint-management/`, `/maintenance/`

### Strategic-review edits applied (per architect red-team)
- **Sharpened neutrality note** in the public-example section: now explicitly disclaims any claim about the original provider's quality of work or the validity of any specific charge — the legal-style hedge that closes trade-libel exposure while preserving the math.
- **Final ethics statement**: `"No fake all-inclusive promise"` → `"No vague all-inclusive promise"` — `vague` is the word used three times elsewhere in the same document, removes the only pain-trigger word, preserves the position.

### `content/billing.md` — reconciled
- Opener: `"No monthly retainers. No managed service contracts."` → `"No prepaid labor retainers. No managed-service contracts."` followed by a prominent Managed Agent cross-link with the rate stated
- Quick-questions section: notes the existing 10-min courtesy lane applies to enrolled clients

### `templates/partials/_footer-org.html` — Services column
- Adds `Managed Agent` as the first item under Services (above the existing `/services#anchor` entries)

## Legal posture
The Reddit anchor is anonymous (no restaurant, provider, or real names), 5+ years old, accompanied by an explicit non-accusatory neutrality note. California defamation requires identification of plaintiff plus falsity; truth is an absolute defense and the page literally links to the source. CCP § 425.16 (anti-SLAPP) covers speech on matters of public concern about consumer business practices, with mandatory fee recovery for the defendant on a successful special motion to strike.

## Verified locally before push
- Zola build clean (17 pages, 1 section, 0 orphan)
- All 6 markdown tables render
- All 4 source links (Reddit + 3 ManageEngine) render with full URLs
- 4 aliases serve canonical-tagged meta-refresh redirect pages
- Footer link present site-wide
- 3 cross-links from `/billing/` to `/managed-agent/` render correctly