### PR TITLE
fix(csp): remove inline style attributes blocking strict style-src 'self' on /managed-agent/ and /field-notes/dns-security-best-practices/

### DIFF
--- a/content/field-notes/dns-security-best-practices.md
+++ b/content/field-notes/dns-security-best-practices.md
@@ -59,7 +59,7 @@ Here is a DNS Tool record snapshot from CISA (Cybersecurity and Infrastructure S
 <img
   src="/images/cisa-dns.png"
   alt="DNS Tool record showing CISA DMARC, SPF, and DKIM enforcement"
-  style="width: 520px !important; max-width: 100% !important; height: auto; margin: 0 auto; display: block;"
+  class="img-centered-520"
   loading="lazy"
   decoding="async">
 

--- a/content/managed-agent.md
+++ b/content/managed-agent.md
@@ -92,7 +92,7 @@ I do not know how many eligible devices that restaurant actually had. A restaura
 But a smaller restaurant may have closer to six eligible endpoints: for example, several POS stations, one tablet, and one back-office computer. In that case the Managed Agent layer would be **$300/month**, not **$1,850/month**.
 
 | Scenario | Calculation | Monthly base |
-|---|---:|---:|
+|---|---|---|
 | 6 eligible devices | 6 × $50 | $300/month |
 | 37 eligible devices | 37 × $50 | $1,850/month |
 | Public example base fee | Given in thread | $1,850/month |
@@ -104,7 +104,7 @@ If a six-device restaurant pays $1,850/month, that behaves like **$308.33 per de
 The yearly view is the strongest proof, because quiet months are where vague retainers become expensive. Use a conservative small-restaurant example of six managed devices. The actual Reddit device count is unknown.
 
 | Annual scenario | Calculation | Yearly cost |
-|---|---:|---:|
+|---|---|---|
 | Transparent base device layer | 6 devices × $50 × 12 | $3,600 |
 | Transparent year with one 6-hour incident | $3,600 + (6 × $275) | $5,250 |
 | Transparent year with incident + example $600 firewall | $5,250 + $600 | $5,850 |
@@ -112,7 +112,7 @@ The yearly view is the strongest proof, because quiet months are where vague ret
 | Public example incident year | $22,200 + $1,410 | $23,610 |
 
 | Comparison | Transparent model | Public example | Difference |
-|---|---:|---:|---:|
+|---|---|---|---|
 | Incident year before hardware | $5,250 | $23,610 | $18,360 less |
 | Incident year with $600 firewall | $5,850 | $23,610 | $17,760 less |
 | 60 hours of senior support | $20,100 | $22,200 base-only | $2,100 less |
@@ -124,7 +124,7 @@ The yearly view is the strongest proof, because quiet months are where vague ret
 ## Support-hour thresholds
 
 | Threshold | Calculation | Hours of senior support |
-|---|---:|---:|
+|---|---|---|
 | Match $22,200 base-only spend, no hardware | ($22,200 − $3,600) / $275 | 67.6 hours |
 | Match $22,200 base-only spend, with $600 hardware | ($22,200 − $3,600 − $600) / $275 | 65.5 hours |
 | Match $23,610 incident-year spend, no hardware | ($23,610 − $3,600) / $275 | 72.8 hours |
@@ -155,7 +155,7 @@ There is also a hard internal cost: the management portal itself has a current f
 ```
 
 | Scenario | Client revenue | After portal floor | Senior time funded | Meaning |
-|---|---:|---:|---:|---|
+|---|---|---|---|---|
 | 4 devices | $200/mo | −$100 | 0 hr; loss before labor | Early/underfilled portal state. |
 | 5 devices | $250/mo | −$50 | 0 hr; loss before labor | Still below the portal floor. |
 | 6 devices | $300/mo | $0 | 0 hr | Covers about the portal floor only. |

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -1563,3 +1563,14 @@ html:not(.switch) h6 a.gold-link:active {
     .how-we-work { grid-template-columns: 1fr 1fr; gap: 0.75rem; }
     .how-we-work .hww-card { break-inside: avoid; border-color: currentColor; }
 }
+
+/* CSP-safe replacement for inline image styling. Used by content/field-notes/dns-security-best-practices.md
+   for the CISA DNS Tool screenshot. Adding the class keeps the visual (centered, capped at 520px,
+   responsive) without inline style="..." which would violate strict style-src 'self'. */
+img.img-centered-520 {
+    width: 520px;
+    max-width: 100%;
+    height: auto;
+    margin: 0 auto;
+    display: block;
+}


### PR DESCRIPTION
**Production CSP regression fix.** Strict `style-src 'self'` was blocking 60+ inline `style="text-align:right"` attributes on `/managed-agent/` and 1 hand-authored inline style on `/field-notes/dns-security-best-practices/`. CSP hashes do not apply to `style="..."` attributes (only to `<style>` blocks) without `'unsafe-hashes'`, which would be a security regression — so the fix is to remove the inline styles, not to relax CSP.

## Root causes

### 1. `content/managed-agent.md` — markdown right-align tables
5 tables used right-align syntax (`|---:|`). pulldown-cmark renders that as `<th align="right">`, and `minify_html = true` then upgrades the deprecated HTML4 `align` attribute to inline `style="text-align:right"`. With the strict `style-src 'self'` CSP, every cell in those tables triggers a violation.

**Fix:** dropped the colon from the 5 alignment markers (`|---:|` → `|---|`). Currency columns are now left-aligned, which is fine for narrative tables. No infrastructure change required.

### 2. `content/field-notes/dns-security-best-practices.md` — hand-authored inline style
One `<img>` for the CISA DNS Tool screenshot carried an inline `style="width: 520px !important; max-width: 100% !important; height: auto; margin: 0 auto; display: block;"`.

**Fix:** replaced the inline style with `class="img-centered-520"` + a matching utility class in `static/css/late-overrides.css`. Visual is preserved exactly (centered, capped at 520px, responsive).

## Verification
- `zola build` clean (~463 ms)
- `/managed-agent/` served HTML: 0 inline `style=` (was 60+)
- `/field-notes/dns-security-best-practices/` served HTML: 0 inline `style=` (was 1)
- Full-site sweep (`rg -l 'style=' public/`): only signature pages still carry inline styles, which is intentional — `infra/cloudfront/generate_policy.py:build_signatures_csp` allows `'unsafe-inline'` on style-src for email-client paste compatibility.
- No other content files use right-align table syntax or hand-authored inline styles.

## Why not just hash the styles?
The browser report itself notes: *"hashes do not apply to … style attributes … unless the `'unsafe-hashes'` keyword is present."* Adding `'unsafe-hashes'` would weaken `style-src` site-wide and is incompatible with our owner-law strict-CSP posture.
