### PR TITLE
hotfix: How-we-work break-out + visible corporate-tree connectors

### DIFF
--- a/static/css/_footer-org.css
+++ b/static/css/_footer-org.css
@@ -95,17 +95,25 @@ a.ftr-node:hover {
     letter-spacing: 0.02em;
 }
 
-/* --- Connectors (vertical/horizontal lines drawn between nodes) --- */
+/* --- Connectors (vertical/horizontal lines drawn between nodes) ---
+   The connectors form the visible "corporate tree" graphic that links
+   Delaware -> California, Consulting -> DNS Tool, and the parent rows to
+   the 4-column leaf grid. At the original 0.18 alpha on #0D1117 the
+   lines were near-invisible, so the tree shape didn't register at all
+   and the badges looked like floating disconnected pills. Bumping to
+   0.6 makes the tree branches clearly readable as structural lines
+   while staying in the same muted-gold family as the brand accents —
+   the tree feels intentional and architectural, not loud. */
 .ftr-vline {
     width: 1px;
     height: 12px;
-    background: rgba(200, 149, 106, 0.18);
+    background: rgba(200, 149, 106, 0.6);
     flex-shrink: 0;
 }
 
 .ftr-hline {
     height: 1px;
-    background: rgba(200, 149, 106, 0.18);
+    background: rgba(200, 149, 106, 0.6);
     flex-shrink: 0;
 }
 
