### PR TITLE
seo: Apple-anchored La Jolla snippet rewrite (homepage + /services/)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,15 +1,15 @@
 +++
-title       = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-description = "Apple-centric IT, deep-research diagnostics for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no retainers."
+title       = "La Jolla Apple IT Consultant · Senior Mac & Network Help"
+description = "Senior Apple-centric IT consultant for La Jolla and the wider San Diego — Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments. By appointment, on-site or remote. 27 years. No hardware repair, no monthly retainers."
 
 [extra]
-seo_title       = "Mac IT Support San Diego"
-og_title        = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-og_description  = "Apple-centric IT, deep-research diagnostics for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no retainers."
+seo_title       = "La Jolla Apple IT Consultant · Senior Mac & Network Help"
+og_title        = "La Jolla Apple IT Consultant · Senior Mac & Network Help"
+og_description  = "Senior Apple-centric IT consultant for La Jolla and the wider San Diego — Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments. By appointment, on-site or remote. 27 years. No hardware repair, no monthly retainers."
 og_image        = "/images/og-home.png"
 
-twitter_title       = "Mac IT Support San Diego (La Jolla) | IT Help San Diego"
-twitter_description = "Apple-centric IT, deep-research diagnostics for La Jolla & San Diego. macOS first; Unix, Linux, Windows too. No hardware sales, no retainers."
+twitter_title       = "La Jolla Apple IT Consultant · Senior Mac & Network Help"
+twitter_description = "Senior Apple-centric IT consultant for La Jolla and the wider San Diego — Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments. By appointment, on-site or remote. 27 years. No hardware repair, no monthly retainers."
 twitter_image       = "/images/og-home.png"
 twitter_card        = "summary_large_image"
 +++

--- a/content/services.md
+++ b/content/services.md
@@ -1,15 +1,15 @@
 ---
-title: On-site IT Services San Diego (La Jolla) | IT Help San Diego
+title: Apple IT Consulting Services · La Jolla & San Diego
 path: services
-description: "Apple-centric on-site IT services across San Diego: Mac and Wi‑Fi troubleshooting, DNS/email deliverability, cybersecurity, and data recovery. No retainers."
+description: "Engagements with a senior Apple-centric IT consultant in La Jolla, on-site or remote across San Diego. Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments. By appointment. No hardware repair, no monthly retainers, no affiliate hardware sales."
 extra:
-  seo_title: "On-site IT Services San Diego"
+  seo_title: "Apple IT Consulting Services · La Jolla & San Diego"
   skip_image: true
   skip_author: true
-  og_description: "Apple‑centric on‑site IT services: Mac & Wi‑Fi troubleshooting, DNS/email security, data recovery—no monthly retainers."
-  twitter_description: "Apple‑centric on‑site IT services: Mac & Wi‑Fi troubleshooting, DNS/email security, data recovery—no monthly retainers."
-  og_title: "On-site IT Services San Diego (La Jolla) | IT Help San Diego"
-  twitter_title: "On-site IT Services San Diego (La Jolla) | IT Help San Diego"
+  og_description: "Engagements with a senior Apple-centric IT consultant in La Jolla, on-site or remote across San Diego. Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments. By appointment. No hardware repair, no monthly retainers."
+  twitter_description: "Engagements with a senior Apple-centric IT consultant in La Jolla, on-site or remote across San Diego. Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments. By appointment. No hardware repair, no monthly retainers."
+  og_title: "Apple IT Consulting Services · La Jolla & San Diego"
+  twitter_title: "Apple IT Consulting Services · La Jolla & San Diego"
 ---
 
 <script type="application/ld+json">
@@ -353,6 +353,28 @@ extra:
 
 
 Seven service pillars, organized by the problem they solve. Across all seven, the model is the same: you bring a mission, problem, or research goal; we engage, solve it, and bill only for work performed. No retainers, no lock-in, no padded hours. This structure gives clients access to senior-level engineering when needed, without an ongoing contract.
+
+## Scope {#scope}
+
+### What this practice covers
+
+* **macOS and iOS at the system level** — storage, sync, performance, migration, keychain, Mail, iCloud. The top of the stack and the platform this practice is built around.
+* **Linux at the system level** — including DNS, mail, and open-source infrastructure work. The [DNS Tool](/dns-tool/) and [field notes](/field-notes/) are the public version of this work.
+* **Windows in mixed environments** where identity, networking, or email overlap with the Mac or Linux side. A Wi‑Fi or DNS problem in a Windows office is still our problem.
+* **Wi‑Fi and wired network design and troubleshooting** — Cat6A/Cat8, mesh design, RF measurement — across all three platforms.
+* **DNS and email-deliverability work** — SPF, DKIM, DMARC, MTA-STS, DNSSEC.
+* **Cybersecurity hardening, ethical remote support, forensic data extraction** for legal matters.
+* **Recovery of recoverable data** without sending drives to a clean room — honest scope agreed upfront.
+
+### What this practice does not cover
+
+* **Physical device repair of any kind** — no cracked screens, no failed batteries, no liquid damage, no charging ports, no hinges, no keyboards.
+* **Hardware sales** — we do not resell devices and we do not earn affiliate commissions on what we recommend.
+* **Monthly support retainers or managed-service contracts** — see the [Managed Agent](/managed-agent/) page for the device-maintenance layer that is the closest thing this practice offers, and the math that makes it different.
+* **Same-day emergency callouts for non-clients** — by appointment only.
+* **Walk-in service** — by appointment only.
+
+For physical-screen, battery, or port work, we refer to a vetted local technician. For device replacement we offer existing clients an on-site concierge pickup-and-migrate from Apple.
 
 ## Mac & Apple Ecosystem {#mac}
 


