### PR TITLE
chore(test): wire npm test to real verifier (zola build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "echo \"no tests\" && exit 0",
+    "test": "zola build",
     "lh": "node infra/audit/quick-lh.mjs",
-    "lh:gate": "node infra/audit/run-lighthouse.mjs"
+    "lh:gate": "node infra/audit/run-lighthouse.mjs",
+    "check": "zola check"
   },
   "devDependencies": {
     "lighthouse": "12.8.2"


### PR DESCRIPTION
The `test` script was a no-op stub (`echo "no tests" && exit 0`) that verified nothing. This wires it to the **real** canonical verifier so passing `npm run test` actually means something.

- **`test` → `zola build`** — validates all templates + internal links, builds all 21 pages, non-zero on any error. Matches what CI compiles.
- **`check` → `zola check`** — full audit incl. external link reachability; kept separate because it exits 1 on pre-existing external 403 bot-blocks (DOI.org/Spamhaus/Farsight) that aren't real breakage.

Verified: `npm run test` → exit 0, 21 pages, 0 orphans, 29 internal links OK.