### PR TITLE
typography: Apple-developer-docs prose measure (74ch) with full-bleed escape hatch

### DIFF
--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -1574,3 +1574,121 @@ img.img-centered-520 {
     margin: 0 auto;
     display: block;
 }
+
+/* ============================================================================
+   Prose measure (line-length) cap — 2026-06-01
+   ----------------------------------------------------------------------------
+   The abridge theme sets `<main>` to min-width:1200px / max-width:70%. On a
+   1440px viewport that produces a ~1008px content column. At our 1.12rem
+   body font (~17.9px) that's ~110–120 characters per line — wider than the
+   measure used by Apple's own editorial properties and well wider than
+   what's comfortable for older readers.
+
+   Decision: match Apple's developer documentation, which is the closest
+   stylistic analogue to this site's long-form articles. The brand has
+   been deliberately positioned to feel adjacent to Apple's visual
+   language, so the prose measure should align too.
+
+   Apple body-prose measurements at 1440px viewport (audited 2026-06-01):
+     - developer.apple.com/design/human-interface-guidelines:
+         740px column, 17px SF Pro Text, 25px line-height (1.47x), ~93 CPL
+     - support.apple.com long-form articles:
+         797–817px column, 17px SF Pro Text, 25px line-height, ~97–106 CPL
+     - apple.com marketing pages:
+         not applicable — short feature-card copy, not flowing prose
+
+   Apple's developer-docs target is the more disciplined of the two and
+   is the right reference for technical articles and consulting-service
+   copy. 74ch at this site's 1.12rem body font lands at approximately
+   740–780px, matching Apple's developer-docs column within the rendering
+   variance of any given font. Generous enough that Gen Z doesn't feel
+   text is cramped; tight enough that older readers don't have to track
+   their eyes across a 1000px line.
+
+   Approach:
+     1. Cap the <article> element itself at 74ch and center it inside
+        <main>. One container narrows, everything inside left-aligns
+        against the SAME left edge — the pattern Apple uses on developer
+        docs and Stripe / Linear use on their respective docs.
+     2. Provide an opt-in .full-bleed escape hatch for tables, code
+        blocks, large figures, and the how-we-work card grid so they
+        keep their full width.
+     3. Tighten line-height from 1.6 to 1.5 — matches Apple's 1.47x ratio
+        on developer docs while still meeting WCAG 1.4.12 minimum (1.5x).
+     4. Gate to >=900px — narrower viewports already wrap naturally.
+
+   The hero (<section class="hero-wrapper">) lives OUTSIDE <article> in
+   templates/index.html, so it's structurally unaffected. Same for the
+   topbar, footer, and any partial that isn't a direct child of <main>.
+
+   `/field-notes/` (the index) uses <ul class="post-list"> directly under
+   <main> with no <article> wrapper, so it gets its own cap rule.
+
+   Cited basis:
+     - Apple developer.apple.com/design/human-interface-guidelines (live
+       audit, 2026-06-01) — 740px / ~93 CPL prose measure
+     - WCAG 2.1 SC 1.4.8 (Visual Presentation) — 80 char target
+       (Apple runs slightly above this on support, deliberately;
+       developer docs at 93 CPL is acceptable with generous leading)
+     - WCAG 2.1 SC 1.4.12 — 1.5x minimum line spacing (met at 1.5)
+   ============================================================================ */
+
+@media (min-width: 900px) {
+    /* Cap the ARTICLE element itself at 74ch and center it inside <main>.
+       74ch at the site's 1.12rem body font lands around 740–780px,
+       matching Apple's developer-docs prose column. One container
+       narrows; everything inside left-aligns against the SAME left edge.
+       Capping individual children instead misaligns headings against
+       their paragraphs because each child centers independently within
+       main. */
+    main > article,
+    main > article.homepage-body {
+        max-width: 74ch;
+        margin-inline: auto;
+    }
+
+    /* Field-notes index — uses <ul class="post-list"> directly under <main>
+       with no <article> wrapper. Same cap, same centering. */
+    main > ul.post-list {
+        max-width: 74ch;
+        margin-inline: auto;
+    }
+
+    /* Opt-in escape hatch. Apply class="full-bleed" to any element inside
+       <article> that should span the wider <main> column instead of being
+       constrained to the prose measure. Used by:
+         - rate tables and scope tables that need horizontal room
+         - pre/code blocks (long shell commands shouldn't wrap mid-token)
+         - large figures and the .how-we-work 2x2 card grid
+         - the signature preview (already 560px fixed, fits inside 68ch
+           so it doesn't need the hatch — listed for safety)
+       The 50vw / -50vw trick re-anchors to the viewport edges; the
+       max-width:1008px ceiling keeps full-bleed elements aligned with
+       the original main column width on screens where main is wider
+       than the viewport-centered 68ch column. */
+    article > .full-bleed,
+    article > table,
+    article > pre,
+    article > .how-we-work {
+        max-width: min(1008px, calc(100vw - 2 * var(--s1, 1rem)));
+        margin-left: 50%;
+        transform: translateX(-50%);
+    }
+
+    /* Inline images inside paragraphs should stay inside the prose column;
+       only .post-image (the article hero portrait wrapper) and standalone
+       figures break out. */
+    article > .post-image,
+    article > figure.full-bleed {
+        max-width: min(1008px, calc(100vw - 2 * var(--s1, 1rem)));
+        margin-left: 50%;
+        transform: translateX(-50%);
+    }
+
+    /* Match Apple's 1.47x line-height on developer docs while meeting the
+       WCAG 1.4.12 1.5x minimum exactly. The previous 1.6 was slightly
+       airy for a 74ch measure; 1.5 reads tighter without crowding. */
+    main > article p {
+        line-height: 1.5;
+    }
+}