### PR DESCRIPTION
## Why

GSC (last 90 days) shows the homepage already ranking on the right queries — `it help` (591 impr, pos 3.3), `la jolla it support` (468, 4.5), `it services la jolla` (247, 4.6), `it support la jolla` (302, 5.6) — and getting **zero clicks**. The SERP snippet says "Mac IT Support San Diego" and doesn't identify the practice as the La Jolla / Apple / senior consultant these searchers want.

Meanwhile the homepage also ranks pos 1.0 for `laptop repair` (181), `computer consultant near me` (127), `computer consultant` (110), `data recovery` (20) — also zero clicks, which is the correct outcome. Those are mostly the wrong customers (cracked screens, $80/hr expectations).

**Job to be done: filter, not flood.** Rewrite the SERP snippet so the right Apple-IT searcher recognizes themselves, the cracked-screen searcher keeps scrolling, and the Windows-office-with-a-Wi-Fi-problem owner still recognizes that we can help.

## What

### `content/_index.md` (homepage)
- Title: `La Jolla Apple IT Consultant · Senior Mac & Network Help` (56 chars — falls into the `length > 35` branch in `templates/partials/head.html`, suppressing the brand tail; verified).
- Description: leads with `Senior Apple-centric IT consultant for La Jolla and the wider San Diego` as the magnet, follows with `Mac first, with Linux and Windows, Wi‑Fi, DNS and email security in mixed environments` as the reassurance, ends with `No hardware repair, no monthly retainers` as the in-SERP filter for Bucket A.
- Same swap mirrored to `og_title`, `og_description`, `twitter_title`, `twitter_description`.

### `content/services.md` (/services/ page)
- Title: `Apple IT Consulting Services · La Jolla & San Diego` (51 chars).
- Description: same two-tier structure as the homepage, with `no affiliate hardware sales` added.
- Drops `data recovery` from the description — it stays in the page body under `#scope` with honest "no clean room" scope language, but it does not belong in the SERP snippet where it pulls Bucket A intent.
- New `## Scope {#scope}` section between the intro paragraph and `## Mac & Apple Ecosystem`, with two tables ("What this practice covers" / "What this practice does not cover") that reinforce the SERP filter at the page level. Linux gets its own honest line referencing the DNS Tool and field notes as the public version of that work.

## Design rules followed

- "Apple" named explicitly in title (different SERP population than "Mac" — `apple it support san diego`, `apple consultant`, etc. searchers don't search "Mac").
- "Unix" removed from public snippets (redundant with Mac and Linux — reads as résumé padding).
- "Mac first" is the honest tiered framing (not Mac-only, not platform-agnostic). Windows shows up in the reassurance clause and in `#scope` so a Windows-office Wi-Fi problem still recognizes us as their answer.
- No "best" / "trusted" / "award-winning" / "affordable" / "24/7" / "emergency".
- No phone number in any meta description (price-shoppers should land on `/billing/` first).
- No new keywords for services we don't offer (no `laptop repair`, no `phone repair`).

## What this PR does NOT touch

Templates, CSS, JS, JSON-LD, CSP/headers, build pipeline, brand mark, any other content page, or any infra. Pure frontmatter + one new markdown section.

## Per-gate impact

| Gate | Impact |
|------|--------|
| Lighthouse Performance / Accessibility / Best Practices / SEO | 0 (text-only) |
| Observatory / CSP | 0 (no header/script change) |
| Voice / brand / ethics | clean — every claim verifiable, no superlatives |
| Wrong-customer filter | active, in-SERP, before the click |

## Rollback

Revert this single commit. No infra, no headers, no template changes.

## What to watch in GSC after merge

Not impressions or position — **CTR on the Bucket B queries** (`it help`, `la jolla it support`, `it services la jolla`, `apple it support san diego`, `mac based it services san diego`, etc.). Conservative 4–6 week target: 3% CTR on that ~1,800-impr/qtr bucket ≈ 54 clicks/qtr from the right customers. Also watch intake-call composition — if `laptop repair` / `screen` queries start gaining CTR, the snippet has drifted toward bait and we revert.