### PR TITLE
Remove dead ithelp-anilogo.html references after signature cleanup

### DIFF
--- a/ROLLBACK.md
+++ b/ROLLBACK.md
@@ -49,14 +49,13 @@ If you want to revert signatures to the old policy:
 
 1. Watch `Actions → deploy.yml` on `main` until it is green.
 2. (Optional) Invalidate CloudFront:
-   - `/ithelp-anilogo.html`
    - `/ithelp-logo-sig-*`
    - `/*` (only if you need instant global refresh)
 3. Verify headers:
 
 ```
 curl -I https://it-help.tech/ | grep -i content-security-policy
-curl -I https://it-help.tech/ithelp-anilogo.html | grep -i content-security-policy
+curl -I https://it-help.tech/ithelp-logo-sig-research.html | grep -i content-security-policy
 ```
 
 ---

--- a/infra/cloudfront/README.md
+++ b/infra/cloudfront/README.md
@@ -20,7 +20,6 @@ To keep a strict CSP on the main site **and** keep the hosted signature pages wo
 1. Create a separate Response Headers Policy in CloudFront using `csp-policy-signatures-v1.json` (name: `security-headers-signatures`).
 2. In each relevant CloudFront distribution, create behaviors for:
    - `ithelp-logo-sig-*`
-   - `ithelp-anilogo.html`
    and set their **Response headers policy** to `security-headers-signatures`.
 3. Keep the default behavior using `security-headers` (site policy).
 4. If you want GitHub Actions to update the signatures policy automatically, add repo secret `CF_HEADERS_POLICY_ID_SIGNATURES` with the policy ID.

--- a/infra/cloudfront/csp-policy-signatures-v1.json
+++ b/infra/cloudfront/csp-policy-signatures-v1.json
@@ -25,7 +25,7 @@
       "Override": true
     },
     "ContentSecurityPolicy": {
-      "ContentSecurityPolicy": "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'none'; worker-src 'none'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'sha256-7C9dOfsnraKSwMhpGpwKO1wi0jO9caXq7o7zs9hIss0='; connect-src 'self'; media-src 'self'; manifest-src 'self'; require-trusted-types-for 'script'; trusted-types 'none'; upgrade-insecure-requests",
+      "ContentSecurityPolicy": "default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'none'; worker-src 'none'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; media-src 'self'; manifest-src 'self'; require-trusted-types-for 'script'; trusted-types 'none'; upgrade-insecure-requests",
       "Override": true
     }
   },

--- a/infra/cloudfront/generate_policy.py
+++ b/infra/cloudfront/generate_policy.py
@@ -9,7 +9,7 @@ Why:
 
 Defaults are tuned for this repo:
   - The **main site** uses strict CSP (no `unsafe-inline`) and allows inline `<style>`/`<script>` via hashes.
-  - **Signature pages** (email signatures + the animation logo page) are expected to be served by a separate
+  - **Signature pages** (email signatures) are expected to be served by a separate
     CloudFront behavior with a separate Response Headers Policy, because they require inline styles.
 """
 
@@ -79,8 +79,6 @@ def _iter_files(public_dir: Path) -> Iterable[Path]:
 
 def _is_signature_page(file: Path) -> bool:
     name = file.name
-    if name == "ithelp-anilogo.html":
-        return True
     if name.startswith("ithelp-logo-sig-") and name.endswith(".html"):
         return True
     return False
@@ -207,13 +205,13 @@ def build_signatures_csp(*, script_hashes: list[str]) -> str:
 
     # Hardening rationale (2026-04-30 — see PROJECT_EVOLUTION_LOG.md):
     # The signature pages are reference renders of the email signature
-    # markup; they have no forms, no Web Workers, and the lone inline
-    # script (in ithelp-anilogo.html, allowlisted by sha256 hash) was
-    # audited and uses zero DOM-XSS sinks (no innerHTML, document.write,
-    # eval, etc.). So the same Trusted Types + form-action 'none' +
+    # markup; they have no forms, no Web Workers, and no inline scripts
+    # (script-src stays 'self'). If a signature page ever reintroduces an
+    # inline script, generate_policy.py will hash it into the allowlist
+    # automatically. So the same Trusted Types + form-action 'none' +
     # worker-src 'none' hardening applied to the marketing site can also
     # apply here.  'unsafe-inline' on style-src has to stay because the
-    # gold/seablue signatures are pure inline-`style="…"` markup (the
+    # signature is pure inline-`style="…"` markup (the
     # email-client portability constraint that drives the whole asset's
     # design). Custom headers in csp-policy-signatures-v1.json mirror the
     # marketing-site set: COOP same-origin, CORP same-origin, COEP
@@ -227,7 +225,7 @@ def build_signatures_csp(*, script_hashes: list[str]) -> str:
         f"worker-src {NONE}",
         f"img-src {SELF} data:",
         f"font-src {SELF}",
-        # Email signature pages and the animation logo page rely on inline styles.
+        # Email signature pages rely on inline styles.
         f"style-src {SELF} 'unsafe-inline'",
         "script-src " + " ".join(script_sources),
         f"connect-src {SELF}",

--- a/scripts/check-no-external-subresources.sh
+++ b/scripts/check-no-external-subresources.sh
@@ -7,8 +7,8 @@
 # zero external subresources today; this gate prevents a future field note
 # (or template change) from silently breaking the COEP-protected pages.
 #
-# Excludes the signature page (`ithelp-anilogo.html`) which is served by a
-# separate CloudFront behavior with its own response-headers policy.
+# Excludes the signature pages (`ithelp-logo-sig-*.html`) which are served
+# by a separate CloudFront behavior with their own response-headers policy.
 #
 # Usage: run from repo root after `zola build`.
 #   scripts/check-no-external-subresources.sh
@@ -68,8 +68,6 @@ def iter_srcset_urls(value: str):
 violations = []
 for html_file in sorted(public.rglob("*.html")):
     # Signature pages are served by a separate CloudFront behavior with their own policy.
-    if html_file.name == "ithelp-anilogo.html":
-        continue
     if html_file.name.startswith("ithelp-logo-sig-"):
         continue
     text = html_file.read_text(encoding="utf-8")


### PR DESCRIPTION
Remove dead ithelp-anilogo.html references after signature cleanup

PR #651 deleted ithelp-anilogo.html (and the gold/seablue signatures),
leaving only ithelp-logo-sig-research.html live. This drops the now-dead
references to the removed page:
- generate_policy.py: dead _is_signature_page name branch + stale rationale
  (signature pages now have zero inline scripts; script-src stays 'self',
  hashing machinery retained for any future inline script).
- csp-policy-signatures-v1.json: drop the orphaned anilogo sha256 hash
  (matches what generate_policy.py --mode signatures now emits).
- check-no-external-subresources.sh: drop dead anilogo exclusion + comment.
- README.md / ROLLBACK.md: drop anilogo behavior/verification steps.

PROJECT_EVOLUTION_LOG.md history is intentionally left intact.