### PR DESCRIPTION
## Symptom

The abridge theme sets `<main>` to `min-width:1200px` / `max-width:70%`, which on a 1440px viewport yields a ~1008px content column. At this site's `1.12rem` body font (~17.9px), that produces **110–120 characters per line** — visibly uncomfortable to read on long-form articles, especially for older readers tracking from end-of-line back to start.

The desktop-Safari render sweep on 2026-06-01 flagged this as the dominant readability defect cross-cutting every content page.

## Decision rule

When the choice is between competing readability heuristics, defer to Apple. The brand has been deliberately positioned to feel adjacent to Apple's visual language, so the prose measure should align too.

## Apple's actual measure (audited 2026-06-01, 1440px viewport)

| Property | Column width | Font | Line-height | CPL |
|---|---|---|---|---|
| developer.apple.com — HIG | **740px** | 17px SF Pro Text | 25px (1.47×) | **~93** |
| support.apple.com long-form | 797–817px | 17px SF Pro Text | 25px | ~97–106 |
| apple.com marketing | (n/a — feature-card copy) | | | |

The developer-docs measure is the closer analogue to long-form articles and consulting copy. Match it.

## What this PR does

- Caps `main > article` and `main > article.homepage-body` at **`max-width: 74ch`** with `margin-inline: auto`. At the site's 1.12rem body font, 74ch lands around 740–780px — matching Apple's developer-docs column within font-rendering variance.
- Caps `main > ul.post-list` (the field-notes index, which has no `<article>` wrapper) at the same 74ch.
- Provides an opt-in `.full-bleed` escape hatch (also auto-applied to `<table>`, `<pre>`, `.how-we-work`, `.post-image`, and `figure.full-bleed`) so structural elements break out via a `50vw / translateX(-50%)` technique. Capped at `min(1008px, calc(100vw - 2 * var(--s1)))` so full-bleed elements don't drift wider than the original main column.
- Tightens `main > article p` line-height from `1.6` to `1.5` — matches Apple's 1.47× ratio while meeting the WCAG 1.4.12 1.5× minimum exactly.
- Gates everything to `@media (min-width: 900px)` — narrower viewports already wrap naturally.

## Why "cap the article, not the children"

Capping individual `article > p, article > h2, …` selectors misaligns headings against paragraphs, because each block centers independently within the wider `<main>`. Capping the `<article>` itself means everything inside left-aligns against the same edge — the pattern Apple developer docs, Stripe Docs, and Linear all use.

## Structural elements unaffected

- The homepage hero (`<section class="hero-wrapper">`) lives **outside** `<article>` in `templates/index.html` — untouched
- The topbar, footer, page-title H1 on article pages, post-image hero portrait wrapper — all untouched
- Mobile and iPad-portrait layouts unchanged (gate is ≥900px)

## Verification

Before / after captured at 1440×900 against the live site (CSS injected via route-intercept since CSP blocks inline styles). Owner reviewed:

- `/field-notes/dns-security-best-practices/`
- `/services/`
- `/billing/`
- `/field-notes/` (index)
- `/` (homepage — hero preserved)

## Cited basis

- Apple [developer.apple.com/design/human-interface-guidelines](https://developer.apple.com/design/human-interface-guidelines/typography) — 740px / ~93 CPL prose column (live audit, 2026-06-01)
- WCAG 2.1 SC 1.4.12 — [1.5× minimum line spacing](https://www.w3.org/TR/WCAG21/#text-spacing)
