### PR TITLE
Fix deploy: drop deleted signature files from copy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Copy images and root files
         run: |
           cp -r static/images public/
-          cp static/ithelp-logo-sig-seablue.html static/ithelp-logo-sig-gold.html static/ithelp-logo-sig-research.html static/ithelp-anilogo.html static/red-plus.ico static/bimi-logo.svg public/
+          cp static/ithelp-logo-sig-research.html static/red-plus.ico static/bimi-logo.svg public/
 
       - name: Verify no external subresources (security-relevant)
         # Original COEP require-corp safety net (Sub-4-bis). require-corp was


### PR DESCRIPTION
Fix deploy: drop deleted signature files from copy step

PR #651 removed ithelp-logo-sig-gold/seablue.html and ithelp-anilogo.html,
but deploy.yml still hardcoded them in the 'Copy images and root files' cp
command, so every deploy since failed at `cp: cannot stat ... No such file`.
Copy only the surviving root files (sig-research, red-plus.ico, bimi-logo.svg).