### PR TITLE
fix(a11y): promote TL;DR from h3 to h2 (iJail field note)

### DIFF
--- a/content/field-notes/apple-sends-you-to-ijail.md
+++ b/content/field-notes/apple-sends-you-to-ijail.md
@@ -21,7 +21,7 @@ extra:
 
 > **The password you entered is wrong. Stop. Breathe. Think. And you won't get locked out.**
 
-### TL;DR
+## TL;DR
 When you sit down to type a password, you either know it or you don't. If you're consulting a piece of paper, you don't know it — you're transcribing. If it's not in a password manager that copy-pastes a known-good string, you don't have a verified credential. The two ecosystems then diverge sharply: **Apple** locks accounts after repeated wrong guesses and pushes you into a recovery flow whose worst-case wait time is "several days or longer." **Google** escalates *sign-in* friction (CAPTCHA, 2FA, recovery prompts) but explicitly states there is **no limit** on attempts inside the recovery process itself. The same operating rule covers both: stop after the second wrong attempt, every time, and start the recovery flow on purpose instead of stumbling into it — for Apple to avoid the lockout, for Google to avoid burning attempts on guesses when you should be assembling your recovery information.
 
 ---


### PR DESCRIPTION
## Summary

Lighthouse flagged a `heading-order` accessibility failure on the iJail page: the document was jumping from `h1` (the post title, auto-emitted by the template) directly to `h3` (the "TL;DR" block). Promoting `TL;DR` from `h3` to `h2` restores sequential order.

## Before / after

```
before:  h1 (title) → h3 (TL;DR) → h2 (The Moment I Catch...) → h2 (Why "I Almost Know It"...) → ...
after:   h1 (title) → h2 (TL;DR) → h2 (The Moment I Catch...) → h2 (Why "I Almost Know It"...) → ...
```

The "Prevention" section's existing `h2 → h3 → h3` (Prevention → For Apple → For Google) was already correct and is untouched.

## Verification

Verified locally with the new `npm run lh` tool from PR #627 against the dev server:

- `heading-order` audit no longer appears in the failing list.
- Mobile Accessibility score moves from **98 → 100**.
- No other audits regress.

## Owner-laws

Pure content fix. No template, CSS, JS, asset, or CSP changes. No risk to Performance, SRI, or any other gate.

## Depends on / related

Independent of the open PRs:
- #626 (responsive hero image on this same page)
- #627 (the `quick-lh.mjs` tool used to verify this fix)

Any merge order works.
