### PR TITLE
policy(license): split reuse posture — LICENSE, NOTICE, /use-policy page

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,182 @@
+IT Help San Diego Inc. — Site License & Reuse Policy
+=====================================================
+
+Copyright (c) IT Help San Diego Inc. All rights reserved.
+
+This repository contains the source for the corporate website at
+https://www.it-help.tech/. Different parts of the repository and the
+published site are covered by different terms. The applicable terms for
+any given asset are the ones listed below. If an asset is not described
+here, treat it as "all rights reserved" by default.
+
+The authoritative, human-readable version of this policy lives at
+https://www.it-help.tech/use-policy/ and in `content/use-policy.md`.
+This LICENSE file is the operational summary.
+
+This file is not legal advice. It states the terms under which we make
+the contents of this repository and the published site available; it
+does not create a lawyer-client relationship and does not substitute for
+counsel where you need it.
+
+---------------------------------------------------------------------
+1. Corporate site content and code — All rights reserved
+---------------------------------------------------------------------
+
+The following are proprietary to IT Help San Diego Inc. and are NOT
+licensed for reuse, redistribution, modification, training, or
+derivative-product creation without prior written permission:
+
+  - Business and service copy (e.g. /services, /billing, /about,
+    /managed-agent, /full-day-engagements, /contact, /privacy,
+    /security-policy, the home page, and all marketing pages).
+  - Pricing, packaging, methodology descriptions, and engagement
+    language.
+  - Templates, partials, SASS sources, JavaScript, configuration, and
+    build/infra scripts in this repository authored by IT Help San
+    Diego Inc. (note: third-party theme and dependencies retain their
+    own licenses; see Section 6).
+  - Any client-facing operational content not explicitly marked
+    otherwise.
+
+You may quote short excerpts for commentary, criticism, news reporting,
+or scholarship consistent with U.S. fair-use principles, with
+attribution and a link back. Anything more requires written permission
+from licensing@it-help.tech.
+
+---------------------------------------------------------------------
+2. Public research and field notes — Default reserved, CC BY 4.0 only
+   where explicitly marked
+---------------------------------------------------------------------
+
+Field notes and research write-ups under /field-notes/ are published as
+part of our public research record. By default they remain
+copyright IT Help San Diego Inc. with the same "all rights reserved"
+posture as the rest of the site.
+
+A field note is offered under the Creative Commons Attribution 4.0
+International license (CC BY 4.0, https://creativecommons.org/licenses/by/4.0/)
+ONLY when it is explicitly marked with one of the following:
+
+  - A `reuse_license = "CC-BY-4.0"` (or `reuse_license: CC-BY-4.0`)
+    entry in the page's frontmatter `[extra]` table, AND/OR
+  - A visible "License" or "Reuse" notice in the page body that names
+    CC BY 4.0 and links to the license text.
+
+Absence of an explicit mark means the article is reserved. Please do
+not assume CC BY 4.0 silently extends to other articles, future
+articles, or the underlying compiled site.
+
+When CC BY 4.0 applies, attribution should read substantially as:
+
+  "<title>" by Carey Balboa / IT Help San Diego Inc., licensed under
+  CC BY 4.0. Source: https://www.it-help.tech/field-notes/<slug>/
+
+Embedded media (photos, diagrams, screenshots, logos, owl marks) inside
+a CC BY 4.0 field note remain governed by Sections 4 and 5 unless the
+caption or alt text explicitly says otherwise.
+
+---------------------------------------------------------------------
+3. DNS Tool (software and product references) — BUSL-1.1
+---------------------------------------------------------------------
+
+The DNS Tool web application at https://dnstool.it-help.tech/ and the
+CLI at https://github.com/IT-Help-San-Diego/dns-tool-intel/ are
+distributed under the Business Source License 1.1 (BUSL-1.1) by their
+own repository. Any references, screenshots, sample reports, or
+description copy about DNS Tool that appear on www.it-help.tech are
+covered by the DNS Tool project's own license and citation terms
+(including the Zenodo deposit where applicable). When in doubt, defer
+to:
+
+  - https://github.com/IT-Help-San-Diego/dns-tool-intel/ (LICENSE, NOTICE)
+  - The DNS Tool project's CITATION.cff / Zenodo record.
+
+Nothing in this corporate-site license grants additional rights over
+DNS Tool software, its source, or its outputs.
+
+---------------------------------------------------------------------
+4. Immutable Fact AI / The Real Bot path — Reserved commercial work
+---------------------------------------------------------------------
+
+Pages, prototypes, naming, and design work associated with the
+"Immutable Fact AI" / "The Real Bot" product path — including the
+field note "The Real Bot Hasn't Been Built Yet" and its companion PDF
+— are protected commercial work product. These are NOT offered under
+CC BY 4.0 or any other open license, even where they appear under
+/field-notes/. Requests for licensing or collaboration:
+licensing@it-help.tech.
+
+---------------------------------------------------------------------
+5. Brand assets, logos, trademarks, identity — All rights reserved
+---------------------------------------------------------------------
+
+The following are reserved and may not be copied, modified, mirrored,
+or used as part of any other product, mark, or training corpus without
+prior written permission:
+
+  - "IT Help San Diego" and "IT Help" name and wordmarks.
+  - The Athenian-owl medallion, the IT+HELP wordmark, the red plus
+    mark, and any combination thereof.
+  - The brand color system documented at /brand-colors/ insofar as it
+    is applied to identify IT Help San Diego Inc.
+  - Trade dress of the corporate site and DNS Tool product, including
+    the gold IT+HELP + red plus + silver SAN DIEGO banner cutout and
+    associated favicons.
+  - Photographs and likenesses of staff and clients.
+
+Trademark rights are asserted independently of, and survive, any
+content license granted elsewhere in this file. CC BY 4.0 on a field
+note does NOT license the owl, the wordmark, or the company name.
+
+---------------------------------------------------------------------
+6. Third-party components — Their own licenses
+---------------------------------------------------------------------
+
+This repository includes third-party software and assets whose
+licenses are upstream and unchanged by this file:
+
+  - Zola (MPL-2.0) and Rust toolchain — build only, not redistributed.
+  - The Abridge theme under `themes/abridge/` — see
+    `themes/abridge/LICENSE`.
+  - Node devDependencies pinned in `package.json` / `package-lock.json`
+    — each retains its own license (Lighthouse, etc.).
+  - Any vendored fonts, icons, or images included for build — see the
+    upstream source for terms.
+
+Nothing in this file overrides any of those upstream licenses.
+
+---------------------------------------------------------------------
+7. AI / LLM ingestion, indexing, and reuse posture
+---------------------------------------------------------------------
+
+Our `robots.txt` and `llms.txt` files explicitly allow major AI and
+search crawlers to fetch and index publicly available pages on
+www.it-help.tech. That permission is narrow and operational: it lets
+real users find us through AI-mediated search and lets crawlers build
+a faithful snapshot of what we publish.
+
+It is NOT a grant of:
+
+  - A license to redistribute or republish our pages verbatim.
+  - A license to train commercial foundation models on the contents of
+    this site beyond what applicable law independently permits.
+  - A license to build derivative products from our text, code,
+    diagrams, brand assets, or research figures.
+  - A license to remove attribution, alter context, or use our
+    company, staff, or client names to imply endorsement of an AI
+    product.
+
+If you operate an AI system that ingests our pages and you want
+broader reuse rights, get in touch: licensing@it-help.tech. Access does
+not equal reuse.
+
+---------------------------------------------------------------------
+8. Contact
+---------------------------------------------------------------------
+
+Licensing and reuse: licensing@it-help.tech
+Security: security@it-help.tech (see SECURITY.md)
+General: https://www.it-help.tech/contact/
+
+This policy may be updated. The version published at
+https://www.it-help.tech/use-policy/ is canonical.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,28 @@
+IT Help San Diego Inc. — NOTICE
+
+This product/site bundles work owned by IT Help San Diego Inc. and work
+owned by third parties. The terms differ. See LICENSE for the full
+breakdown and https://www.it-help.tech/use-policy/ for the human-readable
+version.
+
+Component summary:
+
+  IT Help San Diego Inc. corporate content & code  — All rights reserved
+  /field-notes/ articles                           — Reserved; CC BY 4.0
+                                                     only where the page
+                                                     itself is explicitly
+                                                     marked.
+  DNS Tool references                              — BUSL-1.1 via the
+                                                     DNS Tool repository
+                                                     (dns-tool-intel).
+  Immutable Fact AI / The Real Bot path            — Reserved commercial.
+  Brand, logos, owl marks, trademarks              — All rights reserved.
+  Abridge theme (themes/abridge/)                  — See themes/abridge/LICENSE.
+  Node devDependencies                             — Each retains its own
+                                                     upstream license.
+
+AI / LLM crawlers: indexing access granted via robots.txt and llms.txt
+does not grant reuse, training, or derivative-product rights. See
+LICENSE §7.
+
+Contact: licensing@it-help.tech

--- a/README.md
+++ b/README.md
@@ -2,9 +2,26 @@
 
 This site is a static HTML5 project.
 
-© 2025 IT Help San Diego Inc.
+© IT Help San Diego Inc. All rights reserved.
 
 ✨ Built with Rust (Zola) & Sass and deployed on AWS. We use only a few lines of JavaScript for essential functionality—no frameworks, trackers, or cookies. Just lean, fast, cost-efficient tech. ✨
+
+## License & Reuse
+
+Different parts of this repository and the published site at
+`https://www.it-help.tech/` are covered by different terms. See:
+
+- [`LICENSE`](./LICENSE) — operational summary
+- [`NOTICE`](./NOTICE) — short component map
+- [`/use-policy/`](https://www.it-help.tech/use-policy/) — public,
+  human-readable version (source: `content/use-policy.md`)
+
+Short version: corporate content/code, brand assets, and trademarks are
+reserved; field notes are reserved by default and only reusable under
+CC BY 4.0 **when the article itself is explicitly marked**; the DNS
+Tool product remains BUSL-1.1 via its own repository; AI/LLM indexing
+access does not grant reuse, training, or derivative-product rights.
+Licensing requests: `licensing@it-help.tech`.
 
 ## AI / Automation Notes
 

--- a/content/use-policy.md
+++ b/content/use-policy.md
@@ -1,0 +1,187 @@
++++
+title = "Use, License & Reuse Policy"
+description = "How content, code, brand assets, DNS Tool references, and AI/LLM access are licensed across IT Help San Diego properties."
+path = "use-policy"
+aliases = ["/license/", "/reuse/"]
+
+[extra]
+skip_image = true
+skip_author = true
+seo_title = "Use, License & Reuse Policy — IT Help San Diego"
+og_description = "What you can and cannot reuse from www.it-help.tech: corporate content, field notes, DNS Tool references, brand assets, and AI/LLM ingestion posture."
+twitter_description = "Plain-English split of what is reserved, what is openly licensed only when marked, and how AI crawlers fit in."
++++
+
+This page describes how the work published at `www.it-help.tech` is
+licensed. Different parts of the site are covered by different terms.
+The short version is that **most things are reserved**, a small set of
+research write-ups can be openly reused **only when they say so on the
+page**, and access by AI/search crawlers is not the same as a license to
+republish.
+
+This is a plain-English operations policy, not legal advice. If you
+need a formal license for something specific, write to
+`licensing@it-help.tech` and we will answer in writing.
+
+The machine-readable companion lives in the repository as
+[`LICENSE`](https://github.com/IT-Help-San-Diego/it-help-tech-site/blob/main/LICENSE)
+and [`NOTICE`](https://github.com/IT-Help-San-Diego/it-help-tech-site/blob/main/NOTICE).
+
+## 1. Corporate site content and code — all rights reserved
+
+The business-facing parts of this site — including the home page,
+[Services](/services/), [Billing](/billing/), [About](/about/),
+[Managed Agent](/managed-agent/),
+[Full-Day Engagements](/full-day-engagements/), [Privacy](/privacy/),
+[Security Policy](/security-policy/), [Contact](/contact/), and all
+pricing, packaging, and methodology copy — are proprietary work
+product of IT Help San Diego Inc. The same applies to the templates,
+SASS, JavaScript, build scripts, and infrastructure code in our
+repositories that we authored.
+
+You may quote short excerpts for commentary, criticism, news reporting,
+or scholarship consistent with U.S. fair-use principles, with
+attribution and a link back to the source page. Anything more —
+mirroring, redistribution, modification, training, derivative products
+— requires written permission.
+
+## 2. Field notes / public research — reserved by default, CC BY 4.0
+only where the page says so
+
+[Field Notes](/field-notes/) are part of our public research record.
+They cover topics like DNS, email security, Mac IT, password ergonomics,
+and AI model behaviour, and they cite primary sources so other
+practitioners can verify our work.
+
+By default, each field note is **all rights reserved**, just like the
+rest of the site. We do not silently relicense research articles as
+open content.
+
+A field note is offered under [Creative Commons Attribution
+4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)
+only when the article itself is **explicitly marked**, in one of two
+equivalent ways:
+
+- a `reuse_license = "CC-BY-4.0"` entry in the page's `[extra]`
+  frontmatter table, or
+- a visible "License" / "Reuse" notice in the page body that names
+  CC BY 4.0 and links to the license text.
+
+If neither mark is present, the article is reserved. If you are
+unsure, ask before republishing.
+
+When CC BY 4.0 does apply, attribution should read substantially as:
+
+> "*&lt;Article title&gt;*" by Carey Balboa / IT Help San Diego Inc.,
+> licensed under [CC BY
+> 4.0](https://creativecommons.org/licenses/by/4.0/). Source:
+> `https://www.it-help.tech/field-notes/<slug>/`
+
+Embedded media inside an openly licensed field note — photographs,
+diagrams, screenshots, logos, owl marks — remain governed by sections
+4 and 5 below unless the caption explicitly says otherwise. An open
+licence on the text does not extend to the brand mark next to it.
+
+## 3. DNS Tool — separate license (BUSL-1.1)
+
+[DNS Tool](https://dnstool.it-help.tech) and its CLI live in their own
+repository,
+[`dns-tool-intel`](https://github.com/IT-Help-San-Diego/dns-tool-intel/),
+and are distributed under the Business Source License 1.1 (BUSL-1.1).
+Any DNS Tool references on this site — descriptions, screenshots,
+sample reports, methodology summaries — are covered by the DNS Tool
+project's own license and citation terms (including its Zenodo deposit
+where applicable).
+
+Nothing on `www.it-help.tech` grants additional rights over DNS Tool
+software, source, or outputs. When in doubt, defer to the `LICENSE`,
+`NOTICE`, and `CITATION.cff` files in the DNS Tool repository.
+
+## 4. Immutable Fact AI / The Real Bot path — reserved commercial work
+
+Pages, prototypes, naming, and design work tied to our **Immutable
+Fact AI** / "The Real Bot" product path — including the field note
+[*The Real Bot Hasn't Been Built
+Yet*](/field-notes/the-real-bot-hasnt-been-built-yet/) and its
+companion PDF — are protected commercial work product. They are
+**not** offered under CC BY 4.0 or any other open license, even though
+they appear under `/field-notes/`. The CC BY 4.0 marker described in
+section 2 will not be applied to these pages. Licensing or
+collaboration: `licensing@it-help.tech`.
+
+## 5. Brand, logos, owl marks, trademarks — all rights reserved
+
+Reserved unless and until we agree otherwise in writing:
+
+- The names *"IT Help San Diego"* and *"IT Help"* and their wordmarks.
+- The Athenian-owl medallion, the IT+HELP wordmark, the red plus mark,
+  and any combination thereof.
+- The IT+HELP banner cutout (gold IT+HELP + red plus + silver SAN
+  DIEGO) and the favicon family generated from the same source.
+- The brand colour system at [/brand-colors/](/brand-colors/) when
+  used to identify IT Help San Diego Inc.
+- Photographs and likenesses of our staff and clients.
+
+Trademark rights are asserted independently of any content licence
+elsewhere on the site, and **survive** them. A CC BY 4.0 marker on a
+field note does not license the owl, the wordmark, or the company name.
+
+## 6. Third-party theme and dependencies — their own licences
+
+We build on third-party work that keeps its own licence:
+
+- [Zola](https://www.getzola.org/) static-site generator (build-time
+  only; not redistributed).
+- The [Abridge](https://github.com/Jieiku/abridge) theme under
+  `themes/abridge/`. See `themes/abridge/LICENSE` in the repository.
+- Node devDependencies (Lighthouse, etc.) pinned in `package.json`,
+  each retaining its upstream licence.
+- Any vendored fonts or icons included for build — see upstream source
+  for terms.
+
+Nothing in our policy overrides those upstream licences.
+
+## 7. AI and LLM crawlers — access is not a reuse licence
+
+Our [`robots.txt`](/robots.txt) and [`llms.txt`](/llms.txt) deliberately
+allow major AI and search crawlers — GPTBot, ChatGPT-User,
+OAI-SearchBot, ClaudeBot, PerplexityBot, GeminiBot, Google-Extended,
+CCBot, YouBot, PhindBot, ExaBot, AndiBot, FirecrawlAgent, and the
+traditional Googlebot / Bingbot — to fetch and index publicly
+available pages. We want real people who ask an assistant about
+"Apple IT in San Diego" or "how DMARC works" to find an accurate,
+first-party answer.
+
+That permission is narrow and operational. **Access is not a licence
+to reuse.** Specifically, allowing a crawler to read these pages does
+not grant:
+
+- a right to redistribute or republish our pages verbatim;
+- a right to train commercial foundation models on our content beyond
+  what applicable law independently permits;
+- a right to build derivative products from our text, code, diagrams,
+  research figures, or brand assets;
+- a right to remove attribution or alter context;
+- a right to use our company name, staff names, or client names to
+  imply endorsement of an AI product, dataset, or training corpus.
+
+Sections 1 through 5 above still apply. If you operate an AI system
+and want broader reuse rights, contact `licensing@it-help.tech`. We are
+happy to talk; we are not happy to be quietly relicensed.
+
+## 8. Reporting problems and asking for permission
+
+- **Licensing and reuse requests:** `licensing@it-help.tech`
+- **Security issues:** `security@it-help.tech` — see the
+  [Security Policy](/security-policy/).
+- **General contact:** [/contact/](/contact/)
+
+This page may be updated. The version at
+`https://www.it-help.tech/use-policy/` is canonical; the repository
+`LICENSE` and `NOTICE` files are the operational summary.
+
+---
+
+*This page describes how IT Help San Diego Inc. makes its work
+available. It is not legal advice and does not create a lawyer-client
+relationship.*

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -15,3 +15,23 @@
 ## Optional
 
 - [Field Notes](https://www.it-help.tech/field-notes)
+
+## Use, License & Reuse
+
+Indexing access granted to AI/LLM and search crawlers via this file and
+`/robots.txt` is operational — it lets real users find first-party
+answers through AI-mediated search. It is **not** a license to
+redistribute, train on, or build derivative products from this site's
+content, code, or brand assets. Most material is reserved; a small set
+of field notes may be reused under CC BY 4.0 **only when the page itself
+is explicitly marked** with that license. DNS Tool software is licensed
+separately under BUSL-1.1 via its own repository. Brand, logos, owl
+marks, and trademarks are reserved.
+
+See the full policy:
+
+- [Use, License & Reuse Policy](https://www.it-help.tech/use-policy)
+- Repository LICENSE: https://github.com/IT-Help-San-Diego/it-help-tech-site/blob/main/LICENSE
+- Repository NOTICE: https://github.com/IT-Help-San-Diego/it-help-tech-site/blob/main/NOTICE
+
+Licensing requests: licensing@it-help.tech

--- a/templates/partials/_footer-org.html
+++ b/templates/partials/_footer-org.html
@@ -110,6 +110,7 @@
             <span class="ftr-heading"><svg class="ftr-icon" aria-hidden="true"><use href="#i-shield"/></svg> Trust</span>
             <a href="/security-policy" class="ftr-link">Security Policy</a>
             <a href="/privacy" class="ftr-link">Privacy</a>
+            <a href="/use-policy" class="ftr-link">Use &amp; License</a>
             <a href="/billing" class="ftr-link">Billing &amp; Pricing</a>
             <a href="/full-day-engagements" class="ftr-link">Full-Day Engagements</a>
             <a href="/brand-colors" class="ftr-link">Brand Colors</a>

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -2,6 +2,12 @@
 User-Agent: *
 Disallow: /
 {%- else %}
+# Indexing access is operational, not a reuse license.
+# See https://www.it-help.tech/use-policy/ for what reuse is and isn't
+# permitted. AI / LLM crawlers: access does not grant training,
+# redistribution, or derivative-product rights. Contact:
+# licensing@it-help.tech
+
 # Default: allow all crawlers
 User-agent: *
 Allow: /


### PR DESCRIPTION
## Summary

Adds the missing top-level license & reuse posture for `www.it-help.tech` so corporate content, public research, DNS Tool references, brand assets, and AI/LLM ingestion each have an unambiguous answer. The current state — no root `LICENSE`, footer saying "All rights reserved", but robots/llms files inviting AI crawlers — read as inconsistent and could be misinterpreted as a broad reuse grant. This PR makes the split explicit without silently relicensing anything.

The split, mirrored across `LICENSE`, `NOTICE`, and the public `/use-policy/` page:

- **Corporate site content & code** (Services / Billing / About / Managed Agent / Privacy / Security Policy / templates / SASS / JS / infra) — **all rights reserved**.
- **Field notes / public research** — reserved by default. **CC BY 4.0 only when the page itself is explicitly marked** (`extra.reuse_license = "CC-BY-4.0"` in frontmatter, or a visible in-page notice). No silent blanket relicensing of `/field-notes/`.
- **DNS Tool** — defers to BUSL-1.1 in [`dns-tool-intel`](https://github.com/IT-Help-San-Diego/dns-tool-intel/) (LICENSE/NOTICE/CITATION.cff). Nothing on the corporate site grants extra rights over DNS Tool software.
- **Immutable Fact AI / The Real Bot path** — protected commercial work product. Not CC BY, even though it appears under `/field-notes/`.
- **Brand, logos, Athenian-owl mark, wordmark, red plus, trademarks** — all rights reserved, asserted independently of any content licence, and survive it.
- **AI / LLM crawlers** — `robots.txt` and `llms.txt` permissions stay open (no overblocking), but the policy is explicit: **access ≠ reuse**. Indexing does not grant training, redistribution, or derivative-product rights. Contact for broader rights: `licensing@it-help.tech`.

Includes a non-lawyer note ("plain-English operations policy, not legal advice") in both `LICENSE` and `/use-policy/`.

## Files changed

| File | Change |
| ---- | ------ |
| `LICENSE` (new) | Operational summary of the 8-section split. |
| `NOTICE` (new) | Short component map for downstream consumers. |
| `content/use-policy.md` (new) | Public, human-readable page at `/use-policy/` (aliases `/license/`, `/reuse/`). |
| `templates/partials/_footer-org.html` | Adds "Use & License" link to the Trust cell. |
| `static/llms.txt` | Adds a "Use, License & Reuse" section pointing back to `/use-policy/`. |
| `templates/robots.txt` | Adds a header comment clarifying that crawl access is not a reuse license. |
| `README.md` | Replaces the bare copyright line with the layered summary; links LICENSE/NOTICE/use-policy. |

## Behaviour preserved

- No template logic changes, no nav restructure, no CSP/CSS changes.
- `robots.txt` still allows every AI/SEO crawler that was allowed before — no overblocking.
- `infra/llms/build-llms-full.mjs` allowlist is unchanged, so the new policy page does **not** silently appear in `llms-full.txt`.

## Testing

- [x] TOML frontmatter on `content/use-policy.md` parses cleanly.
- [x] `node infra/llms/build-llms-full.mjs` runs clean (46,763 bytes generated; allowlist unchanged).
- [x] `grep` audit confirms every "/use-policy" link points to the right surface.
- [ ] Manual: spot-check the footer "Use & License" link renders in the Trust column after `zola build` in CI.
- [ ] Manual: confirm `/use-policy/` page renders with the existing page template (uses `skip_image`, `skip_author` like `/privacy/`).

## Residual / follow-up

- No field note has been explicitly marked CC BY 4.0 yet. If/when the owner wants to open up a specific article, that is now a one-line frontmatter change (`extra.reuse_license = "CC-BY-4.0"`) plus an in-page notice — the policy already defines the mechanism.
- Consider mirroring this LICENSE/NOTICE pair in the `dns-tool-intel` repo's README cross-link so the two repos point at each other consistently.
- Owner may want to add `PROJECT_EVOLUTION_LOG.md` entry per the project's documented update process for non-visual changes; left out of this PR so the owner can word the rationale.