### PR TITLE
render: three Safari-specific paint fixes (will-change, ftr-cell, sig-preview contrast)

### DIFF
--- a/static/css/_footer-org.css
+++ b/static/css/_footer-org.css
@@ -203,6 +203,16 @@ a.ftr-node:hover {
     border: 1px solid rgba(48, 54, 61, 0.4);
     border-radius: var(--radius-xl, 10px);
     padding: 0.85rem 0.9rem;
+    /* Safari refuses to paint backdrop-filter unless the element creates an
+       explicit stacking context. translateZ(0) is the cheapest way to do
+       that without changing layout, and it pairs with `will-change:
+       transform` so the compositor keeps the layer on the GPU. Without
+       this, the frosted blur degrades to a flat rgba background in
+       Safari while Chrome/Firefox composite it correctly — the kind of
+       silent cross-engine drift that's hard to spot until a Mac client
+       sees it. */
+    transform: translateZ(0);
+    will-change: transform;
     transition: border-color var(--transition-medium, 250ms ease),
                 background var(--transition-medium, 250ms ease);
 }

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -999,7 +999,12 @@ html:not(.switch) h6 a.gold-link:active {
         backdrop-filter: saturate(160%) blur(14px);
         border-bottom: 1px solid rgba(210, 181, 111, 0.38);
         transform: translateZ(0);
-        will-change: backdrop-filter;
+        /* `will-change: backdrop-filter` is not a valid will-change value;
+           browsers silently coerce it to `auto`, so it never delivered the
+           compositing hint it appeared to. `transform` is the canonical
+           Safari GPU-promotion hint and is what the translateZ(0) above
+           actually depends on. */
+        will-change: transform;
     }
     @supports (background: color-mix(in oklab, red, blue)) {
         .topbar {
@@ -1051,7 +1056,9 @@ html:not(.switch) h6 a.gold-link:active {
             border-bottom: 0;
             box-shadow: none;
             transform: translateZ(0);
-            will-change: backdrop-filter;
+            /* See note in the desktop topbar rule above — `transform` is the
+               valid will-change value; `backdrop-filter` is not. */
+            will-change: transform;
         }
     }
 }

--- a/static/css/signature.css
+++ b/static/css/signature.css
@@ -43,15 +43,22 @@
 .sig-preview .sig-brand-gold { color:#c8a878; }
 .sig-preview .sig-brand-red { color:#c42a2a; }
 .sig-preview .sig-brand-location { color:#6b7280; font-size:11px; letter-spacing:1.8px; font-weight:700; }
-.sig-preview .sig-tagline { font-size:10px; color:#6b7280; margin:0 0 8px 0; font-style:italic; line-height:1.3; letter-spacing:0.3px; }
+/* `#6b7280` on `#111827` is 3.67:1 — fails WCAG AA for normal text (4.5:1
+   threshold). `#9ca3af` lands at 5.75:1 on the same background, restoring
+   AA compliance for the in-page preview without flattening the visual
+   hierarchy against `--text-primary`. The actual email-signature file at
+   /ithelp-logo-sig-research.html keeps `#6b7280` because that signature
+   is pasted into mail clients with light backgrounds where the contrast
+   math is different — do not chase parity between the two surfaces. */
+.sig-preview .sig-tagline { font-size:10px; color:#9ca3af; margin:0 0 8px 0; font-style:italic; line-height:1.3; letter-spacing:0.3px; }
 .sig-preview .sig-details { font-size:12px; color:#d1d5db; line-height:1.5; margin:0; }
 .sig-preview .sig-name { color:#e5e7eb; }
-.sig-preview .sig-muted { color:#6b7280; }
+.sig-preview .sig-muted { color:#9ca3af; }
 .sig-preview .sig-role { color:#9ca3af; }
 .sig-preview .sig-link { color:#c8a878; text-decoration:none; }
 .sig-preview .sig-link:hover { text-decoration:underline; }
 .sig-preview .sig-gap { height:8px; font-size:0; line-height:0; }
-.sig-preview .sig-address { border-top:1px solid rgba(200,168,120,0.18); padding-top:8px; font-size:11px; color:#6b7280; line-height:1.4; margin:0; }
+.sig-preview .sig-address { border-top:1px solid rgba(200,168,120,0.18); padding-top:8px; font-size:11px; color:#9ca3af; line-height:1.4; margin:0; }
 .sig-preview .sig-company { color:#9ca3af; font-weight:600; }
 .sig-preview .sig-sep { color:#374151; }
 .sig-preview .sig-bottom-bar { height:1px; background-color:rgba(200,168,120,0.18); font-size:0; line-height:0; }


### PR DESCRIPTION
A desktop-Safari render sweep across every public page surfaced three concrete defects rooted in Safari's stricter compositing and contrast rules. Each fix is conservative and surgical — no layout changes, no new selectors, no token additions.

## 1. `.topbar` — invalid `will-change` value

**Both the desktop rule (line ~1002) and the iPhone-Safari rule (line ~1054).**

`will-change: backdrop-filter` is not a valid `will-change` value — the spec defines only `auto`, `scroll-position`, `contents`, or any CSS property valid as an animatable property in the sense of `transform`/`opacity`/etc. Browsers silently coerce invalid values to `auto`, so the intended GPU compositing hint has been dropped this whole time.

Switched to `will-change: transform`, which is the canonical pairing with the adjacent `transform: translateZ(0)` already present in both rules. No behavior change in Chrome or Firefox; restores the originally-intended compositing hint on Safari and reduces the chance of sticky-topbar flicker on scroll.

## 2. `.ftr-cell` — Safari `backdrop-filter` silently fails without a stacking context

Safari requires a non-`auto` `transform` or `will-change` (or another explicit compositing trigger) on the element for `backdrop-filter` to actually paint. Without it, the frosted blur degrades to the flat `rgba(22,27,34,.55)` background in Safari while Chrome and Firefox composite it correctly — the kind of silent cross-engine drift that's hard to catch until a Mac client sees it.

Added `transform: translateZ(0)` + `will-change: transform` for the cheapest possible layer promotion. No layout impact.

## 3. `.sig-preview` muted text fails WCAG 2.1 AA

`#6b7280` on `#111827` is 3.67:1 — fails WCAG 2.1 AA for normal text (4.5:1 threshold). Applies to `.sig-tagline`, `.sig-muted`, and `.sig-address` inside the in-page preview at `/signature/`.

Bumped to `#9ca3af` (5.75:1), matching the existing `.sig-role` color so the hierarchy still reads as muted without the AA failure.

**Important:** the actual email-signature file at `static/ithelp-logo-sig-research.html` is **deliberately left at `#6b7280`** because that signature is pasted into mail clients with light backgrounds, where the contrast math is the opposite of the dark-mode in-page preview. The two surfaces serve different rendering contexts and should not be force-paritized. Comment in the CSS documents this intentionally.

## Verification

- Diff is 29 lines across three CSS files, zero new selectors
- No new hex tokens introduced (token-parity unchanged)
- No SRI/CSP impact (CSS, not script)
- No template, content, or JS changes
- Light mode and mobile paths unchanged

## Out of scope for this PR (kept for separate review)

- **Prose max-width / line-length on long-form articles** — flagged in the sweep but it's a typography decision, not a Safari bug. Deserves explicit owner sign-off on the reading-experience tradeoff before applying.
- **`body { overflow-x: hidden }` removal** — real Safari sticky-positioning interaction, but removing it risks horizontal scrollbars on any element that overflows. Needs a per-element overflow audit before flipping.
- **Field-notes thumbnail sizing** — design decision, not a bug.
