### PR TITLE
content: drop redundant 'Unix' from homepage and services copy

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -101,7 +101,7 @@ twitter_card        = "summary_large_image"
   "sameAs": [
     "https://www.linkedin.com/company/it-help-san-diego"
   ],
-  "description": "Apple‑centric IT and deep-research diagnostics for La Jolla & San Diego — Mac first, with Unix, Linux, and Windows. No hardware sales, no monthly retainers.",
+  "description": "Apple‑centric IT and deep-research diagnostics for La Jolla & San Diego — Mac first, with Linux and Windows. No hardware sales, no monthly retainers.",
   "knowsAbout": [
     "macOS troubleshooting",
     "iOS troubleshooting",
@@ -198,7 +198,7 @@ twitter_card        = "summary_large_image"
       "@id": "https://www.it-help.tech/#webpage",
       "url": "https://www.it-help.tech/",
       "name": "Mac IT Support San Diego (La Jolla) | IT Help San Diego",
-      "description": "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla and San Diego. macOS and iOS first, with Unix, Linux, and Windows — a system is a system. 27 years across systems, networks, DNS, and email security (SPF · DKIM · DMARC). No hardware sales, no monthly retainers.",
+      "description": "Apple-centric IT, deep-research diagnostics, and systems work for La Jolla and San Diego. macOS and iOS first, with Linux and Windows — a system is a system. 27 years across systems, networks, DNS, and email security (SPF · DKIM · DMARC). No hardware sales, no monthly retainers.",
       "inLanguage": "en-US",
       "isPartOf": {
         "@id": "https://www.it-help.tech/#website"
@@ -242,7 +242,7 @@ twitter_card        = "summary_large_image"
 macOS, iOS, iCloud, and Apple Mail diagnosed at the system level. Storage, sync, performance, and migration handled correctly the first time. <a href="/services/#mac" class="gold-link">Learn more →</a>
 
 ### <a href="/services/#cross-platform" class="gold-link">Cross-Platform Systems Engineering</a>
-macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. From shell scripts to file servers to mixed-OS environments, we engage the problem, not the logo. <a href="/services/#cross-platform" class="gold-link">Learn more →</a>
+macOS and iOS lead our work, with Linux and Windows getting the same scientific care — a system is a system. From shell scripts to file servers to mixed-OS environments, we engage the problem, not the logo. <a href="/services/#cross-platform" class="gold-link">Learn more →</a>
 
 ### <a href="/services/#wifi" class="gold-link">Wi‑Fi &amp; Network Engineering</a>
 Bespoke wireless and wired networks for large homes, estates, and small offices. Cat6A/Cat8/fiber backbones, mesh design, and dead-zone elimination using measured RF data, not guesswork. <a href="/services/#wifi" class="gold-link">Learn more →</a>

--- a/content/services.md
+++ b/content/services.md
@@ -220,7 +220,7 @@ extra:
       "item": {
         "@type": "Service",
         "name": "Cross-Platform & Systems Work",
-        "description": "Unix, Linux, and Windows systems work alongside macOS — shell scripting, file servers, mixed-OS networks, and server diagnostics.",
+        "description": "Linux and Windows systems work alongside macOS — shell scripting, file servers, mixed-OS networks, and server diagnostics.",
         "provider": { "@id": "https://www.it-help.tech/#business" }
       }
     }
@@ -336,7 +336,7 @@ extra:
       "name": "Cross-Platform & Systems Work",
       "serviceType": "Systems Engineering",
       "provider": { "@id": "https://www.it-help.tech/#business" },
-      "description": "Unix, Linux, and Windows systems work alongside macOS — shell scripting, file servers, mixed-OS networks, and server diagnostics. A system is a system.",
+      "description": "Linux and Windows systems work alongside macOS — shell scripting, file servers, mixed-OS networks, and server diagnostics. A system is a system.",
       "url": "https://www.it-help.tech/services/#cross-platform"
     },
     {
@@ -422,7 +422,7 @@ For law firms and legal professionals: structured extraction of email and iPhone
 
 ## Cross-Platform & Systems Work {#cross-platform}
 
-macOS and iOS lead our work, but Unix, Linux, and Windows get the same scientific care — a system is a system. We engage the problem, not the logo. The same instinct for analyzing logs, tracing packets, and deducing from evidence is applicable regardless of the prompt.
+macOS and iOS lead our work, with Linux and Windows getting the same scientific care — a system is a system. We engage the problem, not the logo. The same instinct for analyzing logs, tracing packets, and deducing from evidence is applicable regardless of the prompt.
 
 * **Shell scripting and automation** — Bash, Zsh, and PowerShell for repeatable, auditable operations instead of click-by-click drift.
 * **File servers and shared storage** — SMB and NFS that hold up across macOS, Windows, and Linux clients without permissions roulette.


### PR DESCRIPTION
## Why

"Unix" was appearing alongside "Linux and Windows" in our service descriptions. For a Mac-first shop in 2026, Unix is redundant — practitioners read it as either (a) a synonym for Linux/macOS (already covered) or (b) commercial Unix (Solaris, AIX, HP-UX), which we don't actually service.

Honest ordering for what we do: **macOS and iOS lead, with Linux and Windows getting the same scientific care.** Same epistemic frame, one fewer word that doesn't pay its rent.

## What changed

Six occurrences across two content files:

**`content/_index.md`**
- JSON-LD Organization `description` — `"Mac first, with Unix, Linux, and Windows"` → `"Mac first, with Linux and Windows"`
- JSON-LD WebPage `description` — `"macOS and iOS first, with Unix, Linux, and Windows"` → `"macOS and iOS first, with Linux and Windows"`
- Cross-Platform Systems Engineering card body — `"but Unix, Linux, and Windows get the same scientific care"` → `"with Linux and Windows getting the same scientific care"`

**`content/services.md`**
- ItemList Service description (BreadcrumbList block)
- Service @type description (main service block)
- Cross-Platform & Systems Work section body

## Voice / framing notes

- Replaced "but" with "with …getting" in the visible prose — same meaning, slightly less defensive cadence ("but" implies the cross-platform work is the exception; "with" frames it as part of normal scope).
- Schema descriptions tightened identically so SERP snippets and AI-engine answers stay in sync with on-page copy.

## Verification

```
$ grep -rn -i "unix" content/ config.toml
(no matches)
```

## Out of scope

- No CSS, JS, or template changes
- No changes to schema beyond the three description strings noted
- No changes to themes/abridge/**
