### PR TITLE
Point State of Malware citation at the direct report

### DIFF
--- a/content/field-notes/mac-cybersecurity-threats.md
+++ b/content/field-notes/mac-cybersecurity-threats.md
@@ -216,7 +216,7 @@ If you have questions, the first ten minutes of a call are no-charge per the [bi
 
 [^8]: Wardle, P. *About — Objective-See Foundation.* Confirms prior NSA tenure. <https://objective-see.org/about.html>
 
-[^9]: Malwarebytes. *State of Malware (annual report series).* Documents Mac-vs-Windows threat-detection volumes and the adware/PUP-dominated composition of Mac detections. <https://www.threatdown.com/resources/>
+[^9]: Malwarebytes. *State of Malware (annual report series).* Documents Mac-vs-Windows threat-detection volumes and the adware/PUP-dominated composition of Mac detections. <https://www.threatdown.com/2025-state-of-malware/>
 
 [^10]: Apple Inc. *About Stolen Device Protection for iPhone.* Specifies the iOS 17.3 release, the Face ID/Touch ID biometric requirement with no passcode fallback, and the security-delay behavior away from familiar locations. <https://support.apple.com/en-us/120340>
 


### PR DESCRIPTION
Point State of Malware citation at the direct report

Use the direct ThreatDown State of Malware report URL instead of the
generic resources hub, so footnote [^9] resolves to the specific cited
series rather than a landing page.