@@ -125,7 +133,9 @@ a.ftr-node:hover {
     top: 0;
     bottom: 0;
     width: 1px;
-    background: rgba(200, 149, 106, 0.18);
+    /* Central spine of the org tree — same 0.6 alpha as the arms so the
+       whole tree reads as one continuous graphic. */
+    background: rgba(200, 149, 106, 0.6);
 }
 
 .ftr-org-reg {
@@ -139,14 +149,14 @@ a.ftr-node:hover {
 
 .ftr-org-reg-left  { display: flex; align-items: center; align-self: flex-end;   margin-right: 50%; }
 .ftr-org-reg-right { display: flex; align-items: center; align-self: flex-start; margin-left:  50%; }
-.ftr-org-reg-arm   { width: 12px; height: 1px; background: rgba(200, 149, 106, 0.18); flex-shrink: 0; }
+.ftr-org-reg-arm   { width: 12px; height: 1px; background: rgba(200, 149, 106, 0.6); flex-shrink: 0; }
 
 .ftr-org-dept            { z-index: 1; display: flex; align-items: flex-start; }
 .ftr-org-dept-left       { flex: 1; display: flex; justify-content: flex-end; }
 .ftr-org-dept-left-col   { display: flex; flex-direction: column; align-items: center; }
 .ftr-org-dept-left-top   { display: flex; align-items: center; }
 .ftr-org-dept-right      { flex: 1; display: flex; align-items: center; }
-.ftr-org-dept-arm        { width: 16px; height: 1px; background: rgba(200, 149, 106, 0.18); flex-shrink: 0; }
+.ftr-org-dept-arm        { width: 16px; height: 1px; background: rgba(200, 149, 106, 0.6); flex-shrink: 0; }
 
 /* --- 4-column connector bar above the link grid --- */
 .ftr-grid-connector {
@@ -166,12 +176,12 @@ a.ftr-node:hover {
     top: 0;
     height: 12px;
     width: 1px;
-    background: rgba(200, 149, 106, 0.18);
+    background: rgba(200, 149, 106, 0.6);
 }
 
 .ftr-grid-bar {
     height: 1px;
-    background: rgba(200, 149, 106, 0.18);
+    background: rgba(200, 149, 106, 0.6);
     align-self: stretch;
     margin: 0 calc(12.5% - 0.375rem);
 }

--- a/static/css/late-overrides.css
+++ b/static/css/late-overrides.css
@@ -1663,33 +1663,30 @@ img.img-centered-520 {
 
     /* Opt-in escape hatch. Apply class="full-bleed" to any element inside
        <article> that should span the wider <main> column instead of being
-       constrained to the prose measure. Used by:
-         - rate tables and scope tables that need horizontal room
-         - pre/code blocks (long shell commands shouldn't wrap mid-token)
-         - large figures and the .how-we-work 2x2 card grid
-         - the signature preview (already 560px fixed, fits inside 68ch
-           so it doesn't need the hatch — listed for safety)
-       The 50vw / -50vw trick re-anchors to the viewport edges; the
-       max-width:1008px ceiling keeps full-bleed elements aligned with
-       the original main column width on screens where main is wider
-       than the viewport-centered 68ch column. */
+       constrained to the prose measure. Auto-applied to elements that
+       always want full width: the .how-we-work card grid, tables, pre
+       code blocks, the .post-image hero portrait, and standalone
+       figures tagged .full-bleed.
+
+       Technique: position:relative + left:50% + translateX(-50%) anchors
+       the element to the horizontal center of the parent and then pulls
+       it back by half its OWN width. Combined with a declared width
+       (not max-width) wider than the parent, this is the only reliable
+       way to break out of a max-width-constrained ancestor in modern
+       CSS without negative margins. The width:min(1008px, ...) ceiling
+       caps the break-out at the original <main> column width so we
+       don't drift wider than the page's structural grid. */
     article > .full-bleed,
     article > table,
     article > pre,
-    article > .how-we-work {
-        max-width: min(1008px, calc(100vw - 2 * var(--s1, 1rem)));
-        margin-left: 50%;
-        transform: translateX(-50%);
-    }
-
-    /* Inline images inside paragraphs should stay inside the prose column;
-       only .post-image (the article hero portrait wrapper) and standalone
-       figures break out. */
+    article > .how-we-work,
     article > .post-image,
     article > figure.full-bleed {
-        max-width: min(1008px, calc(100vw - 2 * var(--s1, 1rem)));
-        margin-left: 50%;
+        position: relative;
+        width: min(1008px, calc(100vw - 2 * var(--s1, 1rem)));
+        left: 50%;
         transform: translateX(-50%);
+        max-width: none;
     }
 
     /* Match Apple's 1.47x line-height on developer docs while meeting the


### PR DESCRIPTION
Two regressions surfaced by owner review after PR #642 landed.

## Regression 1: `.how-we-work` collapsed into the 74ch column

The 3-card "How we work" grid on the homepage rendered as three narrow vertical rails with text wrapping at 7–12 characters per line. Root cause: my full-bleed escape hatch used `margin-left:50%; transform:translateX(-50%)` without declaring an explicit width wider than the parent. Inside a `max-width:74ch` `<article>`, that centers the element within the constrained column rather than breaking out to the original main column.

**Fix:** Replace `margin-left:50%` with the canonical viewport break-out pattern:

```css
position: relative;
left: 50%;
transform: translateX(-50%);
width: min(1008px, calc(100vw - 2 * var(--s1, 1rem)));
max-width: none;
```

The explicit `width` declaration (not `max-width`) wider than the parent is the part that makes the technique work inside a max-width-constrained ancestor. Applied to all auto-promoted elements: `.full-bleed`, `<table>`, `<pre>`, `.how-we-work`, `.post-image`, `figure.full-bleed`.

## Regression 2: Corporate org tree connectors near-invisible

The corporate org-tree graphic at the bottom of the homepage — the visible structure linking `IT Help San Diego Inc.` → Delaware/California registrations → Concierge IT Consulting / DNS Tool departments → the 4-column Services/Expertise/Trust/Company leaf grid — was rendering with near-invisible connector lines. The tree branches were drawn at `rgba(200, 149, 106, 0.18)` on the `#0D1117` dark background, leaving the badges looking like disconnected floating pills with no tree shape visible.

This wasn't introduced by the typography PR — it was a pre-existing low-contrast condition that the now-cleaner page made more noticeable. Either way, it needs to read as a structural graphic, not a hint.

**Fix:** Bump connector-line alpha from `0.18` to `0.6` across all tree branches:

- `.ftr-vline` / `.ftr-hline` — general connectors
- `.ftr-org::before` — central vertical spine
- `.ftr-org-reg-arm` — Delaware/California horizontal arms
- `.ftr-org-dept-arm` — Consulting/DNS Tool horizontal arms
- `.ftr-grid-connector::before` — vertical drop above the leaf bar
- `.ftr-grid-bar` — horizontal bar above the 4-column leaf grid

Same color family (`rgba(200, 149, 106)`) so the tree still reads as muted-gold brand accent, just at the alpha needed to register as structural lines on the dark background. `.ftr-cell:hover` border (still `0.18`) intentionally left alone since it's a hover-only state where brighter would feel loud.

## Verification

Both fixes confirmed at 1440px viewport with the live site CSS replaced via route-intercept. "How we work" now displays as three wide cards across the ~1008px column; the corporate tree branches are clearly readable as gold structural lines connecting every node from the parent entity down to the leaf grid.

## Out-of-scope follow-ups noted

- The homepage body still mentions "Unix" alongside Linux/Windows ("Cross-Platform Systems Engineering" section). Per the earlier session-wide rule ("we don't have to list Unix"), that should be removed from `content/_index.md` in a separate PR — it was caught in SEO snippets but the page body wasn't swept.
